### PR TITLE
feat(condition): Support floating point

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ Here are some examples of conditions you can use:
 | `has`    | Returns `true` or `false` based on whether a given path is valid. Works only with the `[BODY]` placeholder.                                                                                                                         | `has([BODY].errors) == false`      |
 | `pat`    | Specifies that the string passed as parameter should be evaluated as a pattern. Works only with `==` and `!=`.                                                                                                                      | `[IP] == pat(192.168.*)`           |
 | `any`    | Specifies that any one of the values passed as parameters is a valid value. Works only with `==` and `!=`.                                                                                                                          | `[BODY].ip == any(127.0.0.1, ::1)` |
+| `str`    | Specifies that the string passed as parameter should not be parsed/evaluated. Placeholders inside will not be evaluated. Works only with `==` and `!=`.                                                                             | `[BODY].val == str(55e3)`          |
 
 > 💡 Use `pat` only when you need to. `[STATUS] == pat(2*)` is a lot more expensive than `[STATUS] < 300`.
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Here are some examples of conditions you can use:
 | `[BODY].user.name == john`       | JSONPath value of `$.user.name` is equal to `john`  | `{"user":{"name":"john"}}` |                  |
 | `[BODY].data[0].id == 1`         | JSONPath value of `$.data[0].id` is equal to 1      | `{"data":[{"id":1}]}`      |                  |
 | `[BODY].age == [BODY].id`        | JSONPath value of `$.age` is equal JSONPath `$.id`  | `{"age":1,"id":1}`         |                  |
+| `[BODY].score > 95.5`            | JSONPath value of `$.score` is greater than `95.5`  | `{"score": 95.7}`          | `{"score": 93}`  |
 | `len([BODY].data) < 5`           | Array at JSONPath `$.data` has less than 5 elements | `{"data":[{"id":1}]}`      |                  |
 | `len([BODY].name) == 8`          | String at JSONPath `$.name` has a length of 8       | `{"name":"john.doe"}`      | `{"name":"bob"}` |
 | `has([BODY].errors) == false`    | JSONPath `$.errors` does not exist                  | `{"name":"john.doe"}`      | `{"errors":[]}`  |

--- a/core/condition.go
+++ b/core/condition.go
@@ -3,6 +3,7 @@ package core
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -328,8 +329,8 @@ func sanitizeAndResolveNumerical(list []string, result *Result) (parameters []st
 		if duration, err := time.ParseDuration(element); duration != 0 && err == nil {
 			resolvedNumericalParameters = append(resolvedNumericalParameters, float64(duration.Milliseconds()))
 		} else if number, err := strconv.ParseFloat(element, 64); err != nil {
-			// Default to 0 if the string couldn't be converted to an integer
-			resolvedNumericalParameters = append(resolvedNumericalParameters, 0)
+			// Default to NaN if the string couldn't be converted to a number
+			resolvedNumericalParameters = append(resolvedNumericalParameters, math.NaN())
 		} else {
 			resolvedNumericalParameters = append(resolvedNumericalParameters, number)
 		}

--- a/core/condition.go
+++ b/core/condition.go
@@ -217,6 +217,15 @@ func isEqual(first, second string) bool {
 			return false
 		}
 	}
+
+	// If both are numeric, force a numeric comparison.
+	// Ensures valid comparison for numbers expressed in decimal, scientific, etc.
+	firstNumeric, firstParseErr := strconv.ParseFloat(first, 64)
+	secondNumeric, secondParseErr := strconv.ParseFloat(second, 64)
+	if firstParseErr == nil && secondParseErr == nil {
+		return firstNumeric == secondNumeric
+	}
+
 	return first == second
 }
 
@@ -291,12 +300,12 @@ func sanitizeAndResolve(elements []string, result *Result) ([]string, []string) 
 	return parameters, resolvedParameters
 }
 
