### PR TITLE
Update email alerting provider to supply a username

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ endpoints:
 |:-------------------------------|:-------------------------------------------------------------------------------------------|:----------------------|
 | `alerting.email`               | Configuration for alerts of type `email`                                                   | `{}`                  |
 | `alerting.email.from`          | Email used to send the alert                                                               | Required `""`         |
-| `alerting.email.username`      | Username of the SMTP server used to send the alert                                         | `alerting.email.from` |
+| `alerting.email.username`      | Username of the SMTP server used to send the alert. If empty, uses `alerting.email.from`.  | `""`                  |
 | `alerting.email.password`      | Password of the SMTP server used to send the alert                                         | Required `""`         |
 | `alerting.email.host`          | Host of the mail server (e.g. `smtp.gmail.com`)                                            | Required `""`         |
 | `alerting.email.port`          | Port the mail server is listening to (e.g. `587`)                                          | Required `0`          |

--- a/README.md
+++ b/README.md
@@ -352,20 +352,22 @@ endpoints:
 
 
 #### Configuring Email alerts
-| Parameter                      | Description                                                                                | Default       |
-|:-------------------------------|:-------------------------------------------------------------------------------------------|:--------------|
-| `alerting.email`               | Configuration for alerts of type `email`                                                   | `{}`          |
-| `alerting.email.from`          | Email used to send the alert                                                               | Required `""` |
-| `alerting.email.password`      | Password of the email used to send the alert                                               | Required `""` |
-| `alerting.email.host`          | Host of the mail server (e.g. `smtp.gmail.com`)                                            | Required `""` |
-| `alerting.email.port`          | Port the mail server is listening to (e.g. `587`)                                          | Required `0`  |
-| `alerting.email.to`            | Email(s) to send the alerts to                                                             | Required `""` |
-| `alerting.email.default-alert` | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert) | N/A           |
+| Parameter                      | Description                                                                                | Default               |
+|:-------------------------------|:-------------------------------------------------------------------------------------------|:----------------------|
+| `alerting.email`               | Configuration for alerts of type `email`                                                   | `{}`                  |
+| `alerting.email.from`          | Email used to send the alert                                                               | Required `""`         |
+| `alerting.email.username`      | Username of the SMTP server used to send the alert                                         | `alerting.email.from` |
+| `alerting.email.password`      | Password of the SMTP server used to send the alert                                         | Required `""`         |
+| `alerting.email.host`          | Host of the mail server (e.g. `smtp.gmail.com`)                                            | Required `""`         |
+| `alerting.email.port`          | Port the mail server is listening to (e.g. `587`)                                          | Required `0`          |
+| `alerting.email.to`            | Email(s) to send the alerts to                                                             | Required `""`         |
+| `alerting.email.default-alert` | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert) | N/A                   |
 
 ```yaml
 alerting:
   email:
     from: "from@example.com"
+    username: "from@example.com"
     password: "hunter2"
     host: "mail.example.com"
     port: 587

--- a/alerting/provider/email/email.go
+++ b/alerting/provider/email/email.go
@@ -13,6 +13,7 @@ import (
 // AlertProvider is the configuration necessary for sending an alert using SMTP
 type AlertProvider struct {
 	From     string `yaml:"from"`
+	Username string `yaml:"username"`
 	Password string `yaml:"password"`
 	Host     string `yaml:"host"`
 	Port     int    `yaml:"port"`
@@ -29,13 +30,19 @@ func (provider *AlertProvider) IsValid() bool {
 
 // Send an alert using the provider
 func (provider *AlertProvider) Send(endpoint *core.Endpoint, alert *alert.Alert, result *core.Result, resolved bool) error {
+	var username string
+	if len(provider.Username) > 0 {
+		username = provider.Username
+	} else {
+		username = provider.From
+	}
 	subject, body := provider.buildMessageSubjectAndBody(endpoint, alert, result, resolved)
 	m := gomail.NewMessage()
 	m.SetHeader("From", provider.From)
 	m.SetHeader("To", strings.Split(provider.To, ",")...)
 	m.SetHeader("Subject", subject)
 	m.SetBody("text/plain", body)
-	d := gomail.NewDialer(provider.Host, provider.Port, provider.From, provider.Password)
+	d := gomail.NewDialer(provider.Host, provider.Port, username, provider.Password)
 	return d.DialAndSend(m)
 }
 


### PR DESCRIPTION
This is intended to maintain backwards compatibility with using Provider.from.

I am unfamiliar with golang so apologies for any style mistakes