### PR TITLE
feat(alerting): add client config for telegram

### DIFF
--- a/README.md
+++ b/README.md
@@ -784,8 +784,6 @@ alerting:
   telegram:
     token: "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
     id: "0123456789"
-    client:
-      dns-resolver: "tcp://1.1.1.1:53"
 
 endpoints:
   - name: website

--- a/README.md
+++ b/README.md
@@ -776,7 +776,7 @@ Here's an example of what the notifications look like:
 | `alerting.telegram.token`         | Telegram Bot Token                                                                         | Required `""`              |
 | `alerting.telegram.id`            | Telegram User ID                                                                           | Required `""`              |
 | `alerting.telegram.api-url`       | Telegram API URL                                                                           | `https://api.telegram.org` |
-| `alerting.telegram.client`                  | Client configuration. <br />See [Client configuration](#client-configuration).              | `{}`          |
+| `alerting.telegram.client`        | Client configuration. <br />See [Client configuration](#client-configuration).             | `{}`                       |
 | `alerting.telegram.default-alert` | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert) | N/A                        |
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -776,6 +776,7 @@ Here's an example of what the notifications look like:
 | `alerting.telegram.token`         | Telegram Bot Token                                                                         | Required `""`              |
 | `alerting.telegram.id`            | Telegram User ID                                                                           | Required `""`              |
 | `alerting.telegram.api-url`       | Telegram API URL                                                                           | `https://api.telegram.org` |
+| `alerting.telegram.client`                  | Client configuration. <br />See [Client configuration](#client-configuration).              | `{}`          |
 | `alerting.telegram.default-alert` | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert) | N/A                        |
 
 ```yaml
@@ -783,6 +784,8 @@ alerting:
   telegram:
     token: "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
     id: "0123456789"
+    client:
+      dns-resolver: "tcp://1.1.1.1:53"
 
 endpoints:
   - name: website

--- a/alerting/provider/telegram/telegram.go
+++ b/alerting/provider/telegram/telegram.go
@@ -19,12 +19,18 @@ type AlertProvider struct {
 	ID     string `yaml:"id"`
 	APIURL string `yaml:"api-url"`
 
+	// ClientConfig is the configuration of the client used to communicate with the provider's target
+	ClientConfig *client.Config `yaml:"client,omitempty"`
+
 	// DefaultAlert is the default alert configuration to use for endpoints with an alert of the appropriate type
 	DefaultAlert *alert.Alert `yaml:"default-alert,omitempty"`
 }
 
 // IsValid returns whether the provider's configuration is valid
 func (provider *AlertProvider) IsValid() bool {
+	if provider.ClientConfig == nil {
+		provider.ClientConfig = client.GetDefaultConfig()
+	}
 	return len(provider.Token) > 0 && len(provider.ID) > 0
 }
 
@@ -40,7 +46,7 @@ func (provider *AlertProvider) Send(endpoint *core.Endpoint, alert *alert.Alert,
 		return err
 	}
 	request.Header.Set("Content-Type", "application/json")
-	response, err := client.GetHTTPClient(nil).Do(request)
+	response, err := client.GetHTTPClient(provider.ClientConfig).Do(request)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
Adds an option to specify the client config for the telegram alerting provider.
I'm monitoring a local dns server, so the notifications should still go through if the local dns is down.
Builds on top of #284 

I have to admit I have never worked with Go before, so I'm not sure how to compile and test the project, but this change seems relatively straighforward.

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Added the documentation in `README.md`, if applicable.
