### PR TITLE
chore: Add copy config file first when develop.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.db-wal
 gatus
 config/config.yaml
+config/config.yml

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 *.db-shm
 *.db-wal
 gatus
-config/config.yml
+config/config.yaml

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,16 @@ BINARY=gatus
 # Because there's a folder called "test", we need to make the target "test" phony
 .PHONY: test
 
-install:
+.PHONY: config
+config:
+	test -f config/config.yaml || cp -r config.yaml config/config.yaml
+
+.PHONY: install
+install: config
 	go build -mod vendor -o $(BINARY) .
 
-run:
-	GATUS_CONFIG_FILE=./config.yaml ./$(BINARY)
+run: config
+	./$(BINARY)
 
 clean:
 	rm $(BINARY)


### PR DESCRIPTION
Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>

<!-- Thank you for contributing! -->

## Summary

Copy config file to config folder when developing in local build and prevent modifying the origin config file.

