### PR TITLE
feat: Support multiple configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ By default, the configuration file is expected to be at `config/config.yaml`.
 
 You can specify a custom path by setting the `GATUS_CONFIG_FILE` environment variable.
 
+Configuration can be split across multiple files by placing the regarding `*.yml` and `*.yaml` files inside the default directory `config/config.d/`. This path can be overridden using the environment variable `GATUS_CONFIG_DIR`. While both configuration variants are loaded simultaneously and get merged, distributed configuration takes precedence over the main configuration file in case of conflicting values.
+
 Here's a simple example:
 ```yaml
 endpoints:

--- a/README.md
+++ b/README.md
@@ -131,9 +131,7 @@ The main features of Gatus are:
 ## Usage
 By default, the configuration file is expected to be at `config/config.yaml`.
 
-You can specify a custom path by setting the `GATUS_CONFIG_FILE` environment variable.
-
-Configuration can be split across multiple files by placing the regarding `*.yml` and `*.yaml` files inside the default directory `config/config.d/`. This path can be overridden using the environment variable `GATUS_CONFIG_DIR`. While both configuration variants are loaded simultaneously and get merged, distributed configuration takes precedence over the main configuration file in case of conflicting values.
+You can specify a custom path by setting the `GATUS_CONFIG_PATH` environment variable. If `GATUS_CONFIG_PATH` points to a directory, all `*.yaml` and `*.yml` files inside this directory and its subdirectories are concatenated.
 
 Here's a simple example:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The main features of Gatus are:
 ## Usage
 By default, the configuration file is expected to be at `config/config.yaml`.
 
-You can specify a custom path by setting the `GATUS_CONFIG_PATH` environment variable. If `GATUS_CONFIG_PATH` points to a directory, all `*.yaml` and `*.yml` files inside this directory and its subdirectories are concatenated.
+You can specify a custom path by setting the `GATUS_CONFIG_PATH` environment variable. If `GATUS_CONFIG_PATH` points to a directory, all `*.yaml` and `*.yml` files inside this directory and its subdirectories are concatenated. The previously used environment variable `GATUS_CONFIG_FILE` is deprecated but still works.
 
 Here's a simple example:
 ```yaml

