### PR TITLE
feat(docker): add basic healthcheck support

### DIFF
--- a/.examples/docker-compose-postgres-storage/docker-compose.yml
+++ b/.examples/docker-compose-postgres-storage/docker-compose.yml
@@ -12,6 +12,10 @@ services:
       - POSTGRES_PASSWORD=password
     networks:
       - web
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "outline"]
+      interval: 3s
+      retries: 12
 
   gatus:
     image: twinproduction/gatus:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build the go application into a binary
 FROM golang:alpine as builder
-RUN apk --update add ca-certificates
+RUN apk --update --no-cache add ca-certificates curl
 WORKDIR /app
 COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -installsuffix cgo -o gatus .


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
This can help run Gatus with Docker behind proxy like Nginx:

```yaml
  gatus:
    image: twinproduction/gatus:v4.0.0
    restart: always
    volumes:
      - ./config/gatus:/config
      - ./data/gatus:/data/
    healthcheck:
      test: ["CMD-SHELL", "curl -f http://localhost:8080 || exit 1"]
      interval: 30s
      retries: 5
      timeout: 3s
```


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [ ] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Added the documentation in `README.md`, if applicable.
