### PR TITLE
feat(alerting): Add group-specific webhook URL for teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For more details, see [Usage](#usage)
 Have any feedback or want to share your good/bad experience with Gatus? Feel free to email me at [feedback@gatus.io](mailto:feedback@gatus.io)
 
 ## Table of Contents
+- [Table of Contents](#table-of-contents)
 - [Why Gatus?](#why-gatus)
 - [Features](#features)
 - [Usage](#usage)
@@ -76,8 +77,8 @@ Have any feedback or want to share your good/bad experience with Gatus? Feel fre
   - [Endpoint groups](#endpoint-groups)
   - [Exposing Gatus on a custom port](#exposing-gatus-on-a-custom-port)
   - [Badges](#badges)
-    - [Uptime](#uptime)
-    - [Response time](#response-time)
+  - [Uptime](#uptime)
+  - [Response time](#response-time)
   - [API](#api)
   - [High level design overview](#high-level-design-overview)
 - [Sponsors](#sponsors)
@@ -636,11 +637,19 @@ Here's an example of what the notifications look like:
 | `alerting.teams`               | Configuration for alerts of type `teams`                                                   | `{}`          |
 | `alerting.teams.webhook-url`   | Teams Webhook URL                                                                          | Required `""` |
 | `alerting.teams.default-alert` | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert) | N/A           |
+| `alerting.teams.overrides`                   | List of overrides that may be prioritized over the default configuration                   | `[]`    |
+| `alerting.teams.overrides[].group`           | Endpoint group for which the configuration will be overridden by this configuration        | `""`    |
+| `alerting.teams.overrides[].webhook-url`     | Teams Webhook URL                                                    | `""`    |
 
 ```yaml
 alerting:
   teams:
     webhook-url: "https://********.webhook.office.com/webhookb2/************"
+    # You can also add group-specific to keys, which will 
+    # override the to key above for the specified groups
+    overrides:
+      - group: "core"
+        webhook-url: "https://********.webhook.office.com/webhookb3/************"
 
 endpoints:
   - name: website
@@ -650,6 +659,19 @@ endpoints:
       - "[STATUS] == 200"
       - "[BODY].status == UP"
       - "[RESPONSE_TIME] < 300"
+    alerts:
+      - type: teams
+        enabled: true
+        description: "healthcheck failed"
+        send-on-resolved: true
+
+  - name: back-end
+    group: core
+    url: "https://example.org/"
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+      - "[CERTIFICATE_EXPIRATION] > 48h"
     alerts:
       - type: teams
         enabled: true

--- a/README.md
+++ b/README.md
@@ -631,14 +631,15 @@ Here's an example of what the notifications look like:
 
 
 #### Configuring Teams alerts
-| Parameter                      | Description                                                                                | Default       |
-|:-------------------------------|:-------------------------------------------------------------------------------------------|:--------------|
-| `alerting.teams`               | Configuration for alerts of type `teams`                                                   | `{}`          |
-| `alerting.teams.webhook-url`   | Teams Webhook URL                                                                          | Required `""` |
-| `alerting.teams.default-alert` | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert) | N/A           |
-| `alerting.teams.overrides`                   | List of overrides that may be prioritized over the default configuration                   | `[]`    |
-| `alerting.teams.overrides[].group`           | Endpoint group for which the configuration will be overridden by this configuration        | `""`    |
-| `alerting.teams.overrides[].webhook-url`     | Teams Webhook URL                                                    | `""`    |
+
+| Parameter                                | Description                                                                                | Default       |
+|:---------------------------------------- |:------------------------------------------------------------------------------------------ |:------------- |
+| `alerting.teams`                         | Configuration for alerts of type `teams`                                                   | `{}`          |
+| `alerting.teams.webhook-url`             | Teams Webhook URL                                                                          | Required `""` |
+| `alerting.teams.default-alert`           | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert) | N/A           |
+| `alerting.teams.overrides`               | List of overrides that may be prioritized over the default configuration                   | `[]`          |
+| `alerting.teams.overrides[].group`       | Endpoint group for which the configuration will be overridden by this configuration        | `""`          |
+| `alerting.teams.overrides[].webhook-url` | Teams Webhook URL                                                                          | `""`          |
 
 ```yaml
 alerting:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ For more details, see [Usage](#usage)
 Have any feedback or want to share your good/bad experience with Gatus? Feel free to email me at [feedback@gatus.io](mailto:feedback@gatus.io)
 
 ## Table of Contents
-- [Table of Contents](#table-of-contents)
 - [Why Gatus?](#why-gatus)
 - [Features](#features)
 - [Usage](#usage)
@@ -77,8 +76,8 @@ Have any feedback or want to share your good/bad experience with Gatus? Feel fre
   - [Endpoint groups](#endpoint-groups)
   - [Exposing Gatus on a custom port](#exposing-gatus-on-a-custom-port)
   - [Badges](#badges)
-  - [Uptime](#uptime)
-  - [Response time](#response-time)
+    - [Uptime](#uptime)
+    - [Response time](#response-time)
   - [API](#api)
   - [High level design overview](#high-level-design-overview)
 - [Sponsors](#sponsors)

--- a/alerting/provider/teams/teams.go
+++ b/alerting/provider/teams/teams.go
@@ -17,17 +17,35 @@ type AlertProvider struct {
 
 	// DefaultAlert is the default alert configuration to use for endpoints with an alert of the appropriate type
 	DefaultAlert *alert.Alert `yaml:"default-alert,omitempty"`
+
+	// Overrides is a list of Override that may be prioritized over the default configuration
+	Overrides []Override `yaml:"overrides,omitempty"`
+}
+
+// Override is a case under which the default integration is overridden
+type Override struct {
+	Group      string `yaml:"group"`
+	WebhookURL string `yaml:"webhook-url"`
 }
 
 // IsValid returns whether the provider's configuration is valid
 func (provider *AlertProvider) IsValid() bool {
+	registeredGroups := make(map[string]bool)
+	if provider.Overrides != nil {
+		for _, override := range provider.Overrides {
+			if isAlreadyRegistered := registeredGroups[override.Group]; isAlreadyRegistered || override.Group == "" || len(override.WebhookURL) == 0 {
+				return false
+			}
+			registeredGroups[override.Group] = true
+		}
+	}
 	return len(provider.WebhookURL) > 0
 }
 
 // Send an alert using the provider
 func (provider *AlertProvider) Send(endpoint *core.Endpoint, alert *alert.Alert, result *core.Result, resolved bool) error {
 	buffer := bytes.NewBuffer([]byte(provider.buildRequestBody(endpoint, alert, result, resolved)))
-	request, err := http.NewRequest(http.MethodPost, provider.WebhookURL, buffer)
+	request, err := http.NewRequest(http.MethodPost, provider.getWebhookURLForGroup(endpoint.Group), buffer)
 	if err != nil {
 		return err
 	}
@@ -84,6 +102,18 @@ func (provider *AlertProvider) buildRequestBody(endpoint *core.Endpoint, alert *
     }
   ]
 }`, color, message, description, endpoint.URL, results)
+}
+
+// getWebhookURLForGroup returns the appropriate Webhook URL integration to for a given group
+func (provider *AlertProvider) getWebhookURLForGroup(group string) string {
+	if provider.Overrides != nil {
+		for _, override := range provider.Overrides {
+			if group == override.Group {
+				return override.WebhookURL
+			}
+		}
+	}
+	return provider.WebhookURL
 }
 
 // GetDefaultAlert returns the provider's default alert configuration


### PR DESCRIPTION
Add group-specific webhook URL for teams alert

Provides support for paging multiple teams based on the group selector while keeping backward compatibility to the old Teams configuration manifest

integration per team can be specified in the overrides sections in an array form.

```yaml
alerting:
  teams:
    webhook-url: "https://********.webhook.office.com/webhookb2/************"
    # You can also add group-specific to keys, which will 
    # override the to key above for the specified groups
    overrides:
      - group: "core"
        webhook-url: "https://********.webhook.office.com/webhookb3/************"

endpoints:
  - name: website
    url: "https://twin.sh/health"
    interval: 30s
    conditions:
      - "[STATUS] == 200"
      - "[BODY].status == UP"
      - "[RESPONSE_TIME] < 300"
    alerts:
      - type: teams
        enabled: true
        description: "healthcheck failed"
        send-on-resolved: true

  - name: back-end
    group: core
    url: "https://example.org/"
    interval: 5m
    conditions:
      - "[STATUS] == 200"
      - "[CERTIFICATE_EXPIRATION] > 48h"
    alerts:
      - type: teams
        enabled: true
        description: "healthcheck failed"
        send-on-resolved: true
```

ref: https://github.com/TwiN/gatus/issues/96

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>