--- a/config/config.go
+++ b/config/config.go
@@ -376,10 +376,11 @@ func walkConfigDir(path string, fn fs.WalkDirFunc) error {
 	}
 
 	return filepath.WalkDir(path, func(path string, d fs.DirEntry, err error) error {
-		if nil == d {
+		if nil != err {
 			return nil
 		}
-		if d.IsDir() {
+		
+		if nil == d || d.IsDir() {
 			return nil
 		}
 

--- a/config/config.go
+++ b/config/config.go
@@ -112,10 +112,9 @@ func (config Config) HasLoadedConfigurationFileBeenModified() bool {
 	if nil != err {
 		return false
 	}
-
 	if fileInfo.IsDir() {
 		err = walkConfigDir(config.configPath, func (path string, d fs.DirEntry, err error) error {
-			if info, err := d.Info(); nil == err && lastMod < info.ModTime().Unix() {
+			if info, err := d.Info(); err == nil && lastMod < info.ModTime().Unix() {
 				return ErrEarlyReturn
 			}
 			return nil

--- a/config/config.go
+++ b/config/config.go
@@ -107,7 +107,7 @@ func (config *Config) GetEndpointByKey(key string) *core.Endpoint {
 // configuration has been loaded from has been modified since it was last read
 func (config Config) HasLoadedConfigurationFileBeenModified() bool {
 	lastMod := config.lastFileModTime.Unix()
-	fileInfo, err : = os.Stat(config.configPath)
+	fileInfo, err := os.Stat(config.configPath)
 	if err != nil {
 		return false
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -370,13 +370,13 @@ func walkConfigDir(path string, fn fs.WalkDirFunc) error {
 		if nil != err {
 			return nil
 		}
-		
+
 		if nil == d || d.IsDir() {
 			return nil
 		}
 
 		ext := filepath.Ext(path)
-		if "yml" != ext && "yaml" != ext {
+		if ".yml" != ext && ".yaml" != ext {
 			return nil
 		}
 

--- a/config/config.go
+++ b/config/config.go
@@ -163,11 +163,10 @@ func LoadConfiguration(configPath string) (*Config, error) {
 			return nil
 		})
 	} else {
-		var bytes, serr = os.ReadFile(usedConfigPath)
-		if nil == serr {
+		bytes, serr := os.ReadFile(usedConfigPath)
+		if serr == nil {
 			log.Printf("[config][Load] Reading configuration from configFile=%s", configPath)
 			composedContents = bytes
-			usedConfigPath = usedConfigPath
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -182,15 +182,6 @@ func LoadConfiguration(filePath string, directoryPath string) (*Config, error) {
 	return config, err
 }
 
-func readConfigurationFile(fileName string) (config *Config, err error) {
-	var bytes []byte
-	if bytes, err = os.ReadFile(fileName); err == nil {
-		// file exists, so we'll parse it and return it
-		return parseAndValidateConfigBytes(bytes)
-	}
-	return
-}
-
 // parseAndValidateConfigBytes parses a Gatus configuration file into a Config struct and validates its parameters
 func parseAndValidateConfigBytes(yamlBytes []byte) (config *Config, err error) {
 	// Expand environment variables

--- a/config/config.go
+++ b/config/config.go
@@ -106,10 +106,9 @@ func (config *Config) GetEndpointByKey(key string) *core.Endpoint {
 // HasLoadedConfigurationFileBeenModified returns whether one of the file that the
 // configuration has been loaded from has been modified since it was last read
 func (config Config) HasLoadedConfigurationFileBeenModified() bool {
-	var lastMod = config.lastFileModTime.Unix()
-
-	var fileInfo, err = os.Stat(config.configPath)
-	if nil != err {
+	lastMod := config.lastFileModTime.Unix()
+	fileInfo, err : = os.Stat(config.configPath)
+	if err != nil {
 		return false
 	}
 	if fileInfo.IsDir() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -42,6 +42,27 @@ func TestLoadDefaultConfigurationFile(t *testing.T) {
 	}
 }
 
+func TestLoadConfigurationFile(t *testing.T) {
+	_, err := LoadConfiguration("../test-conf/config.yaml", "")
+	if nil != err {
+		t.Error("Should not have returned an error, because the configuration file exists at the provided path")
+	}
+}
+
+func TestLoadDistributedConfiguration(t *testing.T) {
+	_, err := LoadConfiguration("", "../test-conf/conf.d/")
+	if nil != err {
+		t.Error("Should not have returned an error, because configuration files exist at the provided path for distributed files")
+	}
+}
+
+func TestLoadCombinedConfiguration(t *testing.T) {
+	_, err := LoadConfiguration("../test-config/config.yaml", "../test-conf/conf.d")
+	if nil != err {
+		t.Error("Should not have returned an error, because configuration files exist at the provided paths")
+	}
+}
+
 func TestParseAndValidateConfigBytes(t *testing.T) {
 	file := t.TempDir() + "/test.db"
 	config, err := parseAndValidateConfigBytes([]byte(fmt.Sprintf(`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -29,14 +29,14 @@ import (
 )
 
 func TestLoadFileThatDoesNotExist(t *testing.T) {
-	_, err := Load("file-that-does-not-exist.yaml")
+	_, err := LoadConfiguration("file-that-does-not-exist.yaml", "")
 	if err == nil {
 		t.Error("Should've returned an error, because the file specified doesn't exist")
 	}
 }
 
 func TestLoadDefaultConfigurationFile(t *testing.T) {
-	_, err := LoadDefaultConfiguration()
+	_, err := LoadConfiguration("", "")
 	if err == nil {
 		t.Error("Should've returned an error, because there's no configuration files at the default path nor the default fallback path")
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -29,37 +29,37 @@ import (
 )
 
 func TestLoadFileThatDoesNotExist(t *testing.T) {
-	_, err := LoadConfiguration("file-that-does-not-exist.yaml", "")
+	_, err := LoadConfiguration("file-that-does-not-exist.yaml")
 	if err == nil {
 		t.Error("Should've returned an error, because the file specified doesn't exist")
 	}
 }
 
 func TestLoadDefaultConfigurationFile(t *testing.T) {
-	_, err := LoadConfiguration("", "")
+	_, err := LoadConfiguration("")
 	if err == nil {
 		t.Error("Should've returned an error, because there's no configuration files at the default path nor the default fallback path")
 	}
 }
 
 func TestLoadConfigurationFile(t *testing.T) {
-	_, err := LoadConfiguration("../test-conf/config.yaml", "")
+	_, err := LoadConfiguration("../test-conf/config.yaml")
 	if nil != err {
 		t.Error("Should not have returned an error, because the configuration file exists at the provided path")
 	}
 }
 
 func TestLoadDistributedConfiguration(t *testing.T) {
-	_, err := LoadConfiguration("", "../test-conf/conf.d/")
+	_, err := LoadConfiguration("../test-conf/conf.d/")
 	if nil != err {
 		t.Error("Should not have returned an error, because configuration files exist at the provided path for distributed files")
 	}
 }
 
 func TestLoadCombinedConfiguration(t *testing.T) {
-	_, err := LoadConfiguration("../test-config/config.yaml", "../test-conf/conf.d")
-	if nil != err {
-		t.Error("Should not have returned an error, because configuration files exist at the provided paths")
+	_, err := LoadConfiguration("../test-conf/empty-conf.d/")
+	if nil == err {
+		t.Error("Should have returned an error, because the configuration directory does not contain any configuration files")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -53,10 +53,14 @@ func save() {
 }
 
 func loadConfiguration() (*config.Config, error) {
-	return config.LoadConfiguration(
-		os.Getenv("GATUS_CONFIG_FILE"),
-		os.Getenv("GATUS_CONFIG_DIR"),
-	)
+	var configPath = os.GetEnv("GATUS_CONFIG_PATH")
+
+	// backwards compatibility
+	if len(configPath) == 0 {
+		configPath = os.GetEnv("GATUS_CONFIG_FILE")
+	}
+
+	return config.LoadConfiguration(configPath)
 }
 
 // initializeStorage initializes the storage provider

--- a/main.go
+++ b/main.go
@@ -53,11 +53,10 @@ func save() {
 }
 
 func loadConfiguration() (*config.Config, error) {
-	var configPath = os.GetEnv("GATUS_CONFIG_PATH")
-
-	// backwards compatibility
+	var configPath = os.Getenv("GATUS_CONFIG_PATH")
+	// Backwards compatibility
 	if len(configPath) == 0 {
-		configPath = os.GetEnv("GATUS_CONFIG_FILE")
+		configPath = os.Getenv("GATUS_CONFIG_FILE")
 	}
 
 	return config.LoadConfiguration(configPath)

--- a/main.go
+++ b/main.go
@@ -52,14 +52,11 @@ func save() {
 	}
 }
 
-func loadConfiguration() (cfg *config.Config, err error) {
-	customConfigFile := os.Getenv("GATUS_CONFIG_FILE")
-	if len(customConfigFile) > 0 {
-		cfg, err = config.Load(customConfigFile)
-	} else {
-		cfg, err = config.LoadDefaultConfiguration()
-	}
-	return
+func loadConfiguration() (*config.Config, error) {
+	return config.LoadConfiguration(
+		os.Getenv("GATUS_CONFIG_FILE"),
+		os.Getenv("GATUS_CONFIG_DIR"),
+	)
 }
 
 // initializeStorage initializes the storage provider

--- a/test-conf/conf.d/endpoints.yaml
+++ b/test-conf/conf.d/endpoints.yaml
@@ -1,0 +1,24 @@
+endpoints:
+  - name: front-end
+    group: core
+    url: "https://twin.sh/health"
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+      - "[BODY].status == UP"
+      - "[RESPONSE_TIME] < 150"
+
+  - name: back-end
+    group: core
+    url: "https://example.org/"
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+      - "[CERTIFICATE_EXPIRATION] > 48h"
+
+  - name: monitoring
+    group: internal
+    url: "https://example.org/"
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"

--- a/test-conf/conf.d/endpoints.yml
+++ b/test-conf/conf.d/endpoints.yml
@@ -1,0 +1,29 @@
+endpoints:
+  - name: nas
+    group: internal
+    url: "https://example.org/"
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+
+  - name: example-dns-query
+    url: "8.8.8.8" # Address of the DNS server to use
+    interval: 5m
+    dns:
+      query-name: "example.com"
+      query-type: "A"
+    conditions:
+      - "[BODY] == 93.184.216.34"
+      - "[DNS_RCODE] == NOERROR"
+
+  - name: icmp-ping
+    url: "icmp://example.org"
+    interval: 1m
+    conditions:
+      - "[CONNECTED] == true"
+
+  - name: check-domain-expiration
+    url: "https://example.org/"
+    interval: 1h
+    conditions:
+      - "[DOMAIN_EXPIRATION] > 720h"

--- a/test-conf/config.yaml
+++ b/test-conf/config.yaml
@@ -1,0 +1,6 @@
+endpoints:
+  - name: example
+    url: https://example.org
+    interval: 30s
+    conditions:
+      - "[STATUS] == 200"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
This PR allows configuration to split across multiple files using the common `config.d/`-path style. The approach reads all `*.yml` and `*.yaml` files and merges them in memory into a single file before parsing.  This seemed easier und required fewer changes than parsing each file individually and merging the objects afterwards.

Fixes #326

As I did not work with golang before, feel free to remark on obvious errors and bad patterns.

I envisaged to write tests, but did not figure out yet, how invasive tests are intended to be structured for this project. I hope the chosen way is in you interest.


## Checklist
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Added the documentation in `README.md`, if applicable.