-func sanitizeAndResolveNumerical(list []string, result *Result) (parameters []string, resolvedNumericalParameters []int64) {
+func sanitizeAndResolveNumerical(list []string, result *Result) (parameters []string, resolvedNumericalParameters []float64) {
 	parameters, resolvedParameters := sanitizeAndResolve(list, result)
 	for _, element := range resolvedParameters {
 		if duration, err := time.ParseDuration(element); duration != 0 && err == nil {
-			resolvedNumericalParameters = append(resolvedNumericalParameters, duration.Milliseconds())
-		} else if number, err := strconv.ParseInt(element, 10, 64); err != nil {
+			resolvedNumericalParameters = append(resolvedNumericalParameters, float64(duration.Milliseconds()))
+		} else if number, err := strconv.ParseFloat(element, 64); err != nil {
 			// Default to 0 if the string couldn't be converted to an integer
 			resolvedNumericalParameters = append(resolvedNumericalParameters, 0)
 		} else {
@@ -306,8 +315,8 @@ func sanitizeAndResolveNumerical(list []string, result *Result) (parameters []st
 	return parameters, resolvedNumericalParameters
 }
 
-func prettifyNumericalParameters(parameters []string, resolvedParameters []int64, operator string) string {
-	return prettify(parameters, []string{strconv.Itoa(int(resolvedParameters[0])), strconv.Itoa(int(resolvedParameters[1]))}, operator)
+func prettifyNumericalParameters(parameters []string, resolvedParameters []float64, operator string) string {
+	return prettify(parameters, []string{strconv.FormatFloat(resolvedParameters[0], 'f', -1, 64), strconv.FormatFloat(resolvedParameters[1], 'f', -1, 64)}, operator)
 }
 
 // prettify returns a string representation of a condition with its parameters resolved between parentheses

--- a/core/condition_test.go
+++ b/core/condition_test.go
@@ -117,7 +117,7 @@ func TestCondition_evaluate(t *testing.T) {
 			Condition:       Condition("[RESPONSE_TIME] < potato"),
 			Result:          &Result{Duration: 50 * time.Millisecond},
 			ExpectedSuccess: false,
-			ExpectedOutput:  "[RESPONSE_TIME] (50) < potato (0)", // Non-numerical values automatically resolve to 0
+			ExpectedOutput:  "[RESPONSE_TIME] (50) < potato (NaN)", // Non-numerical values automatically resolve to NaN
 		},
 		{
 			Name:            "response-time-using-greater-than",
@@ -202,6 +202,13 @@ func TestCondition_evaluate(t *testing.T) {
 			Result:          &Result{body: []byte("{\"data\": {\"id\": 1}}")},
 			ExpectedSuccess: false,
 			ExpectedOutput:  "[BODY].data.name (INVALID) == john",
+		},
+		{
+			Name:            "body-jsonpath-complex-number-invalid",
+			Condition:       Condition("[BODY].data.id < 3"),
+			Result:          &Result{body: []byte("{\"data\": {\"id\": \"a string\"}}")},
+			ExpectedSuccess: false,
+			ExpectedOutput:  "[BODY].data.id (NaN) < 3",
 		},
 		{
 			Name:            "body-jsonpath-complex-len-invalid",

--- a/core/condition_test.go
+++ b/core/condition_test.go
@@ -246,6 +246,87 @@ func TestCondition_evaluate(t *testing.T) {
 			ExpectedOutput:  "[BODY].data.id == 1",
 		},
 		{
+			Name:            "body-jsonpath-complex-big-int",
+			Condition:       Condition("[BODY].data.val == 10000000000"),
+			Result:          &Result{body: []byte("{\"data\": {\"val\": 10000000000}}")},
+			ExpectedSuccess: true,
+			ExpectedOutput:  "[BODY].data.val == 10000000000",
+		},
+		{
+			Name:            "body-jsonpath-complex-big-int-numerical-only-operator",
+			Condition:       Condition("[BODY].data.val <= 10000000000"),
+			Result:          &Result{body: []byte("{\"data\": {\"val\": 10000000000}}")},
+			ExpectedSuccess: true,
+			ExpectedOutput:  "[BODY].data.val <= 10000000000",
+		},
+		{
+			Name:            "body-jsonpath-complex-big-int-failure",
+			Condition:       Condition("[BODY].data.val != 10000000000"),
+			Result:          &Result{body: []byte("{\"data\": {\"val\": 10000000000}}")},
+			ExpectedSuccess: false,
+			// This is formatted by walk/Sprintf("%v"), which will use scientific notation for large numbers.
+			ExpectedOutput:  "[BODY].data.val (1e+10) != 10000000000",
+		},
+		{
+			Name:            "body-jsonpath-complex-big-int-failure-numerical-only-operator",
+			Condition:       Condition("[BODY].data.val < 10000000000"),
+			Result:          &Result{body: []byte("{\"data\": {\"val\": 10000000000}}")},
+			ExpectedSuccess: false,
+			// This is formatted by prettifyNumericalParameters, which will never use scientific notation.
+			ExpectedOutput:  "[BODY].data.val (10000000000) < 10000000000",
+		},
+		{
+			Name:            "body-jsonpath-complex-float",
+			Condition:       Condition("[BODY].data.val == 1.5"),
+			Result:          &Result{body: []byte("{\"data\": {\"val\": 1.5}}")},
+			ExpectedSuccess: true,
+			ExpectedOutput:  "[BODY].data.val == 1.5",
+		},
+		{
+			Name:            "body-jsonpath-complex-float-scientific",
+			Condition:       Condition("[BODY].data.val == 1.5e3"),
+			Result:          &Result{body: []byte("{\"data\": {\"val\": 1500}}")},
+			ExpectedSuccess: true,
+			ExpectedOutput:  "[BODY].data.val == 1.5e3",
+		},
+		{
+			Name:            "body-jsonpath-complex-float-scientific-numerical-only-operator",
+			Condition:       Condition("[BODY].data.val <= 1.5e3"),
+			Result:          &Result{body: []byte("{\"data\": {\"val\": 1500}}")},
+			ExpectedSuccess: true,
+			ExpectedOutput:  "[BODY].data.val <= 1.5e3",
+		},
+		{
+			Name:            "body-jsonpath-complex-big-float",
+			Condition:       Condition("[BODY].data.val == 10000000000.5"),
+			Result:          &Result{body: []byte("{\"data\": {\"val\": 10000000000.5}}")},
+			ExpectedSuccess: true,
+			ExpectedOutput:  "[BODY].data.val == 10000000000.5",
+		},
+		{
+			Name:            "body-jsonpath-complex-big-float-numerical-only-operator",
+			Condition:       Condition("[BODY].data.val <= 10000000000.5"),
+			Result:          &Result{body: []byte("{\"data\": {\"val\": 10000000000.5}}")},
+			ExpectedSuccess: true,
+			ExpectedOutput:  "[BODY].data.val <= 10000000000.5",
+		},
+		{
+			Name:            "body-jsonpath-complex-big-float-failure",
+			Condition:       Condition("[BODY].data.val != 10000000000.5"),
+			Result:          &Result{body: []byte("{\"data\": {\"val\": 10000000000.5}}")},
+			ExpectedSuccess: false,
+			// This is formatted by walk/Sprintf("%v"), which will use scientific notation for large numbers.
+			ExpectedOutput:  "[BODY].data.val (1.00000000005e+10) != 10000000000.5",
+		},
+		{
+			Name:            "body-jsonpath-complex-big-float-failure-numerical-only-operator",
+			Condition:       Condition("[BODY].data.val < 10000000000.5"),
+			Result:          &Result{body: []byte("{\"data\": {\"val\": 10000000000.5}}")},
+			ExpectedSuccess: false,
+			// This is formatted by prettifyNumericalParameters, which will never use scientific notation.
+			ExpectedOutput:  "[BODY].data.val (10000000000.5) < 10000000000.5",
+		},
+		{
 			Name:            "body-jsonpath-complex-array-int",
 			Condition:       Condition("[BODY].data[1].id == 2"),
 			Result:          &Result{body: []byte("{\"data\": [{\"id\": 1}, {\"id\": 2}, {\"id\": 3}]}")},

--- a/core/condition_test.go
+++ b/core/condition_test.go
@@ -672,6 +672,50 @@ func TestCondition_evaluate(t *testing.T) {
 			ExpectedSuccess:             false,
 			ExpectedOutput:              "has([BODY].errors) == false",
 		},
+		// str
+		{
+			Name:            "str-no-placeholders",
+			Condition:       Condition("55 != str(55.0)"),
+			Result:          &Result{body: []byte("{}")},
+			ExpectedSuccess: true,
+			ExpectedOutput:  "55 != str(55.0)",
+		},
+		{
+			Name:            "str-with-placeholder",
+			Condition:       Condition("[BODY].value != str(55e3)"),
+			Result:          &Result{body: []byte("{ \"value\": \"55.0000\" }")},
+			ExpectedSuccess: true,
+			ExpectedOutput:  "[BODY].value != str(55e3)",
+		},
+		{
+			Name:            "str-leaves-body-placeholder",
+			Condition:       Condition("[BODY].value == str([BODY])"),
+			Result:          &Result{body: []byte("{ \"value\": \"[BODY]\" }")},
+			ExpectedSuccess: true,
+			ExpectedOutput:  "[BODY].value == str([BODY])",
+		},
+		{
+			Name:            "str-leaves-status-placeholder",
+			Condition:       Condition("[BODY].value == str([STATUS])"),
+			Result:          &Result{body: []byte("{ \"value\": \"[STATUS]\" }")},
+			ExpectedSuccess: true,
+			ExpectedOutput:  "[BODY].value == str([STATUS])",
+		},
+		{
+			Name:            "str-failure",
+			Condition:       Condition("[BODY].value == str([BODY])"),
+			Result:          &Result{body: []byte("{ \"value\": \"[NOT BODY]\" }")},
+			ExpectedSuccess: false,
+			ExpectedOutput:  "[BODY].value ([NOT BODY]) == str([BODY]) ([BODY])",
+		},
+		{
+			Name:                        "str-failure-but-dont-resolve",
+			Condition:                   Condition("[BODY].value == str([BODY])"),
+			Result:                      &Result{body: []byte("{ \"value\": \"[NOT BODY]\" }")},
+			DontResolveFailedConditions: true,
+			ExpectedSuccess:             false,
+			ExpectedOutput:  "[BODY].value == str([BODY])",
+		},
 	}
 	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
- Adds support for floating point numbers in conditions.
- Fixes comparison of large integers.
- Adds the `str()` function.
- Resolves non-numeric values to `NaN` for numeric-only operators.

Support for `<`, `<=`, `>`, and `>=` was relatively straightforward since numbers were already parsed.
`==` and `!=` now check if both operands are numeric before falling back to string comparison.

Large integers from `[BODY]` were being parsed to [`float64_t` by `json.Unmarshal`][1] and then formatted in scientific notation by [`Sprintf("%v")` ][2], which made them unparseable as an integer in `sanitizeAndResolveNumerical`.

[1]: https://pkg.go.dev/encoding/json#Unmarshal:~:text=for%20JSON%20booleans-,float64%2C%20for%20JSON%20numbers,-string%2C%20for%20JSON]
[2]: https://pkg.go.dev/fmt#:~:text=float32%2C%20complex64%2C%20etc%3A%20%25g

Added the `str()` function to opt out of the numeric parsing during `==` and `!=` and keep the string comparison behavior.

Numbers are now passed around as `float64_t`, which cannot represent every `int64_t`.
`[BODY]` values were already `float64_t` during deserialization, and `float64_t` can represent `> 285,000` years in milliseconds before losing precision, so I think this should be OK.

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Added the documentation in `README.md`, if applicable.
