### PR TITLE
feat(alerting): Add Pushover provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,7 +793,7 @@ endpoints:
 #### Configuring Pushover alerts
 | Parameter                                       | Description                                                                                | Default                      |
 |:------------------------------------------------|:-------------------------------------------------------------------------------------------|:-----------------------------|
-| `alerting.pushover`                             | Configuration for alerts of type `pagerduty`                                               | `{}`                         |
+| `alerting.pushover`                             | Configuration for alerts of type `pushover`                                                | `{}`                         |
 | `alerting.pushover.application-key`             | Pushover Application key                                                                   | `""`                         |
 | `alerting.pushover.user-key`                    | User or group key                                                                          | `""`                         |
 | `alerting.pushover.title`                       | A fixed title for all messages sent via Pushover                                           | Name of your App in Pushover |
@@ -802,7 +802,7 @@ endpoints:
 
 ```yaml
 alerting:
-  pagerduty:
+  pushover:
     application-key: "******************************"
     user-key: "******************************"
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Have any feedback or questions? [Create a discussion](https://github.com/TwiN/ga
     - [Basic](#basic)
     - [OIDC](#oidc)
   - [Metrics](#metrics)
-  - [Remote instances (EXPERIMENTAL)](#remote-instances--experimental-)
+  - [Remote instances (EXPERIMENTAL)](#remote-instances-experimental)
 - [Deployment](#deployment)
   - [Docker](#docker)
   - [Helm Chart](#helm-chart)

--- a/README.md
+++ b/README.md
@@ -791,19 +791,19 @@ endpoints:
 
 
 #### Configuring Pushover alerts
-| Parameter                                       | Description                                                                                | Default                      |
-|:------------------------------------------------|:-------------------------------------------------------------------------------------------|:-----------------------------|
-| `alerting.pushover`                             | Configuration for alerts of type `pushover`                                                | `{}`                         |
-| `alerting.pushover.application-key`             | Pushover Application key                                                                   | `""`                         |
-| `alerting.pushover.user-key`                    | User or group key                                                                          | `""`                         |
-| `alerting.pushover.title`                       | A fixed title for all messages sent via Pushover                                           | Name of your App in Pushover |
-| `alerting.pushover.priority`                    | Priority of all messages, ranging from -2 (very low) to 2 (Emergency)                      | `0`                          |
-| `alerting.pushover.default-alert`               | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert) | N/A                          |
+| Parameter                              | Description                                                                                | Default                      |
+|:---------------------------------------|:-------------------------------------------------------------------------------------------|:-----------------------------|
+| `alerting.pushover`                    | Configuration for alerts of type `pushover`                                                | `{}`                         |
+| `alerting.pushover.application-token`  | Pushover Application token                                                                 | `""`                         |
+| `alerting.pushover.user-key`           | User or group key                                                                          | `""`                         |
+| `alerting.pushover.title`              | A fixed title for all messages sent via Pushover                                           | Name of your App in Pushover |
+| `alerting.pushover.priority`           | Priority of all messages, ranging from -2 (very low) to 2 (Emergency)                      | `0`                          |
+| `alerting.pushover.default-alert`      | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert) | N/A                          |
 
 ```yaml
 alerting:
   pushover:
-    application-key: "******************************"
+    application-token: "******************************"
     user-key: "******************************"
 
 endpoints:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Gatus is a developer-oriented health dashboard that gives you the ability to monitor your services using HTTP, ICMP, TCP, and even DNS
 queries as well as evaluate the result of said queries by using a list of conditions on values like the status code,
 the response time, the certificate expiration, the body and many others. The icing on top is that each of these health
-checks can be paired with alerting via Slack, PagerDuty, Discord, Twilio and more.
+checks can be paired with alerting via Slack, PagerDuty, Pushover, Discord, Twilio and more.
 
 I personally deploy it in my Kubernetes cluster and let it monitor the status of my
 core applications: https://status.twin.sh/
