### PR TITLE
fix!: Default Alert.Enabled to true

### DIFF
--- a/.examples/docker-compose-mattermost/config/config.yaml
+++ b/.examples/docker-compose-mattermost/config/config.yaml
@@ -7,10 +7,9 @@ endpoints:
   - name: example
     url: https://example.org
     interval: 1m
-    alerts:
-      - type: mattermost
-        enabled: true
-        description: "health check failed 3 times in a row"
-        send-on-resolved: true
     conditions:
       - "[STATUS] == 200"
+    alerts:
+      - type: mattermost
+        description: "health check failed 3 times in a row"
+        send-on-resolved: true

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ If you want to test it locally, see [Docker](#docker).
 | `endpoints[].dns.query-type`                    | Query type (e.g. MX)                                                                                                                               | `""`                       |
 | `endpoints[].dns.query-name`                    | Query name (e.g. example.com)                                                                                                                      | `""`                       |
 | `endpoints[].alerts[].type`                     | Type of alert. <br />Valid types: `slack`, `discord`, `email`, `googlechat`, `pagerduty`, `twilio`, `mattermost`, `messagebird`, `teams` `custom`. | Required `""`              |
-| `endpoints[].alerts[].enabled`                  | Whether to enable the alert.                                                                                                                       | `false`                    |
+| `endpoints[].alerts[].enabled`                  | Whether to enable the alert.                                                                                                                       | `true`                     |
 | `endpoints[].alerts[].failure-threshold`        | Number of failures in a row needed before triggering the alert.                                                                                    | `3`                        |
 | `endpoints[].alerts[].success-threshold`        | Number of successes in a row before an ongoing incident is marked as resolved.                                                                     | `2`                        |
 | `endpoints[].alerts[].send-on-resolved`         | Whether to send a notification once a triggered alert is marked as resolved.                                                                       | `false`                    |
@@ -410,7 +410,6 @@ endpoints:
       - "[RESPONSE_TIME] < 300"
     alerts:
       - type: discord
-        enabled: true
         description: "healthcheck failed"
         send-on-resolved: true
 ```
@@ -457,7 +456,6 @@ endpoints:
       - "[RESPONSE_TIME] < 300"
     alerts:
       - type: email
-        enabled: true
         description: "healthcheck failed"
         send-on-resolved: true
 
@@ -470,7 +468,6 @@ endpoints:
       - "[CERTIFICATE_EXPIRATION] > 48h"
     alerts:
       - type: email
-        enabled: true
         description: "healthcheck failed"
         send-on-resolved: true
 ```
@@ -505,7 +502,6 @@ endpoints:
       - "[RESPONSE_TIME] < 300"
     alerts:
       - type: googlechat
-        enabled: true
         description: "healthcheck failed"
         send-on-resolved: true
 ```
@@ -537,7 +533,6 @@ endpoints:
       - "[RESPONSE_TIME] < 300"
     alerts:
       - type: matrix
-        enabled: true
         send-on-resolved: true
         description: "healthcheck failed"
 ```
@@ -571,7 +566,6 @@ endpoints:
       - "[RESPONSE_TIME] < 300"
     alerts:
       - type: mattermost
-        enabled: true
         description: "healthcheck failed"
         send-on-resolved: true
 ```
@@ -608,7 +602,6 @@ endpoints:
       - "[RESPONSE_TIME] < 300"
     alerts:
       - type: messagebird
-        enabled: true
         failure-threshold: 3
         send-on-resolved: true
         description: "healthcheck failed"
@@ -634,7 +627,6 @@ alerting:
     topic: "gatus-test-topic"
     priority: 2
     default-alert:
-      enabled: true
       failure-threshold: 3
       send-on-resolved: true
 
@@ -711,7 +703,6 @@ endpoints:
       - "[RESPONSE_TIME] < 300"
     alerts:
       - type: pagerduty
-        enabled: true
         failure-threshold: 3
         success-threshold: 5
         send-on-resolved: true
@@ -726,7 +717,6 @@ endpoints:
       - "[CERTIFICATE_EXPIRATION] > 48h"
     alerts:
       - type: pagerduty
-        enabled: true
         failure-threshold: 3
         success-threshold: 5
         send-on-resolved: true
@@ -758,11 +748,9 @@ endpoints:
       - "[RESPONSE_TIME] < 300"
     alerts:
       - type: slack
-        enabled: true
         description: "healthcheck failed 3 times in a row"
         send-on-resolved: true
       - type: slack
-        enabled: true
         failure-threshold: 5
         description: "healthcheck failed 5 times in a row"
         send-on-resolved: true
@@ -804,7 +792,6 @@ endpoints:
       - "[RESPONSE_TIME] < 300"
     alerts:
       - type: teams
-        enabled: true
         description: "healthcheck failed"
         send-on-resolved: true
 
@@ -817,7 +804,6 @@ endpoints:
       - "[CERTIFICATE_EXPIRATION] > 48h"
     alerts:
       - type: teams
-        enabled: true
         description: "healthcheck failed"
         send-on-resolved: true
 ```
@@ -852,7 +838,6 @@ endpoints:
       - "[BODY].status == UP"
     alerts:
       - type: telegram
-        enabled: true
         send-on-resolved: true
 ```
 
@@ -889,7 +874,6 @@ endpoints:
       - "[RESPONSE_TIME] < 300"
     alerts:
       - type: twilio
-        enabled: true
         failure-threshold: 5
         send-on-resolved: true
         description: "healthcheck failed"
@@ -945,7 +929,6 @@ endpoints:
       - "[RESPONSE_TIME] < 300"
     alerts:
       - type: custom
-        enabled: true
         failure-threshold: 10
         success-threshold: 3
         send-on-resolved: true
@@ -985,7 +968,6 @@ alerting:
   slack:
     webhook-url: "https://hooks.slack.com/services/**********/**********/**********"
     default-alert:
-      enabled: true
       description: "health check failed"
       send-on-resolved: true
       failure-threshold: 5
@@ -1032,12 +1014,10 @@ alerting:
   slack:
     webhook-url: "https://hooks.slack.com/services/**********/**********/**********"
     default-alert:
-      enabled: true
       failure-threshold: 3
   pagerduty:
     integration-key: "********************************"
     default-alert:
-      enabled: true
       failure-threshold: 5
 
 endpoints:

--- a/alerting/alert/alert.go
+++ b/alerting/alert/alert.go
@@ -17,6 +17,8 @@ type Alert struct {
 
 	// Enabled defines whether the alert is enabled
 	//
+	// Use Alert.IsEnabled() to retrieve the value of this field.
+	//
 	// This is a pointer, because it is populated by YAML and we need to know whether it was explicitly set to a value
 	// or not for provider.ParseWithDefaultAlert to work.
 	Enabled *bool `yaml:"enabled,omitempty"`
@@ -77,10 +79,10 @@ func (alert Alert) GetDescription() string {
 }
 
 // IsEnabled returns whether an alert is enabled or not
+// Returns true if not set
 func (alert Alert) IsEnabled() bool {
 	if alert.Enabled == nil {
-		// TODO: Default to true in v5.0.0 (unless default-alert.enabled is set to false)
-		return false
+		return true
 	}
 	return *alert.Enabled
 }

--- a/alerting/alert/alert_test.go
+++ b/alerting/alert/alert_test.go
@@ -52,8 +52,8 @@ func TestAlert_ValidateAndSetDefaults(t *testing.T) {
 }
 
 func TestAlert_IsEnabled(t *testing.T) {
-	if (Alert{Enabled: nil}).IsEnabled() {
-		t.Error("alert.IsEnabled() should've returned false, because Enabled was set to nil")
+	if !(Alert{Enabled: nil}).IsEnabled() {
+		t.Error("alert.IsEnabled() should've returned true, because Enabled was set to nil")
 	}
 	if value := false; (Alert{Enabled: &value}).IsEnabled() {
 		t.Error("alert.IsEnabled() should've returned false, because Enabled was set to false")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -448,26 +448,21 @@ endpoints:
     url: https://twin.sh/health
     alerts:
       - type: slack
-        enabled: true
       - type: pagerduty
-        enabled: true
         failure-threshold: 7
         success-threshold: 5
         description: "Healthcheck failed 7 times in a row"
       - type: mattermost
-        enabled: true
       - type: messagebird
+        enabled: false
       - type: discord
-        enabled: true
         failure-threshold: 10
       - type: telegram
         enabled: true
       - type: twilio
-        enabled: true
         failure-threshold: 12
         success-threshold: 15
       - type: teams
-        enabled: true
     conditions:
       - "[STATUS] == 200"
 `))

--- a/core/endpoint_test.go
+++ b/core/endpoint_test.go
@@ -372,8 +372,8 @@ func TestEndpoint_ValidateAndSetDefaults(t *testing.T) {
 	if len(endpoint.Alerts) != 1 {
 		t.Error("Endpoint should've had 1 alert")
 	}
-	if endpoint.Alerts[0].IsEnabled() {
-		t.Error("Endpoint alert should've defaulted to disabled")
+	if !endpoint.Alerts[0].IsEnabled() {
+		t.Error("Endpoint alert should've defaulted to true")
 	}
 	if endpoint.Alerts[0].SuccessThreshold != 2 {
 		t.Error("Endpoint alert should've defaulted to a success threshold of 2")


### PR DESCRIPTION
## Summary
BREAKING CHANGE: It used to default to false, which meant that users had to explicitly set endpoints[].alerts[].enabled to true

Discussion #374 

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Added the documentation in `README.md`, if applicable.
