### PR TITLE
feat(alerting): Add Pushover sound support

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,6 +801,7 @@ endpoints:
 | `alerting.pushover.user-key`           | User or group key                                                                          | `""`                         |
 | `alerting.pushover.title`              | A fixed title for all messages sent via Pushover                                           | Name of your App in Pushover |
 | `alerting.pushover.priority`           | Priority of all messages, ranging from -2 (very low) to 2 (Emergency)                      | `0`                          |
+| `alerting.pushover.sound`              | Sound of all messages<br/ >See [sounds](https://pushover.net/api#sounds)                   | `""` (pushover default)      |
 | `alerting.pushover.default-alert`      | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert) | N/A                          |
 
 ```yaml

--- a/alerting/provider/pushover/pushover.go
+++ b/alerting/provider/pushover/pushover.go
@@ -34,6 +34,10 @@ type AlertProvider struct {
 	// default: 0
 	Priority int `yaml:"priority,omitempty"`
 
+	// Sound of the messages (see: https://pushover.net/api#sounds)
+	// default: "" (pushover)
+	Sound string `yaml:"sound,omitempty"`
+
 	// DefaultAlert is the default alert configuration to use for endpoints with an alert of the appropriate type
 	DefaultAlert *alert.Alert `yaml:"default-alert,omitempty"`
 }
@@ -73,6 +77,7 @@ type Body struct {
 	Title    string `json:"title,omitempty"`
 	Message  string `json:"message"`
 	Priority int    `json:"priority"`
+	Sound    string `json:"sound,omitempty"`
 }
 
 // buildRequestBody builds the request body for the provider
@@ -89,6 +94,7 @@ func (provider *AlertProvider) buildRequestBody(endpoint *core.Endpoint, alert *
 		Title:    provider.Title,
 		Message:  message,
 		Priority: provider.priority(),
+		Sound:    provider.Sound,
 	})
 	return body
 }

--- a/alerting/provider/pushover/pushover_test.go
+++ b/alerting/provider/pushover/pushover_test.go
@@ -139,6 +139,13 @@ func TestAlertProvider_buildRequestBody(t *testing.T) {
 			Resolved:     true,
 			ExpectedBody: "{\"token\":\"TokenWithLengthOf30Characters2\",\"user\":\"TokenWithLengthOf30Characters5\",\"title\":\"Gatus Notifications\",\"message\":\"RESOLVED: endpoint-name - description-2\",\"priority\":2}",
 		},
+		{
+			Name:         "with-sound",
+			Provider:     AlertProvider{ApplicationToken: "TokenWithLengthOf30Characters2", UserKey: "TokenWithLengthOf30Characters5", Title: "Gatus Notifications", Priority: 2, Sound: "falling"},
+			Alert:        alert.Alert{Description: &secondDescription, SuccessThreshold: 5, FailureThreshold: 3},
+			Resolved:     true,
+			ExpectedBody: "{\"token\":\"TokenWithLengthOf30Characters2\",\"user\":\"TokenWithLengthOf30Characters5\",\"title\":\"Gatus Notifications\",\"message\":\"RESOLVED: endpoint-name - description-2\",\"priority\":2,\"sound\":\"falling\"}",
+		},
 	}
 	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
@@ -157,7 +164,7 @@ func TestAlertProvider_buildRequestBody(t *testing.T) {
 				t.Errorf("expected:\n%s\ngot:\n%s", scenario.ExpectedBody, body)
 			}
 			out := make(map[string]interface{})
-			if err := json.Unmarshal([]byte(body), &out); err != nil {
+			if err := json.Unmarshal(body, &out); err != nil {
 				t.Error("expected body to be valid JSON, got error:", err.Error())
 			}
 		})


### PR DESCRIPTION
## Summary
In  extension to #405 (#129) this PR adds support to configure sound for Pushover.
https://pushover.net/api#sounds



## Checklist

- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Added the documentation in `README.md`, if applicable.
