### PR TITLE
feat(storage): Add optional write-through cache to sql store

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,11 +247,12 @@ Here are some examples of conditions you can use:
 
 
 ### Storage
-| Parameter      | Description                                                                    | Default    |
-|:---------------|:-------------------------------------------------------------------------------|:-----------|
-| `storage`      | Storage configuration                                                          | `{}`       |
-| `storage.path` | Path to persist the data in. Only supported for types `sqlite` and `postgres`. | `""`       |
-| `storage.type` | Type of storage. Valid types: `memory`, `sqlite`, `postgres`.                  | `"memory"` |
+| Parameter         | Description                                                                                                                                        | Default    |
+|:------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------|:-----------|
+| `storage`         | Storage configuration                                                                                                                              | `{}`       |
+| `storage.path`    | Path to persist the data in. Only supported for types `sqlite` and `postgres`.                                                                     | `""`       |
+| `storage.type`    | Type of storage. Valid types: `memory`, `sqlite`, `postgres`.                                                                                      | `"memory"` |
+| `storage.caching` | Whether to use write-through caching. Improves loading time for large dashboards. <br />Only supported if `storage.type` is `sqlite` or `postgres` | `false`    |
 
 - If `storage.type` is `memory` (default):
 ```yaml

--- a/storage/config.go
+++ b/storage/config.go
@@ -19,6 +19,12 @@ type Config struct {
 	// Type of store
 	// If blank, uses the default in-memory store
 	Type Type `yaml:"type"`
+
+	// Caching is whether to enable caching.
+	// This is used to drastically decrease read latency by pre-emptively caching writes
+	// as they happen, also known as the write-through caching strategy.
+	// Does not apply if Config.Type is not TypePostgres or TypeSQLite.
+	Caching bool `yaml:"caching,omitempty"`
 }
 
 // ValidateAndSetDefaults validates the configuration and sets the default values (if applicable)

--- a/storage/store/sql/sql.go
+++ b/storage/store/sql/sql.go
@@ -333,7 +333,6 @@ func (s *Store) Insert(endpoint *core.Endpoint, result *core.Result) error {
 			}
 		}
 	}
-	// TODO: add field to automatically refresh the cache when a new result is inserted
 	if s.writeThroughCache != nil {
 		cacheKeysToRefresh := s.writeThroughCache.GetKeysByPattern(endpoint.Key()+"*", 0)
 		for _, cacheKey := range cacheKeysToRefresh {

--- a/storage/store/store.go
+++ b/storage/store/store.go
@@ -12,7 +12,7 @@ import (
 	"github.com/TwiN/gatus/v4/storage/store/sql"
 )
 
-// Store is the interface that each stores should implement
+// Store is the interface that each store should implement
 type Store interface {
 	// GetAllEndpointStatuses returns the JSON encoding of all monitored core.EndpointStatus
 	// with a subset of core.Result defined by the page and pageSize parameters
@@ -103,7 +103,7 @@ func Initialize(cfg *storage.Config) error {
 	ctx, cancelFunc = context.WithCancel(context.Background())
 	switch cfg.Type {
 	case storage.TypeSQLite, storage.TypePostgres:
-		store, err = sql.NewStore(string(cfg.Type), cfg.Path)
+		store, err = sql.NewStore(string(cfg.Type), cfg.Path, cfg.Caching)
 		if err != nil {
 			return err
 		}

--- a/storage/store/store_bench_test.go
+++ b/storage/store/store_bench_test.go
@@ -16,7 +16,7 @@ func BenchmarkStore_GetAllEndpointStatuses(b *testing.B) {
 	if err != nil {
 		b.Fatal("failed to create store:", err.Error())
 	}
-	sqliteStore, err := sql.NewStore("sqlite", b.TempDir()+"/BenchmarkStore_GetAllEndpointStatuses.db")
+	sqliteStore, err := sql.NewStore("sqlite", b.TempDir()+"/BenchmarkStore_GetAllEndpointStatuses.db", false)
 	if err != nil {
 		b.Fatal("failed to create store:", err.Error())
 	}
@@ -85,7 +85,7 @@ func BenchmarkStore_Insert(b *testing.B) {
 	if err != nil {
 		b.Fatal("failed to create store:", err.Error())
 	}
-	sqliteStore, err := sql.NewStore("sqlite", b.TempDir()+"/BenchmarkStore_Insert.db")
+	sqliteStore, err := sql.NewStore("sqlite", b.TempDir()+"/BenchmarkStore_Insert.db", false)
 	if err != nil {
 		b.Fatal("failed to create store:", err.Error())
 	}
@@ -157,7 +157,7 @@ func BenchmarkStore_GetEndpointStatusByKey(b *testing.B) {
 	if err != nil {
 		b.Fatal("failed to create store:", err.Error())
 	}
-	sqliteStore, err := sql.NewStore("sqlite", b.TempDir()+"/BenchmarkStore_GetEndpointStatusByKey.db")
+	sqliteStore, err := sql.NewStore("sqlite", b.TempDir()+"/BenchmarkStore_GetEndpointStatusByKey.db", false)
 	if err != nil {
 		b.Fatal("failed to create store:", err.Error())
 	}

--- a/storage/store/store_test.go
+++ b/storage/store/store_test.go
@@ -93,7 +93,11 @@ func initStoresAndBaseScenarios(t *testing.T, testName string) []*Scenario {
 	if err != nil {
 		t.Fatal("failed to create store:", err.Error())
 	}
-	sqliteStore, err := sql.NewStore("sqlite", t.TempDir()+"/"+testName+".db")
+	sqliteStore, err := sql.NewStore("sqlite", t.TempDir()+"/"+testName+".db", false)
+	if err != nil {
+		t.Fatal("failed to create store:", err.Error())
+	}
+	sqliteStoreWithCaching, err := sql.NewStore("sqlite", t.TempDir()+"/"+testName+"-with-caching.db", true)
 	if err != nil {
 		t.Fatal("failed to create store:", err.Error())
 	}
@@ -105,6 +109,10 @@ func initStoresAndBaseScenarios(t *testing.T, testName string) []*Scenario {
 		{
 			Name:  "sqlite",
 			Store: sqliteStore,
+		},
+		{
+			Name:  "sqlite-with-caching",
+			Store: sqliteStoreWithCaching,
 		},
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->

This adds the ability to enable a write-through cache for storage of type sqlite and postgres.

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Added the documentation in `README.md`, if applicable.
