### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/alerting/provider/custom/custom.go
+++ b/alerting/provider/custom/custom.go
@@ -3,7 +3,7 @@ package custom
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -105,7 +105,7 @@ func (provider *AlertProvider) Send(endpoint *core.Endpoint, alert *alert.Alert,
 		return err
 	}
 	if response.StatusCode > 399 {
-		body, _ := ioutil.ReadAll(response.Body)
+		body, _ := io.ReadAll(response.Body)
 		return fmt.Errorf("call to provider alert returned status code %d: %s", response.StatusCode, string(body))
 	}
 	return err

--- a/alerting/provider/custom/custom_test.go
+++ b/alerting/provider/custom/custom_test.go
@@ -1,7 +1,7 @@
 package custom
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -113,7 +113,7 @@ func TestAlertProvider_buildHTTPRequestWhenResolved(t *testing.T) {
 	if request.URL.String() != ExpectedURL {
 		t.Error("expected URL to be", ExpectedURL, "was", request.URL.String())
 	}
-	body, _ := ioutil.ReadAll(request.Body)
+	body, _ := io.ReadAll(request.Body)
 	if string(body) != ExpectedBody {
 		t.Error("expected body to be", ExpectedBody, "was", string(body))
 	}
@@ -133,7 +133,7 @@ func TestAlertProvider_buildHTTPRequestWhenTriggered(t *testing.T) {
 	if request.URL.String() != ExpectedURL {
 		t.Error("expected URL to be", ExpectedURL, "was", request.URL.String())
 	}
-	body, _ := ioutil.ReadAll(request.Body)
+	body, _ := io.ReadAll(request.Body)
 	if string(body) != ExpectedBody {
 		t.Error("expected body to be", ExpectedBody, "was", string(body))
 	}
@@ -158,7 +158,7 @@ func TestAlertProvider_buildHTTPRequestWithCustomPlaceholder(t *testing.T) {
 	if request.URL.String() != ExpectedURL {
 		t.Error("expected URL to be", ExpectedURL, "was", request.URL.String())
 	}
-	body, _ := ioutil.ReadAll(request.Body)
+	body, _ := io.ReadAll(request.Body)
 	if string(body) != ExpectedBody {
 		t.Error("expected body to be", ExpectedBody, "was", string(body))
 	}
@@ -205,7 +205,7 @@ func TestAlertProvider_isBackwardCompatibleWithServiceRename(t *testing.T) {
 	if request.URL.String() != ExpectedURL {
 		t.Error("expected URL to be", ExpectedURL, "was", request.URL.String())
 	}
-	body, _ := ioutil.ReadAll(request.Body)
+	body, _ := io.ReadAll(request.Body)
 	if string(body) != ExpectedBody {
 		t.Error("expected body to be", ExpectedBody, "was", string(body))
 	}

--- a/alerting/provider/discord/discord.go
+++ b/alerting/provider/discord/discord.go
@@ -3,7 +3,7 @@ package discord
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/TwiN/gatus/v3/alerting/alert"
@@ -37,7 +37,7 @@ func (provider *AlertProvider) Send(endpoint *core.Endpoint, alert *alert.Alert,
 		return err
 	}
 	if response.StatusCode > 399 {
-		body, _ := ioutil.ReadAll(response.Body)
+		body, _ := io.ReadAll(response.Body)
 		return fmt.Errorf("call to provider alert returned status code %d: %s", response.StatusCode, string(body))
 	}
 	return err

--- a/alerting/provider/mattermost/mattermost.go
+++ b/alerting/provider/mattermost/mattermost.go
@@ -3,7 +3,7 @@ package mattermost
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/TwiN/gatus/v3/alerting/alert"
@@ -43,7 +43,7 @@ func (provider *AlertProvider) Send(endpoint *core.Endpoint, alert *alert.Alert,
 		return err
 	}
 	if response.StatusCode > 399 {
-		body, _ := ioutil.ReadAll(response.Body)
+		body, _ := io.ReadAll(response.Body)
 		return fmt.Errorf("call to provider alert returned status code %d: %s", response.StatusCode, string(body))
 	}
 	return err

--- a/alerting/provider/messagebird/messagebird.go
+++ b/alerting/provider/messagebird/messagebird.go
@@ -3,7 +3,7 @@ package messagebird
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/TwiN/gatus/v3/alerting/alert"
@@ -45,7 +45,7 @@ func (provider *AlertProvider) Send(endpoint *core.Endpoint, alert *alert.Alert,
 		return err
 	}
 	if response.StatusCode > 399 {
-		body, _ := ioutil.ReadAll(response.Body)
+		body, _ := io.ReadAll(response.Body)
 		return fmt.Errorf("call to provider alert returned status code %d: %s", response.StatusCode, string(body))
 	}
 	return err

--- a/alerting/provider/pagerduty/pagerduty.go
+++ b/alerting/provider/pagerduty/pagerduty.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 
@@ -64,7 +64,7 @@ func (provider *AlertProvider) Send(endpoint *core.Endpoint, alert *alert.Alert,
 		return err
 	}
 	if response.StatusCode > 399 {
-		body, _ := ioutil.ReadAll(response.Body)
+		body, _ := io.ReadAll(response.Body)
 		return fmt.Errorf("call to provider alert returned status code %d: %s", response.StatusCode, string(body))
 	}
 	if alert.IsSendingOnResolved() {
@@ -73,7 +73,7 @@ func (provider *AlertProvider) Send(endpoint *core.Endpoint, alert *alert.Alert,
 			alert.ResolveKey = ""
 		} else {
 			// We need to retrieve the resolve key from the response
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			var payload pagerDutyResponsePayload
 			if err = json.Unmarshal(body, &payload); err != nil {
 				// Silently fail. We don't want to create tons of alerts just because we failed to parse the body.

--- a/alerting/provider/slack/slack.go
+++ b/alerting/provider/slack/slack.go
@@ -3,7 +3,7 @@ package slack
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/TwiN/gatus/v3/alerting/alert"
@@ -37,7 +37,7 @@ func (provider *AlertProvider) Send(endpoint *core.Endpoint, alert *alert.Alert,
 		return err
 	}
 	if response.StatusCode > 399 {
-		body, _ := ioutil.ReadAll(response.Body)
+		body, _ := io.ReadAll(response.Body)
 		return fmt.Errorf("call to provider alert returned status code %d: %s", response.StatusCode, string(body))
 	}
 	return err

--- a/alerting/provider/teams/teams.go
+++ b/alerting/provider/teams/teams.go
@@ -3,7 +3,7 @@ package teams
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/TwiN/gatus/v3/alerting/alert"
@@ -37,7 +37,7 @@ func (provider *AlertProvider) Send(endpoint *core.Endpoint, alert *alert.Alert,
 		return err
 	}
 	if response.StatusCode > 399 {
-		body, _ := ioutil.ReadAll(response.Body)
+		body, _ := io.ReadAll(response.Body)
 		return fmt.Errorf("call to provider alert returned status code %d: %s", response.StatusCode, string(body))
 	}
 	return err

--- a/alerting/provider/telegram/telegram.go
+++ b/alerting/provider/telegram/telegram.go
@@ -3,7 +3,7 @@ package telegram
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/TwiN/gatus/v3/alerting/alert"
@@ -38,7 +38,7 @@ func (provider *AlertProvider) Send(endpoint *core.Endpoint, alert *alert.Alert,
 		return err
 	}
 	if response.StatusCode > 399 {
-		body, _ := ioutil.ReadAll(response.Body)
+		body, _ := io.ReadAll(response.Body)
 		return fmt.Errorf("call to provider alert returned status code %d: %s", response.StatusCode, string(body))
 	}
 	return err

--- a/alerting/provider/twilio/twilio.go
+++ b/alerting/provider/twilio/twilio.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -43,7 +43,7 @@ func (provider *AlertProvider) Send(endpoint *core.Endpoint, alert *alert.Alert,
 		return err
 	}
 	if response.StatusCode > 399 {
-		body, _ := ioutil.ReadAll(response.Body)
+		body, _ := io.ReadAll(response.Body)
 		return fmt.Errorf("call to provider alert returned status code %d: %s", response.StatusCode, string(body))
 	}
 	return err

--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"errors"
-	"io/ioutil"
 	"log"
 	"os"
 	"time"
@@ -142,7 +141,7 @@ func LoadDefaultConfiguration() (*Config, error) {
 
 func readConfigurationFile(fileName string) (config *Config, err error) {
 	var bytes []byte
-	if bytes, err = ioutil.ReadFile(fileName); err == nil {
+	if bytes, err = os.ReadFile(fileName); err == nil {
 		// file exists, so we'll parse it and return it
 		return parseAndValidateConfigBytes(bytes)
 	}

--- a/controller/handler/gzip.go
+++ b/controller/handler/gzip.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync"
@@ -11,7 +10,7 @@ import (
 
 var gzPool = sync.Pool{
 	New: func() interface{} {
-		return gzip.NewWriter(ioutil.Discard)
+		return gzip.NewWriter(io.Discard)
 	},
 }
 

--- a/core/endpoint.go
+++ b/core/endpoint.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -259,7 +259,7 @@ func (endpoint *Endpoint) call(result *Result) {
 		result.Connected = response.StatusCode > 0
 		// Only read the body if there's a condition that uses the BodyPlaceholder
 		if endpoint.needsToReadBody() {
-			result.body, err = ioutil.ReadAll(response.Body)
+			result.body, err = io.ReadAll(response.Body)
 			if err != nil {
 				result.AddError(err.Error())
 			}

--- a/core/endpoint_test.go
+++ b/core/endpoint_test.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -245,7 +245,7 @@ func TestEndpoint_buildHTTPRequestWithGraphQLEnabled(t *testing.T) {
 	if contentType := request.Header.Get(ContentTypeHeader); contentType != "application/json" {
 		t.Error("request.Header.Content-Type should've been application/json, but was", contentType)
 	}
-	body, _ := ioutil.ReadAll(request.Body)
+	body, _ := io.ReadAll(request.Body)
 	if !strings.HasPrefix(string(body), "{\"query\":") {
 		t.Error("request.body should've started with '{\"query\":', but it didn't:", string(body))
 	}

--- a/storage/store/memory/memory.go
+++ b/storage/store/memory/memory.go
@@ -3,8 +3,8 @@ package memory
 import (
 	"encoding/gob"
 	"io/fs"
-	"io/ioutil"
 	"log"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -51,12 +51,12 @@ func NewStore(file string) (*Store, error) {
 		_, err := store.cache.ReadFromFile(file)
 		if err != nil {
 			// XXX: Remove the block below in v4.0.0
-			if data, err2 := ioutil.ReadFile(file); err2 == nil {
+			if data, err2 := os.ReadFile(file); err2 == nil {
 				isFromOldVersion := strings.Contains(string(data), "*core.ServiceStatus")
 				if isFromOldVersion {
 					log.Println("WARNING: Couldn't read file due to recent change in v3.3.0, see https://github.com/TwiN/gatus/issues/191")
 					log.Println("WARNING: Will automatically rename old file to " + file + ".old and overwrite the current file")
-					if err = ioutil.WriteFile(file+".old", data, fs.ModePerm); err != nil {
+					if err = os.WriteFile(file+".old", data, fs.ModePerm); err != nil {
 						log.Println("WARNING: Tried my best to keep the old file, but it wasn't enough. Sorry, your file will be overwritten :(")
 					}
 					// Return the store regardless of whether there was an error or not


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since gatus has been upgraded to Go 1.17 in babe7b0be9612271c5a491aa124909af7fc7767b, This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.