@@ -56,6 +56,7 @@ Have any feedback or questions? [Create a discussion](https://github.com/TwiN/ga
     - [Configuring Ntfy alerts](#configuring-ntfy-alerts)
     - [Configuring Opsgenie alerts](#configuring-opsgenie-alerts)
     - [Configuring PagerDuty alerts](#configuring-pagerduty-alerts)
+    - [Configuring Pushover alerts](#configuring-pushover-alerts)
     - [Configuring Slack alerts](#configuring-slack-alerts)
     - [Configuring Teams alerts](#configuring-teams-alerts)
     - [Configuring Telegram alerts](#configuring-telegram-alerts)
@@ -67,7 +68,7 @@ Have any feedback or questions? [Create a discussion](https://github.com/TwiN/ga
     - [Basic](#basic)
     - [OIDC](#oidc)
   - [Metrics](#metrics)
-  - [Remote instances (EXPERIMENTAL)](#remote-instances-experimental)
+  - [Remote instances (EXPERIMENTAL)](#remote-instances--experimental-)
 - [Deployment](#deployment)
   - [Docker](#docker)
   - [Helm Chart](#helm-chart)
@@ -408,6 +409,7 @@ ignored.
 | `alerting.ntfy`        | Configuration for alerts of type `ntfy`. <br />See [Configuring Ntfy alerts](#configuring-ntfy-alerts).                      | `{}`    |
 | `alerting.opsgenie`    | Configuration for alerts of type `opsgenie`. <br />See [Configuring Opsgenie alerts](#configuring-opsgenie-alerts).          | `{}`    |
 | `alerting.pagerduty`   | Configuration for alerts of type `pagerduty`. <br />See [Configuring PagerDuty alerts](#configuring-pagerduty-alerts).       | `{}`    |
+| `alerting.pushover`    | Configuration for alerts of type `pushover`. <br />See [Configuring Pushover alerts](#configuring-pushover-alerts).          | `{}`    |
 | `alerting.slack`       | Configuration for alerts of type `slack`. <br />See [Configuring Slack alerts](#configuring-slack-alerts).                   | `{}`    |
 | `alerting.teams`       | Configuration for alerts of type `teams`. <br />See [Configuring Teams alerts](#configuring-teams-alerts).                   | `{}`    |
 | `alerting.telegram`    | Configuration for alerts of type `telegram`. <br />See [Configuring Telegram alerts](#configuring-telegram-alerts).          | `{}`    |
@@ -787,6 +789,38 @@ endpoints:
         description: "healthcheck failed"
 ```
 
+
+#### Configuring Pushover alerts
+| Parameter                                       | Description                                                                                | Default                      |
+|:------------------------------------------------|:-------------------------------------------------------------------------------------------|:-----------------------------|
+| `alerting.pushover`                             | Configuration for alerts of type `pagerduty`                                               | `{}`                         |
+| `alerting.pushover.application-key`             | Pushover Application key                                                                   | `""`                         |
+| `alerting.pushover.user-key`                    | User or group key                                                                          | `""`                         |
+| `alerting.pushover.title`                       | A fixed title for all messages sent via Pushover                                           | Name of your App in Pushover |
+| `alerting.pushover.priority`                    | Priority of all messages, ranging from -2 (very low) to 2 (Emergency)                      | `0`                          |
+| `alerting.pushover.default-alert`               | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert) | N/A                          |
+
+```yaml
+alerting:
+  pagerduty:
+    application-key: "******************************"
+    user-key: "******************************"
+
+endpoints:
+  - name: website
+    url: "https://twin.sh/health"
+    interval: 30s
+    conditions:
+      - "[STATUS] == 200"
+      - "[BODY].status == UP"
+      - "[RESPONSE_TIME] < 300"
+    alerts:
+      - type: pushover
+        failure-threshold: 3
+        success-threshold: 5
+        send-on-resolved: true
+        description: "healthcheck failed"
+```
 
 #### Configuring Slack alerts
 | Parameter                                 | Description                                                                                | Default       |

--- a/alerting/alert/type.go
+++ b/alerting/alert/type.go
@@ -38,6 +38,9 @@ const (
 	// TypePagerDuty is the Type for the pagerduty alerting provider
 	TypePagerDuty Type = "pagerduty"
 
+	// TypePushover is the Type for the pushover alerting provider
+	TypePushover Type = "pushover"
+
 	// TypeSlack is the Type for the slack alerting provider
 	TypeSlack Type = "slack"
 

--- a/alerting/config.go
+++ b/alerting/config.go
@@ -60,7 +60,7 @@ type Config struct {
 	// PagerDuty is the configuration for the pagerduty alerting provider
 	PagerDuty *pagerduty.AlertProvider `yaml:"pagerduty,omitempty"`
 
-	// Pushover is the configuration for the pagerduty alerting provider
+	// Pushover is the configuration for the pushover alerting provider
 	Pushover *pushover.AlertProvider `yaml:"pushover,omitempty"`
 
 	// Slack is the configuration for the slack alerting provider

--- a/alerting/config.go
+++ b/alerting/config.go
@@ -60,7 +60,7 @@ type Config struct {
 	// PagerDuty is the configuration for the pagerduty alerting provider
 	PagerDuty *pagerduty.AlertProvider `yaml:"pagerduty,omitempty"`
 
-	// PagerDuty is the configuration for the pagerduty alerting provider
+	// Pushover is the configuration for the pagerduty alerting provider
 	Pushover *pushover.AlertProvider `yaml:"pushover,omitempty"`
 
 	// Slack is the configuration for the slack alerting provider

--- a/alerting/config.go
+++ b/alerting/config.go
@@ -1,6 +1,7 @@
 package alerting
 
 import (
+	"github.com/TwiN/gatus/v5/alerting/provider/pushover"
 	"log"
 	"reflect"
 	"strings"
@@ -58,6 +59,9 @@ type Config struct {
 
 	// PagerDuty is the configuration for the pagerduty alerting provider
 	PagerDuty *pagerduty.AlertProvider `yaml:"pagerduty,omitempty"`
+
+	// PagerDuty is the configuration for the pagerduty alerting provider
+	Pushover *pushover.AlertProvider `yaml:"pushover,omitempty"`
 
 	// Slack is the configuration for the slack alerting provider
 	Slack *slack.AlertProvider `yaml:"slack,omitempty"`

--- a/alerting/config.go
+++ b/alerting/config.go
@@ -1,7 +1,6 @@
 package alerting
 
 import (
-	"github.com/TwiN/gatus/v5/alerting/provider/pushover"
 	"log"
 	"reflect"
 	"strings"
@@ -19,6 +18,7 @@ import (
 	"github.com/TwiN/gatus/v5/alerting/provider/ntfy"
 	"github.com/TwiN/gatus/v5/alerting/provider/opsgenie"
 	"github.com/TwiN/gatus/v5/alerting/provider/pagerduty"
+	"github.com/TwiN/gatus/v5/alerting/provider/pushover"
 	"github.com/TwiN/gatus/v5/alerting/provider/slack"
 	"github.com/TwiN/gatus/v5/alerting/provider/teams"
 	"github.com/TwiN/gatus/v5/alerting/provider/telegram"

--- a/alerting/provider/provider.go
+++ b/alerting/provider/provider.go
@@ -13,6 +13,7 @@ import (
 	"github.com/TwiN/gatus/v5/alerting/provider/ntfy"
 	"github.com/TwiN/gatus/v5/alerting/provider/opsgenie"
 	"github.com/TwiN/gatus/v5/alerting/provider/pagerduty"
+	"github.com/TwiN/gatus/v5/alerting/provider/pushover"
 	"github.com/TwiN/gatus/v5/alerting/provider/slack"
 	"github.com/TwiN/gatus/v5/alerting/provider/teams"
 	"github.com/TwiN/gatus/v5/alerting/provider/telegram"
@@ -67,6 +68,7 @@ var (
 	_ AlertProvider = (*ntfy.AlertProvider)(nil)
 	_ AlertProvider = (*opsgenie.AlertProvider)(nil)
 	_ AlertProvider = (*pagerduty.AlertProvider)(nil)
+	_ AlertProvider = (*pushover.AlertProvider)(nil)
 	_ AlertProvider = (*slack.AlertProvider)(nil)
 	_ AlertProvider = (*teams.AlertProvider)(nil)
 	_ AlertProvider = (*telegram.AlertProvider)(nil)

--- a/alerting/provider/pushover/pushover.go
+++ b/alerting/provider/pushover/pushover.go
@@ -1,0 +1,106 @@
+package pushover
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/TwiN/gatus/v5/alerting/alert"
+	"github.com/TwiN/gatus/v5/client"
+	"github.com/TwiN/gatus/v5/core"
+)
+
+const (
+	restAPIURL      = "https://api.pushover.net/1/messages.json"
+	defaultPriority = 0
+)
+
+// AlertProvider is the configuration necessary for sending an alert using Messagebird
+type AlertProvider struct {
+	// Key used to authenticate the application sending
+	// See "Your Applications" on the dashboard, or add a new one: https://pushover.net/apps/build
+	ApplicationKey string `yaml:"application-key"`
+
+	// Key of the user or group the messages should be sent to
+	UserKey string `yaml:"user-key"`
+
+	// The title of your message, likely the application name
+	// default: the name of your application in Pushover
+	Title string `yaml:"title,omitempty"`
+
+	// Priority of all messages, ranging from -2 (very low) to 2 (Emergency)
+	// default: 0
+	Priority int `yaml:"priority,omitempty"`
+
+	// DefaultAlert is the default alert configuration to use for endpoints with an alert of the appropriate type
+	DefaultAlert *alert.Alert `yaml:"default-alert,omitempty"`
+}
+
+// IsValid returns whether the provider's configuration is valid
+func (provider *AlertProvider) IsValid() bool {
+	if provider.Priority == 0 {
+		provider.Priority = defaultPriority
+	}
+	return len(provider.ApplicationKey) == 30 && len(provider.UserKey) == 30 && provider.Priority >= -2 && provider.Priority <= 2
+}
+
+// Send an alert using the provider
+// Reference doc for messagebird: https://developers.messagebird.com/api/sms-messaging/#send-outbound-sms
+func (provider *AlertProvider) Send(endpoint *core.Endpoint, alert *alert.Alert, result *core.Result, resolved bool) error {
+	buffer := bytes.NewBuffer(provider.buildRequestBody(endpoint, alert, result, resolved))
+	request, err := http.NewRequest(http.MethodPost, restAPIURL, buffer)
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := client.GetHTTPClient(nil).Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	if response.StatusCode > 399 {
+		body, _ := io.ReadAll(response.Body)
+		return fmt.Errorf("call to provider alert returned status code %d: %s", response.StatusCode, string(body))
+	}
+	return err
+}
+
+type Body struct {
+	Token    string `json:"token"`
+	User     string `json:"user"`
+	Title    string `json:"title,omitempty"`
+	Message  string `json:"message"`
+	Priority int    `json:"priority"`
+}
+
+// buildRequestBody builds the request body for the provider
+func (provider *AlertProvider) buildRequestBody(endpoint *core.Endpoint, alert *alert.Alert, result *core.Result, resolved bool) []byte {
+	var message string
+	if resolved {
+		message = fmt.Sprintf("RESOLVED: %s - %s", endpoint.DisplayName(), alert.GetDescription())
+	} else {
+		message = fmt.Sprintf("TRIGGERED: %s - %s", endpoint.DisplayName(), alert.GetDescription())
+	}
+	body, _ := json.Marshal(Body{
+		Token:    provider.ApplicationKey,
+		User:     provider.UserKey,
+		Title:    provider.Title,
+		Message:  message,
+		Priority: provider.priority(),
+	})
+	return body
+}
+
+func (provider *AlertProvider) priority() int {
+	if provider.Priority == 0 {
+		return defaultPriority
+	}
+	return provider.Priority
+}
+
+// GetDefaultAlert returns the provider's default alert configuration
+func (provider AlertProvider) GetDefaultAlert() *alert.Alert {
+	return provider.DefaultAlert
+}

--- a/alerting/provider/pushover/pushover.go
+++ b/alerting/provider/pushover/pushover.go
@@ -17,7 +17,7 @@ const (
 	defaultPriority = 0
 )
 
-// AlertProvider is the configuration necessary for sending an alert using Messagebird
+// AlertProvider is the configuration necessary for sending an alert using Pushover
 type AlertProvider struct {
 	// Key used to authenticate the application sending
 	// See "Your Applications" on the dashboard, or add a new one: https://pushover.net/apps/build
@@ -47,7 +47,7 @@ func (provider *AlertProvider) IsValid() bool {
 }
 
 // Send an alert using the provider
-// Reference doc for messagebird: https://developers.messagebird.com/api/sms-messaging/#send-outbound-sms
+// Reference doc for pushover: https://pushover.net/api
 func (provider *AlertProvider) Send(endpoint *core.Endpoint, alert *alert.Alert, result *core.Result, resolved bool) error {
 	buffer := bytes.NewBuffer(provider.buildRequestBody(endpoint, alert, result, resolved))
 	request, err := http.NewRequest(http.MethodPost, restAPIURL, buffer)

--- a/alerting/provider/pushover/pushover.go
+++ b/alerting/provider/pushover/pushover.go
@@ -21,7 +21,7 @@ const (
 type AlertProvider struct {
 	// Key used to authenticate the application sending
 	// See "Your Applications" on the dashboard, or add a new one: https://pushover.net/apps/build
-	ApplicationKey string `yaml:"application-key"`
+	ApplicationToken string `yaml:"application-token"`
 
 	// Key of the user or group the messages should be sent to
 	UserKey string `yaml:"user-key"`
@@ -43,7 +43,7 @@ func (provider *AlertProvider) IsValid() bool {
 	if provider.Priority == 0 {
 		provider.Priority = defaultPriority
 	}
-	return len(provider.ApplicationKey) == 30 && len(provider.UserKey) == 30 && provider.Priority >= -2 && provider.Priority <= 2
+	return len(provider.ApplicationToken) == 30 && len(provider.UserKey) == 30 && provider.Priority >= -2 && provider.Priority <= 2
 }
 
 // Send an alert using the provider
@@ -84,7 +84,7 @@ func (provider *AlertProvider) buildRequestBody(endpoint *core.Endpoint, alert *
 		message = fmt.Sprintf("TRIGGERED: %s - %s", endpoint.DisplayName(), alert.GetDescription())
 	}
 	body, _ := json.Marshal(Body{
-		Token:    provider.ApplicationKey,
+		Token:    provider.ApplicationToken,
 		User:     provider.UserKey,
 		Title:    provider.Title,
 		Message:  message,

--- a/alerting/provider/pushover/pushover_test.go
+++ b/alerting/provider/pushover/pushover_test.go
@@ -1,0 +1,174 @@
+package pushover
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/TwiN/gatus/v5/alerting/alert"
+	"github.com/TwiN/gatus/v5/client"
+	"github.com/TwiN/gatus/v5/core"
+	"github.com/TwiN/gatus/v5/test"
+)
+
+func TestPushoverAlertProvider_IsValid(t *testing.T) {
+	invalidProvider := AlertProvider{}
+	if invalidProvider.IsValid() {
+		t.Error("provider shouldn't have been valid")
+	}
+	validProvider := AlertProvider{
+		ApplicationKey: "aTokenWithLengthOf30characters",
+		UserKey:        "aTokenWithLengthOf30characters",
+		Title:          "Gatus Notification",
+		Priority:       1,
+	}
+	if !validProvider.IsValid() {
+		t.Error("provider should've been valid")
+	}
+}
+
+func TestPushoverAlertProvider_IsInvalid(t *testing.T) {
+	invalidProvider := AlertProvider{
+		ApplicationKey: "aTokenWithLengthOfMoreThan30characters",
+		UserKey:        "aTokenWithLengthOfMoreThan30characters",
+		Priority:       5,
+	}
+	if invalidProvider.IsValid() {
+		t.Error("provider should've been invalid")
+	}
+}
+
+func TestAlertProvider_Send(t *testing.T) {
+	defer client.InjectHTTPClient(nil)
+	firstDescription := "description-1"
+	secondDescription := "description-2"
+	scenarios := []struct {
+		Name             string
+		Provider         AlertProvider
+		Alert            alert.Alert
+		Resolved         bool
+		MockRoundTripper test.MockRoundTripper
+		ExpectedError    bool
+	}{
+		{
+			Name:     "triggered",
+			Provider: AlertProvider{},
+			Alert:    alert.Alert{Description: &firstDescription, SuccessThreshold: 5, FailureThreshold: 3},
+			Resolved: false,
+			MockRoundTripper: test.MockRoundTripper(func(r *http.Request) *http.Response {
+				return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}
+			}),
+			ExpectedError: false,
+		},
+		{
+			Name:     "triggered-error",
+			Provider: AlertProvider{},
+			Alert:    alert.Alert{Description: &firstDescription, SuccessThreshold: 5, FailureThreshold: 3},
+			Resolved: false,
+			MockRoundTripper: test.MockRoundTripper(func(r *http.Request) *http.Response {
+				return &http.Response{StatusCode: http.StatusInternalServerError, Body: http.NoBody}
+			}),
+			ExpectedError: true,
+		},
+		{
+			Name:     "resolved",
+			Provider: AlertProvider{},
+			Alert:    alert.Alert{Description: &secondDescription, SuccessThreshold: 5, FailureThreshold: 3},
+			Resolved: true,
+			MockRoundTripper: test.MockRoundTripper(func(r *http.Request) *http.Response {
+				return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}
+			}),
+			ExpectedError: false,
+		},
+		{
+			Name:     "resolved-error",
+			Provider: AlertProvider{},
+			Alert:    alert.Alert{Description: &secondDescription, SuccessThreshold: 5, FailureThreshold: 3},
+			Resolved: true,
+			MockRoundTripper: test.MockRoundTripper(func(r *http.Request) *http.Response {
+				return &http.Response{StatusCode: http.StatusInternalServerError, Body: http.NoBody}
+			}),
+			ExpectedError: true,
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			client.InjectHTTPClient(&http.Client{Transport: scenario.MockRoundTripper})
+			err := scenario.Provider.Send(
+				&core.Endpoint{Name: "endpoint-name"},
+				&scenario.Alert,
+				&core.Result{
+					ConditionResults: []*core.ConditionResult{
+						{Condition: "[CONNECTED] == true", Success: scenario.Resolved},
+						{Condition: "[STATUS] == 200", Success: scenario.Resolved},
+					},
+				},
+				scenario.Resolved,
+			)
+			if scenario.ExpectedError && err == nil {
+				t.Error("expected error, got none")
+			}
+			if !scenario.ExpectedError && err != nil {
+				t.Error("expected no error, got", err.Error())
+			}
+		})
+	}
+}
+
+func TestAlertProvider_buildRequestBody(t *testing.T) {
+	firstDescription := "description-1"
+	secondDescription := "description-2"
+	scenarios := []struct {
+		Name         string
+		Provider     AlertProvider
+		Alert        alert.Alert
+		Resolved     bool
+		ExpectedBody string
+	}{
+		{
+			Name:         "triggered",
+			Provider:     AlertProvider{ApplicationKey: "TokenWithLengthOf30Characters1", UserKey: "TokenWithLengthOf30Characters4"},
+			Alert:        alert.Alert{Description: &firstDescription, SuccessThreshold: 5, FailureThreshold: 3},
+			Resolved:     false,
+			ExpectedBody: "{\"token\":\"TokenWithLengthOf30Characters1\",\"user\":\"TokenWithLengthOf30Characters4\",\"message\":\"TRIGGERED: endpoint-name - description-1\",\"priority\":0}",
+		},
+		{
+			Name:         "resolved",
+			Provider:     AlertProvider{ApplicationKey: "TokenWithLengthOf30Characters2", UserKey: "TokenWithLengthOf30Characters5", Title: "Gatus Notifications", Priority: 2},
+			Alert:        alert.Alert{Description: &secondDescription, SuccessThreshold: 5, FailureThreshold: 3},
+			Resolved:     true,
+			ExpectedBody: "{\"token\":\"TokenWithLengthOf30Characters2\",\"user\":\"TokenWithLengthOf30Characters5\",\"title\":\"Gatus Notifications\",\"message\":\"RESOLVED: endpoint-name - description-2\",\"priority\":2}",
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			body := scenario.Provider.buildRequestBody(
+				&core.Endpoint{Name: "endpoint-name"},
+				&scenario.Alert,
+				&core.Result{
+					ConditionResults: []*core.ConditionResult{
+						{Condition: "[CONNECTED] == true", Success: scenario.Resolved},
+						{Condition: "[STATUS] == 200", Success: scenario.Resolved},
+					},
+				},
+				scenario.Resolved,
+			)
+			if string(body) != scenario.ExpectedBody {
+				t.Errorf("expected:\n%s\ngot:\n%s", scenario.ExpectedBody, body)
+			}
+			out := make(map[string]interface{})
+			if err := json.Unmarshal([]byte(body), &out); err != nil {
+				t.Error("expected body to be valid JSON, got error:", err.Error())
+			}
+		})
+	}
+}
+
+func TestAlertProvider_GetDefaultAlert(t *testing.T) {
+	if (AlertProvider{DefaultAlert: &alert.Alert{}}).GetDefaultAlert() == nil {
+		t.Error("expected default alert to be not nil")
+	}
+	if (AlertProvider{DefaultAlert: nil}).GetDefaultAlert() != nil {
+		t.Error("expected default alert to be nil")
+	}
+}

--- a/alerting/provider/pushover/pushover_test.go
+++ b/alerting/provider/pushover/pushover_test.go
@@ -17,10 +17,10 @@ func TestPushoverAlertProvider_IsValid(t *testing.T) {
 		t.Error("provider shouldn't have been valid")
 	}
 	validProvider := AlertProvider{
-		ApplicationKey: "aTokenWithLengthOf30characters",
-		UserKey:        "aTokenWithLengthOf30characters",
-		Title:          "Gatus Notification",
-		Priority:       1,
+		ApplicationToken: "aTokenWithLengthOf30characters",
+		UserKey:          "aTokenWithLengthOf30characters",
+		Title:            "Gatus Notification",
+		Priority:         1,
 	}
 	if !validProvider.IsValid() {
 		t.Error("provider should've been valid")
@@ -29,9 +29,9 @@ func TestPushoverAlertProvider_IsValid(t *testing.T) {
 
 func TestPushoverAlertProvider_IsInvalid(t *testing.T) {
 	invalidProvider := AlertProvider{
-		ApplicationKey: "aTokenWithLengthOfMoreThan30characters",
-		UserKey:        "aTokenWithLengthOfMoreThan30characters",
-		Priority:       5,
+		ApplicationToken: "aTokenWithLengthOfMoreThan30characters",
+		UserKey:          "aTokenWithLengthOfMoreThan30characters",
+		Priority:         5,
 	}
 	if invalidProvider.IsValid() {
 		t.Error("provider should've been invalid")
@@ -127,14 +127,14 @@ func TestAlertProvider_buildRequestBody(t *testing.T) {
 	}{
 		{
 			Name:         "triggered",
-			Provider:     AlertProvider{ApplicationKey: "TokenWithLengthOf30Characters1", UserKey: "TokenWithLengthOf30Characters4"},
+			Provider:     AlertProvider{ApplicationToken: "TokenWithLengthOf30Characters1", UserKey: "TokenWithLengthOf30Characters4"},
 			Alert:        alert.Alert{Description: &firstDescription, SuccessThreshold: 5, FailureThreshold: 3},
 			Resolved:     false,
 			ExpectedBody: "{\"token\":\"TokenWithLengthOf30Characters1\",\"user\":\"TokenWithLengthOf30Characters4\",\"message\":\"TRIGGERED: endpoint-name - description-1\",\"priority\":0}",
 		},
 		{
 			Name:         "resolved",
-			Provider:     AlertProvider{ApplicationKey: "TokenWithLengthOf30Characters2", UserKey: "TokenWithLengthOf30Characters5", Title: "Gatus Notifications", Priority: 2},
+			Provider:     AlertProvider{ApplicationToken: "TokenWithLengthOf30Characters2", UserKey: "TokenWithLengthOf30Characters5", Title: "Gatus Notifications", Priority: 2},
 			Alert:        alert.Alert{Description: &secondDescription, SuccessThreshold: 5, FailureThreshold: 3},
 			Resolved:     true,
 			ExpectedBody: "{\"token\":\"TokenWithLengthOf30Characters2\",\"user\":\"TokenWithLengthOf30Characters5\",\"title\":\"Gatus Notifications\",\"message\":\"RESOLVED: endpoint-name - description-2\",\"priority\":2}",

--- a/config/config.go
+++ b/config/config.go
@@ -352,6 +352,7 @@ func validateAlertingConfig(alertingConfig *alerting.Config, endpoints []*core.E
 		alert.TypeNtfy,
 		alert.TypeOpsgenie,
 		alert.TypePagerDuty,
+		alert.TypePushover,
 		alert.TypeSlack,
 		alert.TypeTeams,
 		alert.TypeTelegram,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -686,7 +686,7 @@ alerting:
   pagerduty:
     integration-key: "00000000000000000000000000000000"
   pushover:
-    application-key: "000000000000000000000000000000"
+    application-token: "000000000000000000000000000000"
     user-key: "000000000000000000000000000000"
   mattermost:
     webhook-url: "http://example.com"
@@ -887,7 +887,7 @@ alerting:
       failure-threshold: 7
       success-threshold: 5
   pushover:
-    application-key: "000000000000000000000000000000"
+    application-token: "000000000000000000000000000000"
     user-key: "000000000000000000000000000000"
     default-alert:
       enabled: true
@@ -980,8 +980,8 @@ endpoints:
 	if config.Alerting.Pushover.GetDefaultAlert() == nil {
 		t.Fatal("Pushover.GetDefaultAlert() shouldn't have returned nil")
 	}
-	if config.Alerting.Pushover.ApplicationKey != "000000000000000000000000000000" {
-		t.Errorf("Pushover application key should've been %s, but was %s", "000000000000000000000000000000", config.Alerting.Pushover.ApplicationKey)
+	if config.Alerting.Pushover.ApplicationToken != "000000000000000000000000000000" {
+		t.Errorf("Pushover application token should've been %s, but was %s", "000000000000000000000000000000", config.Alerting.Pushover.ApplicationToken)
 	}
 	if config.Alerting.Pushover.UserKey != "000000000000000000000000000000" {
 		t.Errorf("Pushover user key should've been %s, but was %s", "000000000000000000000000000000", config.Alerting.Pushover.UserKey)
@@ -1289,7 +1289,7 @@ func TestParseAndValidateConfigBytesWithInvalidPushoverAlertingConfig(t *testing
 	config, err := parseAndValidateConfigBytes([]byte(`
 alerting:
   pushover:
-    application-key: "INVALID_KEY"
+    application-token: "INVALID_TOKEN"
 endpoints:
   - name: website
     url: https://twin.sh/health

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,7 +3,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"github.com/TwiN/gatus/v5/alerting/provider/pushover"
 	"os"
 	"path/filepath"
 	"testing"
@@ -23,6 +22,7 @@ import (
 	"github.com/TwiN/gatus/v5/alerting/provider/ntfy"
 	"github.com/TwiN/gatus/v5/alerting/provider/opsgenie"
 	"github.com/TwiN/gatus/v5/alerting/provider/pagerduty"
+	"github.com/TwiN/gatus/v5/alerting/provider/pushover"
 	"github.com/TwiN/gatus/v5/alerting/provider/slack"
 	"github.com/TwiN/gatus/v5/alerting/provider/teams"
 	"github.com/TwiN/gatus/v5/alerting/provider/telegram"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"github.com/TwiN/gatus/v5/alerting/provider/pushover"
 	"os"
 	"path/filepath"
 	"testing"
@@ -684,6 +685,9 @@ alerting:
     webhook-url: "http://example.org"
   pagerduty:
     integration-key: "00000000000000000000000000000000"
+  pushover:
+    application-key: "000000000000000000000000000000"
+    user-key: "000000000000000000000000000000"
   mattermost:
     webhook-url: "http://example.com"
     client:
@@ -723,6 +727,7 @@ endpoints:
         failure-threshold: 12
         success-threshold: 15
       - type: teams
+      - type: pushover
     conditions:
       - "[STATUS] == 200"
 `))
@@ -749,8 +754,8 @@ endpoints:
 	if config.Endpoints[0].Interval != 60*time.Second {
 		t.Errorf("Interval should have been %s, because it is the default value", 60*time.Second)
 	}
-	if len(config.Endpoints[0].Alerts) != 8 {
-		t.Fatal("There should've been 8 alerts configured")
+	if len(config.Endpoints[0].Alerts) != 9 {
+		t.Fatal("There should've been 9 alerts configured")
 	}
 
 	if config.Endpoints[0].Alerts[0].Type != alert.TypeSlack {
@@ -850,6 +855,13 @@ endpoints:
 	if config.Endpoints[0].Alerts[7].SuccessThreshold != 2 {
 		t.Errorf("The default success threshold of the alert should've been %d, but it was %d", 2, config.Endpoints[0].Alerts[7].SuccessThreshold)
 	}
+
+	if config.Endpoints[0].Alerts[8].Type != alert.TypePushover {
+		t.Errorf("The type of the alert should've been %s, but it was %s", alert.TypePushover, config.Endpoints[0].Alerts[8].Type)
+	}
+	if !config.Endpoints[0].Alerts[8].IsEnabled() {
+		t.Error("The alert should've been enabled")
+	}
 }
 
 func TestParseAndValidateConfigBytesWithAlertingAndDefaultAlert(t *testing.T) {
@@ -874,6 +886,14 @@ alerting:
       description: default description
       failure-threshold: 7
       success-threshold: 5
+  pushover:
+    application-key: "000000000000000000000000000000"
+    user-key: "000000000000000000000000000000"
+    default-alert:
+      enabled: true
+      description: default description
+      failure-threshold: 5
+      success-threshold: 3
   mattermost:
     webhook-url: "http://example.com"
     default-alert:
@@ -917,6 +937,7 @@ endpoints:
      - type: telegram
      - type: twilio
      - type: teams
+     - type: pushover
    conditions:
      - "[STATUS] == 200"
 `))
@@ -951,6 +972,19 @@ endpoints:
 	}
 	if config.Alerting.PagerDuty.IntegrationKey != "00000000000000000000000000000000" {
 		t.Errorf("PagerDuty integration key should've been %s, but was %s", "00000000000000000000000000000000", config.Alerting.PagerDuty.IntegrationKey)
+	}
+
+	if config.Alerting.Pushover == nil || !config.Alerting.Pushover.IsValid() {
+		t.Fatal("Pushover alerting config should've been valid")
+	}
+	if config.Alerting.Pushover.GetDefaultAlert() == nil {
+		t.Fatal("Pushover.GetDefaultAlert() shouldn't have returned nil")
+	}
+	if config.Alerting.Pushover.ApplicationKey != "000000000000000000000000000000" {
+		t.Errorf("Pushover application key should've been %s, but was %s", "000000000000000000000000000000", config.Alerting.Pushover.ApplicationKey)
+	}
+	if config.Alerting.Pushover.UserKey != "000000000000000000000000000000" {
+		t.Errorf("Pushover user key should've been %s, but was %s", "000000000000000000000000000000", config.Alerting.Pushover.UserKey)
 	}
 
 	if config.Alerting.Mattermost == nil || !config.Alerting.Mattermost.IsValid() {
@@ -1026,8 +1060,8 @@ endpoints:
 	if config.Endpoints[0].Interval != 60*time.Second {
 		t.Errorf("Interval should have been %s, because it is the default value", 60*time.Second)
 	}
-	if len(config.Endpoints[0].Alerts) != 8 {
-		t.Fatal("There should've been 8 alerts configured")
+	if len(config.Endpoints[0].Alerts) != 9 {
+		t.Fatal("There should've been 9 alerts configured")
 	}
 
 	if config.Endpoints[0].Alerts[0].Type != alert.TypeSlack {
@@ -1129,6 +1163,19 @@ endpoints:
 	}
 	if config.Endpoints[0].Alerts[7].SuccessThreshold != 2 {
 		t.Errorf("The default success threshold of the alert should've been %d, but it was %d", 2, config.Endpoints[0].Alerts[7].SuccessThreshold)
+	}
+
+	if config.Endpoints[0].Alerts[8].Type != alert.TypePushover {
+		t.Errorf("The type of the alert should've been %s, but it was %s", alert.TypePushover, config.Endpoints[0].Alerts[8].Type)
+	}
+	if !config.Endpoints[0].Alerts[8].IsEnabled() {
+		t.Error("The alert should've been enabled")
+	}
+	if config.Endpoints[0].Alerts[8].FailureThreshold != 5 {
+		t.Errorf("The default failure threshold of the alert should've been %d, but it was %d", 3, config.Endpoints[0].Alerts[8].FailureThreshold)
+	}
+	if config.Endpoints[0].Alerts[8].SuccessThreshold != 3 {
+		t.Errorf("The default success threshold of the alert should've been %d, but it was %d", 2, config.Endpoints[0].Alerts[8].SuccessThreshold)
 	}
 
 }
@@ -1238,6 +1285,32 @@ endpoints:
 		t.Fatal("PagerDuty alerting config should've been set to nil, because its IsValid() method returned false and therefore alerting.Config.SetAlertingProviderToNil() should've been called")
 	}
 }
+func TestParseAndValidateConfigBytesWithInvalidPushoverAlertingConfig(t *testing.T) {
+	config, err := parseAndValidateConfigBytes([]byte(`
+alerting:
+  pushover:
+    application-key: "INVALID_KEY"
+endpoints:
+  - name: website
+    url: https://twin.sh/health
+    alerts:
+      - type: pushover
+    conditions:
+      - "[STATUS] == 200"
+`))
+	if err != nil {
+		t.Error("expected no error, got", err.Error())
+	}
+	if config == nil {
+		t.Fatal("Config shouldn't have been nil")
+	}
+	if config.Alerting == nil {
+		t.Fatal("config.Alerting shouldn't have been nil")
+	}
+	if config.Alerting.Pushover != nil {
+		t.Fatal("Pushover alerting config should've been set to nil, because its IsValid() method returned false and therefore alerting.Config.SetAlertingProviderToNil() should've been called")
+	}
+}
 
 func TestParseAndValidateConfigBytesWithCustomAlertingConfig(t *testing.T) {
 	config, err := parseAndValidateConfigBytes([]byte(`
@@ -1266,7 +1339,7 @@ endpoints:
 		t.Fatal("config.Alerting shouldn't have been nil")
 	}
 	if config.Alerting.Custom == nil {
-		t.Fatal("PagerDuty alerting config shouldn't have been nil")
+		t.Fatal("Custom alerting config shouldn't have been nil")
 	}
 	if !config.Alerting.Custom.IsValid() {
 		t.Fatal("Custom alerting config should've been valid")
@@ -1311,7 +1384,7 @@ endpoints:
 		t.Fatal("config.Alerting shouldn't have been nil")
 	}
 	if config.Alerting.Custom == nil {
-		t.Fatal("PagerDuty alerting config shouldn't have been nil")
+		t.Fatal("Custom alerting config shouldn't have been nil")
 	}
 	if !config.Alerting.Custom.IsValid() {
 		t.Fatal("Custom alerting config should've been valid")
@@ -1351,7 +1424,7 @@ endpoints:
 		t.Fatal("config.Alerting shouldn't have been nil")
 	}
 	if config.Alerting.Custom == nil {
-		t.Fatal("PagerDuty alerting config shouldn't have been nil")
+		t.Fatal("Custom alerting config shouldn't have been nil")
 	}
 	if !config.Alerting.Custom.IsValid() {
 		t.Fatal("Custom alerting config should've been valid")
@@ -1481,6 +1554,7 @@ func TestGetAlertingProviderByAlertType(t *testing.T) {
 		Ntfy:        &ntfy.AlertProvider{},
 		Opsgenie:    &opsgenie.AlertProvider{},
 		PagerDuty:   &pagerduty.AlertProvider{},
+		Pushover:    &pushover.AlertProvider{},
 		Slack:       &slack.AlertProvider{},
 		Telegram:    &telegram.AlertProvider{},
 		Twilio:      &twilio.AlertProvider{},
@@ -1501,6 +1575,7 @@ func TestGetAlertingProviderByAlertType(t *testing.T) {
 		{alertType: alert.TypeNtfy, expected: alertingConfig.Ntfy},
 		{alertType: alert.TypeOpsgenie, expected: alertingConfig.Opsgenie},
 		{alertType: alert.TypePagerDuty, expected: alertingConfig.PagerDuty},
+		{alertType: alert.TypePushover, expected: alertingConfig.Pushover},
 		{alertType: alert.TypeSlack, expected: alertingConfig.Slack},
 		{alertType: alert.TypeTelegram, expected: alertingConfig.Telegram},
 		{alertType: alert.TypeTwilio, expected: alertingConfig.Twilio},

--- a/watchdog/alerting_test.go
+++ b/watchdog/alerting_test.go
@@ -212,8 +212,8 @@ func TestHandleAlertingWhenTriggeredAlertIsResolvedPushover(t *testing.T) {
 		Debug: true,
 		Alerting: &alerting.Config{
 			Pushover: &pushover.AlertProvider{
-				ApplicationKey: "000000000000000000000000000000",
-				UserKey:        "000000000000000000000000000000",
+				ApplicationToken: "000000000000000000000000000000",
+				UserKey:          "000000000000000000000000000000",
 			},
 		},
 	}
@@ -315,8 +315,8 @@ func TestHandleAlertingWithProviderThatReturnsAnError(t *testing.T) {
 			AlertType: alert.TypePushover,
 			AlertingConfig: &alerting.Config{
 				Pushover: &pushover.AlertProvider{
-					ApplicationKey: "000000000000000000000000000000",
-					UserKey:        "000000000000000000000000000000",
+					ApplicationToken: "000000000000000000000000000000",
+					UserKey:          "000000000000000000000000000000",
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

I am not sure if I missed something. There are a lot of files where providers are referenced, but I think I got all of them.

- Adds new provider named Pushover with corresponding tests
- Adds Pushover as a provider to the configuration and adjusts test accordingly
- Adds Pushover to alerting_test.go, provider.go and type.go
- Updates the readme with configuration details

Before merging: what would be the best way to properly test this with real API calls? Is there any process defined or should I just try to build it and check if a config works?

Additional thoughts/ideas that could be implemented later:
- Add support for other configuration options, like device support, the Gatus URL in it or setting a sound
- Allow overriding of title, priority,... per group like the PagerDuty provider does.
- Allow usage of placeholders in title and description like the custom provider does.

Related: ##129

## Checklist
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Added the documentation in `README.md`, if applicable.
