### PR TITLE
fix: add Google Chat to list of alert types when determining valid providers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -302,6 +302,7 @@ func validateAlertingConfig(alertingConfig *alerting.Config, endpoints []*core.E
 	alertTypes := []alert.Type{
 		alert.TypeCustom,
 		alert.TypeDiscord,
+		alert.TypeGoogleChat,
 		alert.TypeEmail,
 		alert.TypeMatrix,
 		alert.TypeMattermost,


### PR DESCRIPTION
## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->

Related to #234.

It seems like this was missed in the PR, rendering Google Chat alerts not working.



## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Added the documentation in `README.md`, if applicable.
