### PR TITLE
fix(alerting): Use reflection to set invalid providers to nil instead of re-validating on every alert trigger/resolve

### DIFF
--- a/alerting/config.go
+++ b/alerting/config.go
@@ -1,6 +1,9 @@
 package alerting
 
 import (
+	"fmt"
+	"reflect"
+
 	"github.com/TwiN/gatus/v5/alerting/alert"
 	"github.com/TwiN/gatus/v5/alerting/provider"
 	"github.com/TwiN/gatus/v5/alerting/provider/custom"
@@ -153,4 +156,18 @@ func (config Config) GetAlertingProviderByAlertType(alertType alert.Type) provid
 		return config.Twilio
 	}
 	return nil
+}
+
+// SetAlertingProviderToNil Sets an alerting provider to nil to avoid having to revalidate it every time an
+// alert of its corresponding type is sent.
+func (config *Config) SetAlertingProviderToNil(p provider.AlertProvider) {
+	fmt.Println(config.GitHub)
+	entityType := reflect.TypeOf(config).Elem()
+	for i := 0; i < entityType.NumField(); i++ {
+		field := entityType.Field(i)
+		if field.Type == reflect.TypeOf(p) {
+			fmt.Println("Setting", field.Name, "to nil")
+			reflect.ValueOf(config).Elem().Field(i).Set(reflect.Zero(field.Type))
+		}
+	}
 }

