### PR TITLE
feat(remote): Implement lazy distributed feature

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -17,7 +17,7 @@ import (
 // injectedHTTPClient is used for testing purposes
 var injectedHTTPClient *http.Client
 
-// GetHTTPClient returns the shared HTTP client
+// GetHTTPClient returns the shared HTTP client, or the client from the configuration passed
 func GetHTTPClient(config *Config) *http.Client {
 	if injectedHTTPClient != nil {
 		return injectedHTTPClient

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TwiN/gatus/v4/alerting/alert"
 	"github.com/TwiN/gatus/v4/alerting/provider"
 	"github.com/TwiN/gatus/v4/config/maintenance"
+	"github.com/TwiN/gatus/v4/config/remote"
 	"github.com/TwiN/gatus/v4/config/ui"
 	"github.com/TwiN/gatus/v4/config/web"
 	"github.com/TwiN/gatus/v4/core"
@@ -84,6 +85,10 @@ type Config struct {
 
 	// Maintenance is the configuration for creating a maintenance window in which no alerts are sent
 	Maintenance *maintenance.Config `yaml:"maintenance,omitempty"`
+
+	// Remote is the configuration for remote Gatus instances
+	// WARNING: This is in ALPHA and may change or be completely removed in the future
+	Remote *remote.Config `yaml:"remote,omitempty"`
 
 	filePath        string    // path to the file from which config was loaded from
 	lastFileModTime time.Time // last modification time
@@ -185,8 +190,20 @@ func parseAndValidateConfigBytes(yamlBytes []byte) (config *Config, err error) {
 		if err := validateStorageConfig(config); err != nil {
 			return nil, err
 		}
+		if err := validateRemoteConfig(config); err != nil {
+			return nil, err
+		}
 	}
 	return
+}
+
+func validateRemoteConfig(config *Config) error {
+	if config.Remote != nil {
+		if err := config.Remote.ValidateAndSetDefaults(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func validateStorageConfig(config *Config) error {

--- a/config/remote/remote.go
+++ b/config/remote/remote.go
@@ -1,0 +1,38 @@
+package remote
+
+import (
+	"log"
+
+	"github.com/TwiN/gatus/v4/client"
+)
+
+// NOTICE: This is an experimental alpha feature and may be updated/removed in future versions.
+// For more information, see https://github.com/TwiN/gatus/issues/64
+
+type Config struct {
+	// Instances is a list of remote instances to retrieve endpoint statuses from.
+	Instances []Instance `yaml:"instances,omitempty"`
+
+	// ClientConfig is the configuration of the client used to communicate with the provider's target
+	ClientConfig *client.Config `yaml:"client,omitempty"`
+}
+
+type Instance struct {
+	EndpointPrefix string `yaml:"endpoint-prefix"`
+	URL            string `yaml:"url"`
+}
+
+func (c *Config) ValidateAndSetDefaults() error {
+	if c.ClientConfig == nil {
+		c.ClientConfig = client.GetDefaultConfig()
+	} else {
+		if err := c.ClientConfig.ValidateAndSetDefaults(); err != nil {
+			return err
+		}
+	}
+	if len(c.Instances) > 0 {
+		log.Println("WARNING: Your configuration is using 'remote', which is in alpha and may be updated/removed in future versions.")
+		log.Println("WARNING: See https://github.com/TwiN/gatus/issues/64 for more information")
+	}
+	return nil
+}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -8,10 +8,9 @@ import (
 	"os"
 	"time"
 
+	"github.com/TwiN/gatus/v4/config"
 	"github.com/TwiN/gatus/v4/config/ui"
-	"github.com/TwiN/gatus/v4/config/web"
 	"github.com/TwiN/gatus/v4/controller/handler"
-	"github.com/TwiN/gatus/v4/security"
 )
 
 var (
@@ -21,19 +20,19 @@ var (
 )
 
 // Handle creates the router and starts the server
-func Handle(securityConfig *security.Config, webConfig *web.Config, uiConfig *ui.Config, enableMetrics bool) {
-	var router http.Handler = handler.CreateRouter(ui.StaticFolder, securityConfig, uiConfig, enableMetrics)
+func Handle(cfg *config.Config) {
+	var router http.Handler = handler.CreateRouter(ui.StaticFolder, cfg)
 	if os.Getenv("ENVIRONMENT") == "dev" {
 		router = handler.DevelopmentCORS(router)
 	}
 	server = &http.Server{
-		Addr:         fmt.Sprintf("%s:%d", webConfig.Address, webConfig.Port),
+		Addr:         fmt.Sprintf("%s:%d", cfg.Web.Address, cfg.Web.Port),
 		Handler:      router,
 		ReadTimeout:  15 * time.Second,
 		WriteTimeout: 15 * time.Second,
 		IdleTimeout:  15 * time.Second,
 	}
-	log.Println("[controller][Handle] Listening on " + webConfig.SocketAddress())
+	log.Println("[controller][Handle] Listening on " + cfg.Web.SocketAddress())
 	if os.Getenv("ROUTER_TEST") == "true" {
 		return
 	}

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -32,7 +32,7 @@ func TestHandle(t *testing.T) {
 	_ = os.Setenv("ROUTER_TEST", "true")
 	_ = os.Setenv("ENVIRONMENT", "dev")
 	defer os.Clearenv()
-	Handle(cfg.Security, cfg.Web, cfg.UI, cfg.Metrics)
+	Handle(cfg)
 	defer Shutdown()
 	request, _ := http.NewRequest("GET", "/health", http.NoBody)
 	responseRecorder := httptest.NewRecorder()

--- a/controller/handler/badge_test.go
+++ b/controller/handler/badge_test.go
@@ -31,7 +31,7 @@ func TestBadge(t *testing.T) {
 	}
 	watchdog.UpdateEndpointStatuses(cfg.Endpoints[0], &core.Result{Success: true, Connected: true, Duration: time.Millisecond, Timestamp: time.Now()})
 	watchdog.UpdateEndpointStatuses(cfg.Endpoints[1], &core.Result{Success: false, Connected: false, Duration: time.Second, Timestamp: time.Now()})
-	router := CreateRouter("../../web/static", cfg.Security, nil, cfg.Metrics)
+	router := CreateRouter("../../web/static", cfg)
 	type Scenario struct {
 		Name         string
 		Path         string

--- a/controller/handler/chart_test.go
+++ b/controller/handler/chart_test.go
@@ -30,7 +30,7 @@ func TestResponseTimeChart(t *testing.T) {
 	}
 	watchdog.UpdateEndpointStatuses(cfg.Endpoints[0], &core.Result{Success: true, Duration: time.Millisecond, Timestamp: time.Now()})
 	watchdog.UpdateEndpointStatuses(cfg.Endpoints[1], &core.Result{Success: false, Duration: time.Second, Timestamp: time.Now()})
-	router := CreateRouter("../../web/static", cfg.Security, nil, cfg.Metrics)
+	router := CreateRouter("../../web/static", cfg)
 	type Scenario struct {
 		Name         string
 		Path         string

--- a/controller/handler/endpoint_status_test.go
+++ b/controller/handler/endpoint_status_test.go
@@ -97,7 +97,7 @@ func TestEndpointStatus(t *testing.T) {
 	}
 	watchdog.UpdateEndpointStatuses(cfg.Endpoints[0], &core.Result{Success: true, Duration: time.Millisecond, Timestamp: time.Now()})
 	watchdog.UpdateEndpointStatuses(cfg.Endpoints[1], &core.Result{Success: false, Duration: time.Second, Timestamp: time.Now()})
-	router := CreateRouter("../../web/static", cfg.Security, nil, cfg.Metrics)
+	router := CreateRouter("../../web/static", cfg)
 
 	type Scenario struct {
 		Name         string
@@ -153,7 +153,7 @@ func TestEndpointStatuses(t *testing.T) {
 	// Can't be bothered dealing with timezone issues on the worker that runs the automated tests
 	firstResult.Timestamp = time.Time{}
 	secondResult.Timestamp = time.Time{}
-	router := CreateRouter("../../web/static", nil, nil, false)
+	router := CreateRouter("../../web/static", &config.Config{Metrics: true})
 
 	type Scenario struct {
 		Name         string

--- a/controller/handler/favicon_test.go
+++ b/controller/handler/favicon_test.go
@@ -4,10 +4,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/TwiN/gatus/v4/config"
 )
 
 func TestFavIcon(t *testing.T) {
-	router := CreateRouter("../../web/static", nil, nil, false)
+	router := CreateRouter("../../web/static", &config.Config{})
 	type Scenario struct {
 		Name         string
 		Path         string

--- a/controller/handler/handler.go
+++ b/controller/handler/handler.go
@@ -3,32 +3,31 @@ package handler
 import (
 	"net/http"
 
-	"github.com/TwiN/gatus/v4/config/ui"
-	"github.com/TwiN/gatus/v4/security"
+	"github.com/TwiN/gatus/v4/config"
 	"github.com/TwiN/health"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-func CreateRouter(staticFolder string, securityConfig *security.Config, uiConfig *ui.Config, enabledMetrics bool) *mux.Router {
+func CreateRouter(staticFolder string, cfg *config.Config) *mux.Router {
 	router := mux.NewRouter()
-	if enabledMetrics {
+	if cfg.Metrics {
 		router.Handle("/metrics", promhttp.Handler()).Methods("GET")
 	}
 	api := router.PathPrefix("/api").Subrouter()
 	protected := api.PathPrefix("/").Subrouter()
 	unprotected := api.PathPrefix("/").Subrouter()
-	if securityConfig != nil {
-		if err := securityConfig.RegisterHandlers(router); err != nil {
+	if cfg.Security != nil {
+		if err := cfg.Security.RegisterHandlers(router); err != nil {
 			panic(err)
 		}
-		if err := securityConfig.ApplySecurityMiddleware(protected); err != nil {
+		if err := cfg.Security.ApplySecurityMiddleware(protected); err != nil {
 			panic(err)
 		}
 	}
 	// Endpoints
-	unprotected.Handle("/v1/config", ConfigHandler{securityConfig: securityConfig}).Methods("GET")
-	protected.HandleFunc("/v1/endpoints/statuses", EndpointStatuses).Methods("GET") // No GzipHandler for this one, because we cache the content as Gzipped already
+	unprotected.Handle("/v1/config", ConfigHandler{securityConfig: cfg.Security}).Methods("GET")
+	protected.HandleFunc("/v1/endpoints/statuses", EndpointStatuses(cfg)).Methods("GET") // No GzipHandler for this one, because we cache the content as Gzipped already
 	protected.HandleFunc("/v1/endpoints/{key}/statuses", GzipHandlerFunc(EndpointStatus)).Methods("GET")
 	unprotected.HandleFunc("/v1/endpoints/{key}/health/badge.svg", HealthBadge).Methods("GET")
 	unprotected.HandleFunc("/v1/endpoints/{key}/uptimes/{duration}/badge.svg", UptimeBadge).Methods("GET")
@@ -38,8 +37,8 @@ func CreateRouter(staticFolder string, securityConfig *security.Config, uiConfig
 	router.Handle("/health", health.Handler().WithJSON(true)).Methods("GET")
 	router.HandleFunc("/favicon.ico", FavIcon(staticFolder)).Methods("GET")
 	// SPA
-	router.HandleFunc("/endpoints/{name}", SinglePageApplication(staticFolder, uiConfig)).Methods("GET")
-	router.HandleFunc("/", SinglePageApplication(staticFolder, uiConfig)).Methods("GET")
+	router.HandleFunc("/endpoints/{name}", SinglePageApplication(staticFolder, cfg.UI)).Methods("GET")
+	router.HandleFunc("/", SinglePageApplication(staticFolder, cfg.UI)).Methods("GET")
 	// Everything else falls back on static content
 	router.PathPrefix("/").Handler(GzipHandler(http.FileServer(http.Dir(staticFolder))))
 	return router

--- a/controller/handler/handler_test.go
+++ b/controller/handler/handler_test.go
@@ -4,10 +4,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/TwiN/gatus/v4/config"
 )
 
 func TestCreateRouter(t *testing.T) {
-	router := CreateRouter("../../web/static", nil, nil, true)
+	router := CreateRouter("../../web/static", &config.Config{Metrics: true})
 	type Scenario struct {
 		Name         string
 		Path         string

--- a/controller/handler/spa_test.go
+++ b/controller/handler/spa_test.go
@@ -30,7 +30,7 @@ func TestSinglePageApplication(t *testing.T) {
 	}
 	watchdog.UpdateEndpointStatuses(cfg.Endpoints[0], &core.Result{Success: true, Duration: time.Millisecond, Timestamp: time.Now()})
 	watchdog.UpdateEndpointStatuses(cfg.Endpoints[1], &core.Result{Success: false, Duration: time.Second, Timestamp: time.Now()})
-	router := CreateRouter("../../web/static", cfg.Security, nil, cfg.Metrics)
+	router := CreateRouter("../../web/static", cfg)
 	type Scenario struct {
 		Name         string
 		Path         string

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 }
 
 func start(cfg *config.Config) {
-	go controller.Handle(cfg.Security, cfg.Web, cfg.UI, cfg.Metrics)
+	go controller.Handle(cfg)
 	watchdog.Monitor(cfg)
 	go listenToConfigurationFileChanges(cfg)
 }


### PR DESCRIPTION
This is an experimental feature and it may be removed or updated in a breaking manner at any time. Use at your own risk.

Basically, all it does it retrieve the endpoint statuses from another remote host before returning the endpoint statuses. You may specify an endpoint prefix to prefix the name of all endpoints coming from a given remote instance with a string.

```yaml
remote:
  instances:
    - endpoint-prefix: "myremoteinstance-"
      url: "https://status.example.org/api/v1/endpoints/statuses"
```

Relevant: #64 