### PR TITLE
fix(config): replace hostname in error string if opted

### DIFF
--- a/core/endpoint.go
+++ b/core/endpoint.go
@@ -197,6 +197,9 @@ func (endpoint *Endpoint) EvaluateHealth() *Result {
 	result.body = nil
 	// Clean up parameters that we don't need to keep in the results
 	if endpoint.UIConfig.HideHostname {
+		for errIdx, errorString := range result.Errors {
+			result.Errors[errIdx] = strings.ReplaceAll(errorString, result.Hostname, "host")
+		}
 		result.Hostname = ""
 	}
 	return result


### PR DESCRIPTION
- Replace all occurences of hostname in errors of result with "host"
- Closes #240 
