### PR TITLE
fix: Prevent jsonpath from causing panic when body is expected to be array but isn't

### DIFF
--- a/core/condition_test.go
+++ b/core/condition_test.go
@@ -232,6 +232,13 @@ func TestCondition_evaluate(t *testing.T) {
 			ExpectedOutput:  "[BODY][0].id == 1",
 		},
 		{
+			Name:            "body-jsonpath-when-body-is-array-but-actual-body-is-not",
+			Condition:       Condition("[BODY][0].name == test"),
+			Result:          &Result{body: []byte("{\"statusCode\": 500, \"message\": \"Internal Server Error\"}")},
+			ExpectedSuccess: false,
+			ExpectedOutput:  "[BODY][0].name == test",
+		},
+		{
 			Name:            "body-jsonpath-complex-int",
 			Condition:       Condition("[BODY].data.id == 1"),
 			Result:          &Result{body: []byte("{\"data\": {\"id\": 1}}")},

--- a/core/condition_test.go
+++ b/core/condition_test.go
@@ -236,7 +236,7 @@ func TestCondition_evaluate(t *testing.T) {
 			Condition:       Condition("[BODY][0].name == test"),
 			Result:          &Result{body: []byte("{\"statusCode\": 500, \"message\": \"Internal Server Error\"}")},
 			ExpectedSuccess: false,
-			ExpectedOutput:  "[BODY][0].name == test",
+			ExpectedOutput:  "[BODY][0].name (INVALID) == test",
 		},
 		{
 			Name:            "body-jsonpath-complex-int",

--- a/jsonpath/jsonpath.go
+++ b/jsonpath/jsonpath.go
@@ -93,7 +93,7 @@ func extractValue(currentKey string, value interface{}) interface{} {
 		currentKeyWithoutIndex := currentKey[:startOfBracket]
 		// if currentKeyWithoutIndex contains only an index (i.e. [0] or 0)
 		if len(currentKeyWithoutIndex) == 0 {
-			array := value.([]interface{})
+			array, _ := value.([]interface{})
 			if len(array) > arrayIndex {
 				if isNestedArray {
 					return extractValue(currentKey[endOfBracket+1:], array[arrayIndex])
@@ -106,7 +106,7 @@ func extractValue(currentKey string, value interface{}) interface{} {
 			return nil
 		}
 		// if currentKeyWithoutIndex contains both a key and an index (i.e. data[0])
-		array := value.(map[string]interface{})[currentKeyWithoutIndex].([]interface{})
+		array, _ := value.(map[string]interface{})[currentKeyWithoutIndex].([]interface{})
 		if len(array) > arrayIndex {
 			if isNestedArray {
 				return extractValue(currentKey[endOfBracket+1:], array[arrayIndex])


### PR DESCRIPTION
## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
Fixes #391


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Added the documentation in `README.md`, if applicable.