--- a/alerting/config.go
+++ b/alerting/config.go
@@ -161,12 +161,10 @@ func (config Config) GetAlertingProviderByAlertType(alertType alert.Type) provid
 // SetAlertingProviderToNil Sets an alerting provider to nil to avoid having to revalidate it every time an
 // alert of its corresponding type is sent.
 func (config *Config) SetAlertingProviderToNil(p provider.AlertProvider) {
-	fmt.Println(config.GitHub)
 	entityType := reflect.TypeOf(config).Elem()
 	for i := 0; i < entityType.NumField(); i++ {
 		field := entityType.Field(i)
 		if field.Type == reflect.TypeOf(p) {
-			fmt.Println("Setting", field.Name, "to nil")
 			reflect.ValueOf(config).Elem().Field(i).Set(reflect.Zero(field.Type))
 		}
 	}

--- a/alerting/config.go
+++ b/alerting/config.go
@@ -1,8 +1,9 @@
 package alerting
 
 import (
-	"fmt"
+	"log"
 	"reflect"
+	"strings"
 
 	"github.com/TwiN/gatus/v5/alerting/alert"
 	"github.com/TwiN/gatus/v5/alerting/provider"
@@ -68,93 +69,19 @@ type Config struct {
 }
 
 // GetAlertingProviderByAlertType returns an provider.AlertProvider by its corresponding alert.Type
-func (config Config) GetAlertingProviderByAlertType(alertType alert.Type) provider.AlertProvider {
-	switch alertType {
-	case alert.TypeCustom:
-		if config.Custom == nil {
-			// Since we're returning an interface, we need to explicitly return nil, even if the provider itself is nil
-			return nil
+func (config *Config) GetAlertingProviderByAlertType(alertType alert.Type) provider.AlertProvider {
+	entityType := reflect.TypeOf(config).Elem()
+	for i := 0; i < entityType.NumField(); i++ {
+		field := entityType.Field(i)
+		if strings.ToLower(field.Name) == string(alertType) {
+			fieldValue := reflect.ValueOf(config).Elem().Field(i)
+			if fieldValue.IsNil() {
+				return nil
+			}
+			return fieldValue.Interface().(provider.AlertProvider)
 		}
-		return config.Custom
-	case alert.TypeDiscord:
-		if config.Discord == nil {
-			// Since we're returning an interface, we need to explicitly return nil, even if the provider itself is nil
-			return nil
-		}
-		return config.Discord
-	case alert.TypeEmail:
-		if config.Email == nil {
-			// Since we're returning an interface, we need to explicitly return nil, even if the provider itself is nil
-			return nil
-		}
-		return config.Email
-	case alert.TypeGoogleChat:
-		if config.GoogleChat == nil {
-			// Since we're returning an interface, we need to explicitly return nil, even if the provider itself is nil
-			return nil
-		}
-		return config.GoogleChat
-	case alert.TypeMatrix:
-		if config.Matrix == nil {
-			// Since we're returning an interface, we need to explicitly return nil, even if the provider itself is nil
-			return nil
-		}
-		return config.Matrix
-	case alert.TypeMattermost:
-		if config.Mattermost == nil {
-			// Since we're returning an interface, we need to explicitly return nil, even if the provider itself is nil
-			return nil
-		}
-		return config.Mattermost
-	case alert.TypeMessagebird:
-		if config.Messagebird == nil {
-			// Since we're returning an interface, we need to explicitly return nil, even if the provider itself is nil
-			return nil
-		}
-		return config.Messagebird
-	case alert.TypeNtfy:
-		if config.Ntfy == nil {
-			// Since we're returning an interface, we need to explicitly return nil, even if the provider itself is nil
-			return nil
-		}
-		return config.Ntfy
-	case alert.TypeOpsgenie:
-		if config.Opsgenie == nil {
-			// Since we're returning an interface, we need to explicitly return nil, even if the provider itself is nil
-			return nil
-		}
-		return config.Opsgenie
-	case alert.TypePagerDuty:
-		if config.PagerDuty == nil {
-			// Since we're returning an interface, we need to explicitly return nil, even if the provider itself is nil
-			return nil
-		}
-		return config.PagerDuty
-	case alert.TypeSlack:
-		if config.Slack == nil {
-			// Since we're returning an interface, we need to explicitly return nil, even if the provider itself is nil
-			return nil
-		}
-		return config.Slack
-	case alert.TypeTeams:
-		if config.Teams == nil {
-			// Since we're returning an interface, we need to explicitly return nil, even if the provider itself is nil
-			return nil
-		}
-		return config.Teams
-	case alert.TypeTelegram:
-		if config.Telegram == nil {
-			// Since we're returning an interface, we need to explicitly return nil, even if the provider itself is nil
-			return nil
-		}
-		return config.Telegram
-	case alert.TypeTwilio:
-		if config.Twilio == nil {
-			// Since we're returning an interface, we need to explicitly return nil, even if the provider itself is nil
-			return nil
-		}
-		return config.Twilio
 	}
+	log.Printf("[alerting][GetAlertingProviderByAlertType] No alerting provider found for alert type %s", alertType)
 	return nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -323,6 +323,7 @@ func validateAlertingConfig(alertingConfig *alerting.Config, endpoints []*core.E
 			} else {
 				log.Printf("[config][validateAlertingConfig] Ignoring provider=%s because configuration is invalid", alertType)
 				invalidProviders = append(invalidProviders, alertType)
+				alertingConfig.SetAlertingProviderToNil(alertProvider)
 			}
 		} else {
 			invalidProviders = append(invalidProviders, alertType)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -980,11 +980,8 @@ endpoints:
 	if config.Alerting == nil {
 		t.Fatal("config.Alerting shouldn't have been nil")
 	}
-	if config.Alerting.PagerDuty == nil {
-		t.Fatal("PagerDuty alerting config shouldn't have been nil")
-	}
-	if config.Alerting.PagerDuty.IsValid() {
-		t.Fatal("PagerDuty alerting config should've been invalid")
+	if config.Alerting.PagerDuty != nil {
+		t.Fatal("PagerDuty alerting config should've been set to nil, because its IsValid() method returned false and therefore alerting.Config.SetAlertingProviderToNil() should've been called")
 	}
 }
 

--- a/watchdog/alerting.go
+++ b/watchdog/alerting.go
@@ -36,7 +36,7 @@ func handleAlertsToTrigger(endpoint *core.Endpoint, result *core.Result, alertin
 			continue
 		}
 		alertProvider := alertingConfig.GetAlertingProviderByAlertType(endpointAlert.Type)
-		if alertProvider != nil && alertProvider.IsValid() {
+		if alertProvider != nil {
 			log.Printf("[watchdog][handleAlertsToTrigger] Sending %s alert because alert for endpoint=%s with description='%s' has been TRIGGERED", endpointAlert.Type, endpoint.Name, endpointAlert.GetDescription())
 			var err error
 			if os.Getenv("MOCK_ALERT_PROVIDER") == "true" {
@@ -70,7 +70,7 @@ func handleAlertsToResolve(endpoint *core.Endpoint, result *core.Result, alertin
 			continue
 		}
 		alertProvider := alertingConfig.GetAlertingProviderByAlertType(endpointAlert.Type)
-		if alertProvider != nil && alertProvider.IsValid() {
+		if alertProvider != nil {
 			log.Printf("[watchdog][handleAlertsToResolve] Sending %s alert because alert for endpoint=%s with description='%s' has been RESOLVED", endpointAlert.Type, endpoint.Name, endpointAlert.GetDescription())
 			err := alertProvider.Send(endpoint, endpointAlert, result, true)
 			if err != nil {


### PR DESCRIPTION
## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
Instead of re-validating the corresponding alerting provider of an alert every time said alert is triggered/resolved, use reflection to set the alerting configuration's provider field to nil


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Added the documentation in `README.md`, if applicable.
