### PR TITLE
feat(client): Added client configuration option for using a custom DNS resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ the client used to send the request.
 | `client.insecure`             | Whether to skip verifying the server's certificate chain and host name.    | `false`         |
 | `client.ignore-redirect`      | Whether to ignore redirects (true) or follow them (false, default).        | `false`         |
 | `client.timeout`              | Duration before timing out.                                                | `10s`           |
+| `client.dns-resolver`         | Override the DNS resolver using the format `{proto}://{host}:{port}`.      | `""`            |
 | `client.oauth2`               | OAuth2 client configuration.                                               | `{}`            |
 | `client.oauth2.token-url`     | The token endpoint URL                                                     | required `""`   |
 | `client.oauth2.client-id`     | The client id which should be used for the `Client credentials flow`       | required `""`   |
@@ -308,6 +309,17 @@ endpoints:
       insecure: false
       ignore-redirect: false
       timeout: 10s
+    conditions:
+      - "[STATUS] == 200"
+```
+
+This example shows how you can use a `custom DNS Resolver`:
+```yaml
+endpoints:
+  - name: website
+    url: "https://your.health.api/getHealth"
+    client:
+      dns-resolver: "tcp://1.1.1.1:53"
     conditions:
       - "[STATUS] == 200"
 ```

--- a/client/config.go
+++ b/client/config.go
@@ -19,7 +19,7 @@ const (
 )
 
 var (
-	ErrInvalidDNSResolver = errors.New("invalid DNS resolver specified. Required format is {proto}://{ip}:{port}")
+	ErrInvalidDNSResolver        = errors.New("invalid DNS resolver specified. Required format is {proto}://{ip}:{port}")
 	ErrInvalidClientOAuth2Config = errors.New("invalid OAuth2 configuration, all fields are required")
 
 	defaultConfig = Config{
@@ -46,7 +46,7 @@ type Config struct {
 	// Timeout for the client
 	Timeout time.Duration `yaml:"timeout"`
 
-	// DNS Resolver override for the HTTPClient
+	// DNSResolver override for the HTTPClient
 	// Expected format is {protocol}://{host}:{port}
 	DNSResolver string `yaml:"dns-resolver,omitempty"`
 

--- a/client/config.go
+++ b/client/config.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
+	"net"
 	"net/http"
+	"regexp"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -16,6 +19,7 @@ const (
 )
 
 var (
+	ErrInvalidDNSResolver = errors.New("invalid DNS resolver specified. Required format is {proto}://{ip}:{port}")
 	ErrInvalidClientOAuth2Config = errors.New("invalid OAuth2 configuration, all fields are required")
 
 	defaultConfig = Config{
@@ -42,6 +46,10 @@ type Config struct {
 	// Timeout for the client
 	Timeout time.Duration `yaml:"timeout"`
 
+	// DNS Resolver override for the HTTPClient
+	// Expected format is {protocol}://{host}:{port}
+	DNSResolver string `yaml:"dns-resolver,omitempty"`
+
 	// OAuth2Config is the OAuth2 configuration used for the client.
 	//
 	// If non-nil, the http.Client returned by getHTTPClient will automatically retrieve a token if necessary.
@@ -49,6 +57,13 @@ type Config struct {
 	OAuth2Config *OAuth2Config `yaml:"oauth2,omitempty"`
 
 	httpClient *http.Client
+}
+
+// DNSResolverConfig is the parsed configuration from the DNSResolver config string.
+type DNSResolverConfig struct {
+	Protocol string
+	Host     string
+	Port     string
 }
 
 // OAuth2Config is the configuration for the OAuth2 client credentials flow
@@ -64,10 +79,42 @@ func (c *Config) ValidateAndSetDefaults() error {
 	if c.Timeout < time.Millisecond {
 		c.Timeout = 10 * time.Second
 	}
+	if c.HasCustomDNSResolver() {
+		_, err := c.ParseDNSResolver()
+		if err != nil {
+			return ErrInvalidDNSResolver
+		}
+	}
 	if c.HasOAuth2Config() && !c.OAuth2Config.isValid() {
 		return ErrInvalidClientOAuth2Config
 	}
 	return nil
+}
+
+// Returns true if the DNSResolver is set in the configuration
+func (c *Config) HasCustomDNSResolver() bool {
+	return len(c.DNSResolver) > 0
+}
+
+// Parses the DNSResolver configuration string into the DNSResolverConfig struct
+func (c *Config) ParseDNSResolver() (DNSResolverConfig, error) {
+	re := regexp.MustCompile(`^(?P<proto>(.*))://(?P<host>[A-Za-z0-9\-\.]+):(?P<port>[0-9]+)?(.*)$`)
+	matches := re.FindStringSubmatch(c.DNSResolver)
+	if len(matches) == 0 {
+		return DNSResolverConfig{}, errors.New("ParseError")
+	}
+	r := make(map[string]string)
+	for i, k := range re.SubexpNames() {
+		if i != 0 && k != "" {
+			r[k] = matches[i]
+		}
+	}
+
+	return DNSResolverConfig{
+		Protocol: r["proto"],
+		Host:     r["host"],
+		Port:     r["port"],
+	}, nil
 }
 
 // HasOAuth2Config returns true if the client has OAuth2 configuration parameters
@@ -101,6 +148,22 @@ func (c *Config) getHTTPClient() *http.Client {
 				// Follow redirects
 				return nil
 			},
+		}
+		if c.HasCustomDNSResolver() {
+			dnsResolver, _ := c.ParseDNSResolver()
+			dialer := &net.Dialer{
+				Resolver: &net.Resolver{
+					PreferGo: true,
+					Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+						d := net.Dialer{}
+						return d.DialContext(ctx, dnsResolver.Protocol, fmt.Sprintf("%s:%s", dnsResolver.Host, dnsResolver.Port))
+					},
+				},
+			}
+			dialCtx := func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return dialer.DialContext(ctx, network, addr)
+			}
+			c.httpClient.Transport.(*http.Transport).DialContext = dialCtx
 		}
 		if c.HasOAuth2Config() {
 			c.httpClient = configureOAuth2(c.httpClient, *c.OAuth2Config)


### PR DESCRIPTION
Added a new configuration option to the `client` to allow the user to specify a custom DNS resolver.

Example config:

```yaml
# use Cloudflare DNS to lookup the DNS name for the endpoint
endpoints:
  - name: front-end
    group: core
    url: "https://twin.sh/health"
    interval: 30s
    client:
      dns-resolver: "tcp://1.1.1.1:53"
    conditions:
      - "[STATUS] == 200"
      - "[BODY].status == UP"
      - "[RESPONSE_TIME] < 150"
```



## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Added the documentation in `README.md`, if applicable.
