### PR TITLE
Add Matrix alert provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Have any feedback or questions? [Create a discussion](https://github.com/TwiN/ga
     - [Configuring Teams alerts](#configuring-teams-alerts)
     - [Configuring Telegram alerts](#configuring-telegram-alerts)
     - [Configuring Twilio alerts](#configuring-twilio-alerts)
+    - [Configuring Matrix alerts](#configuring-matrix-alerts)
     - [Configuring custom alerts](#configuring-custom-alerts)
     - [Setting a default alert](#setting-a-default-alert)
   - [Maintenance](#maintenance)
@@ -276,7 +277,7 @@ See [examples/docker-compose-postgres-storage](.examples/docker-compose-postgres
 
 
 ### Client configuration
-In order to support a wide range of environments, each monitored endpoint has a unique configuration for 
+In order to support a wide range of environments, each monitored endpoint has a unique configuration for
 the client used to send the request.
 
 | Parameter                     | Description                                                                | Default         |
@@ -377,7 +378,7 @@ ignored.
 
 ```yaml
 alerting:
-  discord: 
+  discord:
     webhook-url: "https://discord.com/api/webhooks/**********/**********"
 
 endpoints:
@@ -420,7 +421,7 @@ alerting:
     host: "mail.example.com"
     port: 587
     to: "recipient1@example.com,recipient2@example.com"
-    # You can also add group-specific to keys, which will 
+    # You can also add group-specific to keys, which will
     # override the to key above for the specified groups
     overrides:
       - group: "core"
@@ -470,7 +471,7 @@ endpoints:
 
 ```yaml
 alerting:
-  googlechat: 
+  googlechat:
     webhook-url: "https://chat.googleapis.com/v1/spaces/*******/messages?key=**********&token=********"
 
 endpoints:
@@ -501,7 +502,7 @@ endpoints:
 
 ```yaml
 alerting:
-  mattermost: 
+  mattermost:
     webhook-url: "http://**********/hooks/**********"
     client:
       insecure: true
@@ -601,9 +602,9 @@ Behavior:
 
 ```yaml
 alerting:
-  pagerduty: 
+  pagerduty:
     integration-key: "********************************"
-    # You can also add group-specific integration keys, which will 
+    # You can also add group-specific integration keys, which will
     # override the integration key above for the specified groups
     overrides:
       - group: "core"
@@ -653,7 +654,7 @@ endpoints:
 | `alerting.slack.overrides[].webhook-url`  | Slack Webhook URL                                                                          | `""`          |
 ```yaml
 alerting:
-  slack: 
+  slack:
     webhook-url: "https://hooks.slack.com/services/**********/**********/**********"
 
 endpoints:
@@ -696,7 +697,7 @@ Here's an example of what the notifications look like:
 alerting:
   teams:
     webhook-url: "https://********.webhook.office.com/webhookb2/************"
-    # You can also add group-specific to keys, which will 
+    # You can also add group-specific to keys, which will
     # override the to key above for the specified groups
     overrides:
       - group: "core"
@@ -745,7 +746,7 @@ Here's an example of what the notifications look like:
 
 ```yaml
 alerting:
-  telegram: 
+  telegram:
     token: "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
     id: "0123456789"
 
@@ -801,6 +802,36 @@ endpoints:
         description: "healthcheck failed"
 ```
 
+#### Configuring Matrix alerts
+| Parameter                          | Description                                                                                | Default                            |
+|:-----------------------------------|:-------------------------------------------------------------------------------------------|:-----------------------------------|
+| `alerting.matrix`                  | Settings for alerts of type `matrix`                                                       | `{}`                               |
+| `alerting.matrix.homeserver-url`   | Custom homeserver URL                                                                      | `https://matrix-client.matrix.org` |
+| `alerting.matrix.access-token`     | Bot user access token                                                                      | Required `""`                      |
+| `alerting.matrix.internal-room-id` | Internal room ID of room that bot user can send messages  to                               | Required `""`                      |
+| `alerting.matrix.default-alert`    | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert) | N/A                                |
+
+```yaml
+alerting:
+  matrix:
+    homeserver-url: "..."
+    access-token: "..."
+    internal-room-id: "..."
+
+endpoints:
+  - name: website
+    interval: 30s
+    url: "https://twin.sh/health"
+    conditions:
+      - "[STATUS] == 200"
+      - "[BODY].status == UP"
+      - "[RESPONSE_TIME] < 300"
+    alerts:
+      - type: matrix
+        enabled: true
+        send-on-resolved: true
+        description: "healthcheck failed"
+```
 
 #### Configuring custom alerts
 | Parameter                       | Description                                                                                | Default       |
@@ -813,9 +844,9 @@ endpoints:
 | `alerting.custom.client`        | Client configuration. <br />See [Client configuration](#client-configuration).             | `{}`          |
 | `alerting.custom.default-alert` | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert) | N/A           |
 
-While they're called alerts, you can use this feature to call anything. 
+While they're called alerts, you can use this feature to call anything.
 
-For instance, you could automate rollbacks by having an application that keeps tracks of new deployments, and by 
+For instance, you could automate rollbacks by having an application that keeps tracks of new deployments, and by
 leveraging Gatus, you could have Gatus call that application endpoint when an endpoint starts failing. Your application
 would then check if the endpoint that started failing was part of the recently deployed application, and if it was,
 then automatically roll it back.
@@ -827,7 +858,7 @@ Furthermore, you may use the following placeholders in the body (`alerting.custo
 - `[ENDPOINT_URL]` (resolved from `endpoints[].url`)
 
 If you have an alert using the `custom` provider with `send-on-resolved` set to `true`, you can use the
-`[ALERT_TRIGGERED_OR_RESOLVED]` placeholder to differentiate the notifications. 
+`[ALERT_TRIGGERED_OR_RESOLVED]` placeholder to differentiate the notifications.
 The aforementioned placeholder will be replaced by `TRIGGERED` or `RESOLVED` accordingly, though it can be modified
 (details at the end of this section).
 
@@ -867,7 +898,7 @@ alerting:
         TRIGGERED: "partial_outage"
         RESOLVED: "operational"
 ```
-As a result, the `[ALERT_TRIGGERED_OR_RESOLVED]` in the body of first example of this section would be replaced by 
+As a result, the `[ALERT_TRIGGERED_OR_RESOLVED]` in the body of first example of this section would be replaced by
 `partial_outage` when an alert is triggered and `operational` when an alert is resolved.
 
 
@@ -886,7 +917,7 @@ long configuration file.
 To avoid such problem, you can use the `default-alert` parameter present in each provider configuration:
 ```yaml
 alerting:
-  slack: 
+  slack:
     webhook-url: "https://hooks.slack.com/services/**********/**********/**********"
     default-alert:
       enabled: true
@@ -963,7 +994,7 @@ endpoints:
 ```
 
 ### Maintenance
-If you have maintenance windows, you may not want to be annoyed by alerts. 
+If you have maintenance windows, you may not want to be annoyed by alerts.
 To do that, you'll have to use the maintenance configuration:
 
 | Parameter              | Description                                                                                                                            | Default       |
@@ -1069,8 +1100,8 @@ To run Gatus locally with Docker:
 docker run -p 8080:8080 --name gatus twinproduction/gatus
 ```
 
-Other than using one of the examples provided in the [.examples](.examples) folder, you can also try it out locally by 
-creating a configuration file, we'll call it `config.yaml` for this example, and running the following 
+Other than using one of the examples provided in the [.examples](.examples) folder, you can also try it out locally by
+creating a configuration file, we'll call it `config.yaml` for this example, and running the following
 command:
 ```console
 docker run -p 8080:8080 --mount type=bind,source="$(pwd)"/config.yaml,target=/config/config.yaml --name gatus twinproduction/gatus
@@ -1154,26 +1185,26 @@ will send a `POST` request to `http://localhost:8080/playground` with the follow
 To ensure that Gatus provides reliable and accurate results (i.e. response time), Gatus only evaluates one endpoint at a time
 In other words, even if you have multiple endpoints with the same interval, they will not execute at the same time.
 
-You can test this yourself by running Gatus with several endpoints configured with a very short, unrealistic interval, 
+You can test this yourself by running Gatus with several endpoints configured with a very short, unrealistic interval,
 such as 1ms. You'll notice that the response time does not fluctuate - that is because while endpoints are evaluated on
 different goroutines, there's a global lock that prevents multiple endpoints from running at the same time.
 
-Unfortunately, there is a drawback. If you have a lot of endpoints, including some that are very slow or prone to timing out 
+Unfortunately, there is a drawback. If you have a lot of endpoints, including some that are very slow or prone to timing out
 (the default timeout is 10s), then it means that for the entire duration of the request, no other endpoint can be evaluated.
 
-The interval does not include the duration of the request itself, which means that if an endpoint has an interval of 30s 
-and the request takes 2s to complete, the timestamp between two evaluations will be 32s, not 30s. 
+The interval does not include the duration of the request itself, which means that if an endpoint has an interval of 30s
+and the request takes 2s to complete, the timestamp between two evaluations will be 32s, not 30s.
 
-While this does not prevent Gatus' from performing health checks on all other endpoints, it may cause Gatus to be unable 
+While this does not prevent Gatus' from performing health checks on all other endpoints, it may cause Gatus to be unable
 to respect the configured interval, for instance:
-- Endpoint A has an interval of 5s, and times out after 10s to complete 
+- Endpoint A has an interval of 5s, and times out after 10s to complete
 - Endpoint B has an interval of 5s, and takes 1ms to complete
 - Endpoint B will be unable to run every 5s, because endpoint A's health evaluation takes longer than its interval
 
-To sum it up, while Gatus can handle any interval you throw at it, you're better off having slow requests with 
+To sum it up, while Gatus can handle any interval you throw at it, you're better off having slow requests with
 higher interval.
 
-As a rule of thumb, I personally set the interval for more complex health checks to `5m` (5 minutes) and 
+As a rule of thumb, I personally set the interval for more complex health checks to `5m` (5 minutes) and
 simple health checks used for alerting (PagerDuty/Twilio) to `30s`.
 
 
@@ -1199,18 +1230,18 @@ endpoints:
       - "[CONNECTED] == true"
 ```
 
-Placeholders `[STATUS]` and `[BODY]` as well as the fields `endpoints[].body`, `endpoints[].headers`, 
+Placeholders `[STATUS]` and `[BODY]` as well as the fields `endpoints[].body`, `endpoints[].headers`,
 `endpoints[].method` and `endpoints[].graphql` are not supported for TCP endpoints.
 
 This works for applications such as databases (Postgres, MySQL, etc.) and caches (Redis, Memcached, etc.).
 
-**NOTE**: `[CONNECTED] == true` does not guarantee that the endpoint itself is healthy - it only guarantees that there's 
-something at the given address listening to the given port, and that a connection to that address was successfully 
+**NOTE**: `[CONNECTED] == true` does not guarantee that the endpoint itself is healthy - it only guarantees that there's
+something at the given address listening to the given port, and that a connection to that address was successfully
 established.
 
 
 ### Monitoring an endpoint using ICMP
-By prefixing `endpoints[].url` with `icmp:\\`, you can monitor endpoints at a very basic level using ICMP, or more 
+By prefixing `endpoints[].url` with `icmp:\\`, you can monitor endpoints at a very basic level using ICMP, or more
 commonly known as "ping" or "echo":
 
 ```yaml
@@ -1242,12 +1273,12 @@ endpoints:
 
 There are two placeholders that can be used in the conditions for endpoints of type DNS:
 - The placeholder `[BODY]` resolves to the output of the query. For instance, a query of type `A` would return an IPv4.
-- The placeholder `[DNS_RCODE]` resolves to the name associated to the response code returned by the query, such as 
+- The placeholder `[DNS_RCODE]` resolves to the name associated to the response code returned by the query, such as
 `NOERROR`, `FORMERR`, `SERVFAIL`, `NXDOMAIN`, etc.
 
 
 ### Monitoring an endpoint using STARTTLS
-If you have an email server that you want to ensure there are no problems with, monitoring it through STARTTLS 
+If you have an email server that you want to ensure there are no problems with, monitoring it through STARTTLS
 will serve as a good initial indicator:
 ```yaml
 endpoints:
@@ -1280,11 +1311,11 @@ endpoints:
 ### disable-monitoring-lock
 Setting `disable-monitoring-lock` to `true` means that multiple endpoints could be monitored at the same time.
 
-While this behavior wouldn't generally be harmful, conditions using the `[RESPONSE_TIME]` placeholder could be impacted 
+While this behavior wouldn't generally be harmful, conditions using the `[RESPONSE_TIME]` placeholder could be impacted
 by the evaluation of multiple endpoints at the same time, therefore, the default value for this parameter is `false`.
 
 There are three main reasons why you might want to disable the monitoring lock:
-- You're using Gatus for load testing (each endpoint are periodically evaluated on a different goroutine, so 
+- You're using Gatus for load testing (each endpoint are periodically evaluated on a different goroutine, so
 technically, if you create 100 endpoints with a 1 seconds interval, Gatus will send 100 requests per second)
 - You have a _lot_ of endpoints to monitor
 - You want to test multiple endpoints at very short intervals (< 5s)
@@ -1381,7 +1412,7 @@ web:
 ![Uptime 7d](https://status.twin.sh/api/v1/endpoints/core_blog-external/uptimes/7d/badge.svg)
 
 Gatus can automatically generate an SVG badge for one of your monitored endpoints.
-This allows you to put badges in your individual applications' README or even create your own status page if you 
+This allows you to put badges in your individual applications' README or even create your own status page if you
 desire.
 
 The path to generate a badge is the following:
@@ -1392,7 +1423,7 @@ Where:
 - `{duration}` is `7d`, `24h` or `1h`
 - `{key}` has the pattern `<GROUP_NAME>_<ENDPOINT_NAME>` in which both variables have ` `, `/`, `_`, `,` and `.` replaced by `-`.
 
-For instance, if you want the uptime during the last 24 hours from the endpoint `frontend` in the group `core`, 
+For instance, if you want the uptime during the last 24 hours from the endpoint `frontend` in the group `core`,
 the URL would look like this:
 ```
 https://example.com/api/v1/endpoints/core_frontend/uptimes/7d/badge.svg
@@ -1418,7 +1449,7 @@ The path to generate a badge is the following:
 Where:
 - `{key}` has the pattern `<GROUP_NAME>_<ENDPOINT_NAME>` in which both variables have ` `, `/`, `_`, `,` and `.` replaced by `-`.
 
-For instance, if you want the current status of the endpoint `frontend` in the group `core`, 
+For instance, if you want the current status of the endpoint `frontend` in the group `core`,
 the URL would look like this:
 ```
 https://example.com/api/v1/endpoints/core_frontend/health/badge.svg
@@ -1456,7 +1487,7 @@ Example: https://status.twin.sh/api/v1/endpoints/core_blog-home/statuses
 
 Gzip compression will be used if the `Accept-Encoding` HTTP header contains `gzip`.
 
-The API will return a JSON payload with the `Content-Type` response header set to `application/json`. 
+The API will return a JSON payload with the `Content-Type` response header set to `application/json`.
 No such header is required to query the API.
 
 

--- a/alerting/alert/type.go
+++ b/alerting/alert/type.go
@@ -40,4 +40,7 @@ const (
 
 	// TypeOpsgenie is the Type for the opsgenie alerting provider
 	TypeOpsgenie Type = "opsgenie"
+
+	// TypeMatrix is the Type for the matrix alerting provider
+	TypeMatrix Type = "matrix"
 )

--- a/alerting/config.go
+++ b/alerting/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/TwiN/gatus/v4/alerting/provider/discord"
 	"github.com/TwiN/gatus/v4/alerting/provider/email"
 	"github.com/TwiN/gatus/v4/alerting/provider/googlechat"
+	"github.com/TwiN/gatus/v4/alerting/provider/matrix"
 	"github.com/TwiN/gatus/v4/alerting/provider/mattermost"
 	"github.com/TwiN/gatus/v4/alerting/provider/messagebird"
 	"github.com/TwiN/gatus/v4/alerting/provider/opsgenie"
@@ -54,6 +55,9 @@ type Config struct {
 
 	// Opsgenie is the configuration for the opsgenie alerting provider
 	Opsgenie *opsgenie.AlertProvider `yaml:"opsgenie,omitempty"`
+
+	// Matrix is the configuration for the matrix alerting provider
+	Matrix *matrix.AlertProvider `yaml:"matrix,omitempty"`
 }
 
 // GetAlertingProviderByAlertType returns an provider.AlertProvider by its corresponding alert.Type
@@ -131,6 +135,12 @@ func (config Config) GetAlertingProviderByAlertType(alertType alert.Type) provid
 			return nil
 		}
 		return config.Twilio
+	case alert.TypeMatrix:
+		if config.Matrix == nil {
+			// Since we're returning an interface, we need to explicitly return nil, even if the provider itself is nil
+			return nil
+		}
+		return config.Matrix
 	}
 	return nil
 }

--- a/alerting/provider/matrix/matrix.go
+++ b/alerting/provider/matrix/matrix.go
@@ -1,0 +1,192 @@
+package matrix
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/TwiN/gatus/v4/alerting/alert"
+	"github.com/TwiN/gatus/v4/client"
+	"github.com/TwiN/gatus/v4/core"
+)
+
+// AlertProvider is the configuration necessary for sending an alert using Matrix
+type AlertProvider struct {
+	// HomeserverURL is the custom homeserver to use (optional)
+	HomeserverURL string `yaml:"homeserver-url"`
+	// AccessToken is the bot user's access token to send messages
+	AccessToken string `yaml:"access-token"`
+	// InternalRoomID is the room that the bot user has permissions to send messages to
+	InternalRoomID string `yaml:"internal-room-id"`
+
+	// DefaultAlert is the default alert configuration to use for endpoints with an alert of the appropriate type
+	DefaultAlert *alert.Alert `yaml:"default-alert,omitempty"`
+
+	// Overrides is a list of Override that may be prioritized over the default configuration
+	Overrides []Override `yaml:"overrides,omitempty"`
+}
+
+// Override is a case under which the default integration is overridden
+type Override struct {
+	Group string `yaml:"group"`
+
+	HomeserverURL  string `yaml:"homeserver-url"`
+	AccessToken    string `yaml:"access-token"`
+	InternalRoomID string `yaml:"internal-room-id"`
+}
+
+const defaultHomeserverURL = "https://matrix-client.matrix.org"
+
+type matrixProviderConfig struct {
+	HomeserverURL  string `yaml:"homeserver-url"`
+	AccessToken    string `yaml:"access-token"`
+	InternalRoomID string `yaml:"internal-room-id"`
+}
+
+// IsValid returns whether the provider's configuration is valid
+func (provider *AlertProvider) IsValid() bool {
+	registeredGroups := make(map[string]bool)
+	if provider.Overrides != nil {
+		for _, override := range provider.Overrides {
+			if isAlreadyRegistered := registeredGroups[override.Group]; isAlreadyRegistered || override.Group == "" || len(override.AccessToken) == 0 || len(override.InternalRoomID) == 0 {
+				return false
+			}
+			registeredGroups[override.Group] = true
+		}
+	}
+	return len(provider.AccessToken) > 0 && len(provider.InternalRoomID) > 0
+}
+
+// Send an alert using the provider
+func (provider *AlertProvider) Send(endpoint *core.Endpoint, alert *alert.Alert, result *core.Result, resolved bool) error {
+	buffer := bytes.NewBuffer([]byte(provider.buildRequestBody(endpoint, alert, result, resolved)))
+	config := provider.getConfigForGroup(endpoint.Group)
+	if config.HomeserverURL == "" {
+		config.HomeserverURL = defaultHomeserverURL
+	}
+	txnId := randStringBytes(24)
+	request, err := http.NewRequest(
+		http.MethodPut,
+		fmt.Sprintf("%s/_matrix/client/r0/rooms/%s/send/m.room.message/%s?access_token=%s",
+			config.HomeserverURL,
+			url.PathEscape(config.InternalRoomID),
+			txnId,
+			url.QueryEscape(config.AccessToken),
+		),
+		buffer,
+	)
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := client.GetHTTPClient(nil).Do(request)
+	if err != nil {
+		return err
+	}
+	if response.StatusCode > 399 {
+		body, _ := io.ReadAll(response.Body)
+		return fmt.Errorf("call to provider alert returned status code %d: %s", response.StatusCode, string(body))
+	}
+	return err
+}
+
+// buildRequestBody builds the request body for the provider
+func (provider *AlertProvider) buildRequestBody(endpoint *core.Endpoint, alert *alert.Alert, result *core.Result, resolved bool) string {
+	return fmt.Sprintf(`{
+	"msgtype": "m.text",
+	"format": "org.matrix.custom.html",
+	"body": "%s",
+	"formatted_body": "%s"
+}`,
+		buildPlaintextMessageBody(endpoint, alert, result, resolved),
+		buildHTMLMessageBody(endpoint, alert, result, resolved),
+	)
+}
+
+// buildPlaintextMessageBody builds the message body in plaintext to include in request
+func buildPlaintextMessageBody(endpoint *core.Endpoint, alert *alert.Alert, result *core.Result, resolved bool) string {
+	var message, results string
+	if resolved {
+		message = fmt.Sprintf("An alert for `%s` has been resolved after passing successfully %d time(s) in a row", endpoint.DisplayName(), alert.SuccessThreshold)
+	} else {
+		message = fmt.Sprintf("An alert for `%s` has been triggered due to having failed %d time(s) in a row", endpoint.DisplayName(), alert.FailureThreshold)
+	}
+	for _, conditionResult := range result.ConditionResults {
+		var prefix string
+		if conditionResult.Success {
+			prefix = "✓"
+		} else {
+			prefix = "✕"
+		}
+		results += fmt.Sprintf("\\n%s - %s", prefix, conditionResult.Condition)
+	}
+	var description string
+	if alertDescription := alert.GetDescription(); len(alertDescription) > 0 {
+		description = "\\n" + alertDescription
+	}
+	return fmt.Sprintf("%s%s\\n%s", message, description, results)
+}
+
+// buildHTMLMessageBody builds the message body in HTML to include in request
+func buildHTMLMessageBody(endpoint *core.Endpoint, alert *alert.Alert, result *core.Result, resolved bool) string {
+	var message, results string
+	if resolved {
+		message = fmt.Sprintf("An alert for <code>%s</code> has been resolved after passing successfully %d time(s) in a row", endpoint.DisplayName(), alert.SuccessThreshold)
+	} else {
+		message = fmt.Sprintf("An alert for <code>%s</code> has been triggered due to having failed %d time(s) in a row", endpoint.DisplayName(), alert.FailureThreshold)
+	}
+	for _, conditionResult := range result.ConditionResults {
+		var prefix string
+		if conditionResult.Success {
+			prefix = "✅"
+		} else {
+			prefix = "❌"
+		}
+		results += fmt.Sprintf("<li>%s - <code>%s</code></li>", prefix, conditionResult.Condition)
+	}
+	var description string
+	if alertDescription := alert.GetDescription(); len(alertDescription) > 0 {
+		description = fmt.Sprintf("\\n<blockquote>%s</blockquote>", alertDescription)
+	}
+	return fmt.Sprintf("<h3>%s</h3>%s\\n<h5>Condition results</h5><ul>%s</ul>", message, description, results)
+}
+
+// getConfigForGroup returns the appropriate configuration for a given group
+func (provider *AlertProvider) getConfigForGroup(group string) matrixProviderConfig {
+	if provider.Overrides != nil {
+		for _, override := range provider.Overrides {
+			if group == override.Group {
+				return matrixProviderConfig{
+					HomeserverURL:  override.HomeserverURL,
+					AccessToken:    override.AccessToken,
+					InternalRoomID: override.InternalRoomID,
+				}
+			}
+		}
+	}
+	return matrixProviderConfig{
+		HomeserverURL:  provider.HomeserverURL,
+		AccessToken:    provider.AccessToken,
+		InternalRoomID: provider.InternalRoomID,
+	}
+}
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+func randStringBytes(n int) string {
+	b := make([]byte, n)
+	rand.Seed(time.Now().UnixNano())
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
+}
+
+// GetDefaultAlert returns the provider's default alert configuration
+func (provider AlertProvider) GetDefaultAlert() *alert.Alert {
+	return provider.DefaultAlert
+}

--- a/alerting/provider/matrix/matrix_test.go
+++ b/alerting/provider/matrix/matrix_test.go
@@ -1,0 +1,295 @@
+package matrix
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/TwiN/gatus/v4/alerting/alert"
+	"github.com/TwiN/gatus/v4/client"
+	"github.com/TwiN/gatus/v4/core"
+	"github.com/TwiN/gatus/v4/test"
+)
+
+func TestAlertProvider_IsValid(t *testing.T) {
+	invalidProvider := AlertProvider{AccessToken: "", InternalRoomID: ""}
+	if invalidProvider.IsValid() {
+		t.Error("provider shouldn't have been valid")
+	}
+	validProvider := AlertProvider{AccessToken: "1", InternalRoomID: "!a:example.com"}
+	if !validProvider.IsValid() {
+		t.Error("provider should've been valid")
+	}
+	validProviderWithHomeserver := AlertProvider{HomeserverURL: "https://example.com", AccessToken: "1", InternalRoomID: "!a:example.com"}
+	if !validProviderWithHomeserver.IsValid() {
+		t.Error("provider with homeserver should've been valid")
+	}
+}
+
+func TestAlertProvider_IsValidWithOverride(t *testing.T) {
+	providerWithInvalidOverrideGroup := AlertProvider{
+		Overrides: []Override{
+			{
+				AccessToken:    "",
+				InternalRoomID: "",
+				Group:          "",
+			},
+		},
+	}
+	if providerWithInvalidOverrideGroup.IsValid() {
+		t.Error("provider Group shouldn't have been valid")
+	}
+	providerWithInvalidOverrideTo := AlertProvider{
+		Overrides: []Override{
+			{
+				AccessToken:    "",
+				InternalRoomID: "",
+				Group:          "group",
+			},
+		},
+	}
+	if providerWithInvalidOverrideTo.IsValid() {
+		t.Error("provider integration key shouldn't have been valid")
+	}
+	providerWithValidOverride := AlertProvider{
+		AccessToken:    "1",
+		InternalRoomID: "!a:example.com",
+		Overrides: []Override{
+			{
+				HomeserverURL:  "https://example.com",
+				AccessToken:    "1",
+				InternalRoomID: "!a:example.com",
+				Group:          "group",
+			},
+		},
+	}
+	if !providerWithValidOverride.IsValid() {
+		t.Error("provider should've been valid")
+	}
+}
+
+func TestAlertProvider_Send(t *testing.T) {
+	defer client.InjectHTTPClient(nil)
+	firstDescription := "description-1"
+	secondDescription := "description-2"
+	scenarios := []struct {
+		Name             string
+		Provider         AlertProvider
+		Alert            alert.Alert
+		Resolved         bool
+		MockRoundTripper test.MockRoundTripper
+		ExpectedError    bool
+	}{
+		{
+			Name:     "triggered",
+			Provider: AlertProvider{},
+			Alert:    alert.Alert{Description: &firstDescription, SuccessThreshold: 5, FailureThreshold: 3},
+			Resolved: false,
+			MockRoundTripper: test.MockRoundTripper(func(r *http.Request) *http.Response {
+				return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}
+			}),
+			ExpectedError: false,
+		},
+		{
+			Name:     "triggered-error",
+			Provider: AlertProvider{},
+			Alert:    alert.Alert{Description: &firstDescription, SuccessThreshold: 5, FailureThreshold: 3},
+			Resolved: false,
+			MockRoundTripper: test.MockRoundTripper(func(r *http.Request) *http.Response {
+				return &http.Response{StatusCode: http.StatusInternalServerError, Body: http.NoBody}
+			}),
+			ExpectedError: true,
+		},
+		{
+			Name:     "resolved",
+			Provider: AlertProvider{},
+			Alert:    alert.Alert{Description: &secondDescription, SuccessThreshold: 5, FailureThreshold: 3},
+			Resolved: true,
+			MockRoundTripper: test.MockRoundTripper(func(r *http.Request) *http.Response {
+				return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}
+			}),
+			ExpectedError: false,
+		},
+		{
+			Name:     "resolved-error",
+			Provider: AlertProvider{},
+			Alert:    alert.Alert{Description: &secondDescription, SuccessThreshold: 5, FailureThreshold: 3},
+			Resolved: true,
+			MockRoundTripper: test.MockRoundTripper(func(r *http.Request) *http.Response {
+				return &http.Response{StatusCode: http.StatusInternalServerError, Body: http.NoBody}
+			}),
+			ExpectedError: true,
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			client.InjectHTTPClient(&http.Client{Transport: scenario.MockRoundTripper})
+			err := scenario.Provider.Send(
+				&core.Endpoint{Name: "endpoint-name"},
+				&scenario.Alert,
+				&core.Result{
+					ConditionResults: []*core.ConditionResult{
+						{Condition: "[CONNECTED] == true", Success: scenario.Resolved},
+						{Condition: "[STATUS] == 200", Success: scenario.Resolved},
+					},
+				},
+				scenario.Resolved,
+			)
+			if scenario.ExpectedError && err == nil {
+				t.Error("expected error, got none")
+			}
+			if !scenario.ExpectedError && err != nil {
+				t.Error("expected no error, got", err.Error())
+			}
+		})
+	}
+}
+
+func TestAlertProvider_buildRequestBody(t *testing.T) {
+	firstDescription := "description-1"
+	secondDescription := "description-2"
+	scenarios := []struct {
+		Name         string
+		Provider     AlertProvider
+		Alert        alert.Alert
+		Resolved     bool
+		ExpectedBody string
+	}{
+		{
+			Name:         "triggered",
+			Provider:     AlertProvider{},
+			Alert:        alert.Alert{Description: &firstDescription, SuccessThreshold: 5, FailureThreshold: 3},
+			Resolved:     false,
+			ExpectedBody: "{\n\t\"msgtype\": \"m.text\",\n\t\"format\": \"org.matrix.custom.html\",\n\t\"body\": \"An alert for `endpoint-name` has been triggered due to having failed 3 time(s) in a row\\ndescription-1\\n\\n✕ - [CONNECTED] == true\\n✕ - [STATUS] == 200\",\n\t\"formatted_body\": \"<h3>An alert for <code>endpoint-name</code> has been triggered due to having failed 3 time(s) in a row</h3>\\n<blockquote>description-1</blockquote>\\n<h5>Condition results</h5><ul><li>❌ - <code>[CONNECTED] == true</code></li><li>❌ - <code>[STATUS] == 200</code></li></ul>\"\n}",
+		},
+		{
+			Name:         "resolved",
+			Provider:     AlertProvider{},
+			Alert:        alert.Alert{Description: &secondDescription, SuccessThreshold: 5, FailureThreshold: 3},
+			Resolved:     true,
+			ExpectedBody: "{\n\t\"msgtype\": \"m.text\",\n\t\"format\": \"org.matrix.custom.html\",\n\t\"body\": \"An alert for `endpoint-name` has been resolved after passing successfully 5 time(s) in a row\\ndescription-2\\n\\n✓ - [CONNECTED] == true\\n✓ - [STATUS] == 200\",\n\t\"formatted_body\": \"<h3>An alert for <code>endpoint-name</code> has been resolved after passing successfully 5 time(s) in a row</h3>\\n<blockquote>description-2</blockquote>\\n<h5>Condition results</h5><ul><li>✅ - <code>[CONNECTED] == true</code></li><li>✅ - <code>[STATUS] == 200</code></li></ul>\"\n}",
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			body := scenario.Provider.buildRequestBody(
+				&core.Endpoint{Name: "endpoint-name"},
+				&scenario.Alert,
+				&core.Result{
+					ConditionResults: []*core.ConditionResult{
+						{Condition: "[CONNECTED] == true", Success: scenario.Resolved},
+						{Condition: "[STATUS] == 200", Success: scenario.Resolved},
+					},
+				},
+				scenario.Resolved,
+			)
+			if body != scenario.ExpectedBody {
+				t.Errorf("expected %s, got %s", scenario.ExpectedBody, body)
+			}
+			out := make(map[string]interface{})
+			if err := json.Unmarshal([]byte(body), &out); err != nil {
+				t.Error("expected body to be valid JSON, got error:", err.Error())
+			}
+		})
+	}
+}
+
+func TestAlertProvider_GetDefaultAlert(t *testing.T) {
+	if (AlertProvider{DefaultAlert: &alert.Alert{}}).GetDefaultAlert() == nil {
+		t.Error("expected default alert to be not nil")
+	}
+	if (AlertProvider{DefaultAlert: nil}).GetDefaultAlert() != nil {
+		t.Error("expected default alert to be nil")
+	}
+}
+
+func TestAlertProvider_getConfigForGroup(t *testing.T) {
+	tests := []struct {
+		Name           string
+		Provider       AlertProvider
+		InputGroup     string
+		ExpectedOutput matrixProviderConfig
+	}{
+		{
+			Name: "provider-no-override-specify-no-group-should-default",
+			Provider: AlertProvider{
+				HomeserverURL:  "https://example.com",
+				AccessToken:    "1",
+				InternalRoomID: "!a:example.com",
+				Overrides:      nil,
+			},
+			InputGroup: "",
+			ExpectedOutput: matrixProviderConfig{
+				HomeserverURL:  "https://example.com",
+				AccessToken:    "1",
+				InternalRoomID: "!a:example.com",
+			},
+		},
+		{
+			Name: "provider-no-override-specify-group-should-default",
+			Provider: AlertProvider{
+				HomeserverURL:  "https://example.com",
+				AccessToken:    "1",
+				InternalRoomID: "!a:example.com",
+				Overrides:      nil,
+			},
+			InputGroup: "group",
+			ExpectedOutput: matrixProviderConfig{
+				HomeserverURL:  "https://example.com",
+				AccessToken:    "1",
+				InternalRoomID: "!a:example.com",
+			},
+		},
+		{
+			Name: "provider-with-override-specify-no-group-should-default",
+			Provider: AlertProvider{
+				HomeserverURL:  "https://example.com",
+				AccessToken:    "1",
+				InternalRoomID: "!a:example.com",
+				Overrides: []Override{
+					{
+						Group:          "group",
+						HomeserverURL:  "https://example01.com",
+						AccessToken:    "12",
+						InternalRoomID: "!a:example01.com",
+					},
+				},
+			},
+			InputGroup: "",
+			ExpectedOutput: matrixProviderConfig{
+				HomeserverURL:  "https://example.com",
+				AccessToken:    "1",
+				InternalRoomID: "!a:example.com",
+			},
+		},
+		{
+			Name: "provider-with-override-specify-group-should-override",
+			Provider: AlertProvider{
+				HomeserverURL:  "https://example.com",
+				AccessToken:    "1",
+				InternalRoomID: "!a:example.com",
+				Overrides: []Override{
+					{
+						Group:          "group",
+						HomeserverURL:  "https://example01.com",
+						AccessToken:    "12",
+						InternalRoomID: "!a:example01.com",
+					},
+				},
+			},
+			InputGroup: "group",
+			ExpectedOutput: matrixProviderConfig{
+				HomeserverURL:  "https://example01.com",
+				AccessToken:    "12",
+				InternalRoomID: "!a:example01.com",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			if got := tt.Provider.getConfigForGroup(tt.InputGroup); got != tt.ExpectedOutput {
+				t.Errorf("AlertProvider.getConfigForGroup() = %v, want %v", got, tt.ExpectedOutput)
+			}
+		})
+	}
+}

--- a/alerting/provider/provider.go
+++ b/alerting/provider/provider.go
@@ -6,6 +6,7 @@ import (
 	"github.com/TwiN/gatus/v4/alerting/provider/discord"
 	"github.com/TwiN/gatus/v4/alerting/provider/email"
 	"github.com/TwiN/gatus/v4/alerting/provider/googlechat"
+	"github.com/TwiN/gatus/v4/alerting/provider/matrix"
 	"github.com/TwiN/gatus/v4/alerting/provider/mattermost"
 	"github.com/TwiN/gatus/v4/alerting/provider/messagebird"
 	"github.com/TwiN/gatus/v4/alerting/provider/opsgenie"
@@ -65,4 +66,5 @@ var (
 	_ AlertProvider = (*teams.AlertProvider)(nil)
 	_ AlertProvider = (*telegram.AlertProvider)(nil)
 	_ AlertProvider = (*twilio.AlertProvider)(nil)
+	_ AlertProvider = (*matrix.AlertProvider)(nil)
 )

--- a/config/config.go
+++ b/config/config.go
@@ -282,6 +282,7 @@ func validateAlertingConfig(alertingConfig *alerting.Config, endpoints []*core.E
 		alert.TypeTeams,
 		alert.TypeTelegram,
 		alert.TypeTwilio,
+		alert.TypeMatrix,
 	}
 	var validProviders, invalidProviders []alert.Type
 	for _, alertType := range alertTypes {

--- a/watchdog/alerting_test.go
+++ b/watchdog/alerting_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/TwiN/gatus/v4/alerting/provider/custom"
 	"github.com/TwiN/gatus/v4/alerting/provider/discord"
 	"github.com/TwiN/gatus/v4/alerting/provider/email"
+	"github.com/TwiN/gatus/v4/alerting/provider/matrix"
 	"github.com/TwiN/gatus/v4/alerting/provider/mattermost"
 	"github.com/TwiN/gatus/v4/alerting/provider/messagebird"
 	"github.com/TwiN/gatus/v4/alerting/provider/pagerduty"
@@ -309,6 +310,17 @@ func TestHandleAlertingWithProviderThatReturnsAnError(t *testing.T) {
 					Token: "2",
 					From:  "3",
 					To:    "4",
+				},
+			},
+		},
+		{
+			Name:      "matrix",
+			AlertType: alert.TypeMatrix,
+			AlertingConfig: &alerting.Config{
+				Matrix: &matrix.AlertProvider{
+					HomeserverURL:  "https://example.com",
+					AccessToken:    "1",
+					InternalRoomID: "!a:example.com",
 				},
 			},
 		},


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
Adds support to use Matrix as an alert provider. Requires a user account and a room to send messages to, and optionally a custom homeserver.


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Added the documentation in `README.md`, if applicable.
