### PR TITLE
feat(ui): Show number of failing checks per group

### DIFF
--- a/web/app/src/components/EndpointGroup.vue
+++ b/web/app/src/components/EndpointGroup.vue
@@ -7,11 +7,8 @@
             {{ collapsed ? '&#9660;' : '&#9650;' }}
           </span>
           {{ name }}
-          <span v-if="unhealthyCount" class="float-right text-yellow-500 text-sm w-7 hover:scale-110" title="Partial Outage">
-            <span v-if="unhealthyCount<100" class="rounded-xl bg-yellow-500 text-gray-900 font-bold leading-6 float-right w-6 h-6 text-center hover:scale-110">{{unhealthyCount}}</span>
-            <ExclamationCircleIcon v-if="unhealthyCount>=100" />
-          </span>
-          <span v-if="unhealthyCount==0" class="float-right text-green-600 w-7 hover:scale-110" title="Operational">
+          <span v-if="unhealthyCount" class="rounded-xl bg-red-600 text-white px-2 font-bold leading-6 float-right h-6 text-center hover:scale-110 text-sm" title="Partial Outage">{{unhealthyCount}}</span>
+          <span v-if="unhealthyCount === 0" class="float-right text-green-600 w-7 hover:scale-110" title="Operational">
             <CheckCircleIcon />
           </span>
         </h5>
@@ -33,14 +30,13 @@
 
 <script>
 import Endpoint from './Endpoint.vue';
-import { CheckCircleIcon, ExclamationCircleIcon } from '@heroicons/vue/20/solid'
+import { CheckCircleIcon } from '@heroicons/vue/20/solid'
 
 export default {
   name: 'EndpointGroup',
   components: {
     Endpoint,
-    CheckCircleIcon,
-    ExclamationCircleIcon
+    CheckCircleIcon
   },
   props: {
     name: String,

--- a/web/app/src/components/EndpointGroup.vue
+++ b/web/app/src/components/EndpointGroup.vue
@@ -7,11 +7,12 @@
             {{ collapsed ? '&#9660;' : '&#9650;' }}
           </span>
           {{ name }}
-          <span v-if="healthy" class="float-right text-green-600 w-7 hover:scale-110" title="Operational">
-            <CheckCircleIcon />
+          <span v-if="unhealthyCount" class="float-right text-yellow-500 text-sm w-7 hover:scale-110" title="Partial Outage">
+            <span v-if="unhealthyCount<100" class="rounded-xl bg-yellow-500 text-gray-900 font-bold leading-6 float-right w-6 h-6 text-center hover:scale-110">{{unhealthyCount}}</span>
+            <ExclamationCircleIcon v-if="unhealthyCount>=100" />
           </span>
-          <span v-else class="float-right text-yellow-500 text-sm w-7 hover:scale-110" title="Partial Outage">
-            <ExclamationCircleIcon />
+          <span v-if="unhealthyCount==0" class="float-right text-green-600 w-7 hover:scale-110" title="Operational">
+            <CheckCircleIcon />
           </span>
         </h5>
       </div>
@@ -49,22 +50,17 @@ export default {
   emits: ['showTooltip', 'toggleShowAverageResponseTime'],
   methods: {
     healthCheck() {
+      let unhealthyCount = 0
       if (this.endpoints) {
         for (let i in this.endpoints) {
           if (this.endpoints[i].results && this.endpoints[i].results.length > 0) {
             if (!this.endpoints[i].results[this.endpoints[i].results.length-1].success) {
-              if (this.healthy) {
-                this.healthy = false;
-              }
-              return;
+              unhealthyCount++
             }
           }
         }
       }
-      // Set the endpoint group to healthy (only if it's currently unhealthy)
-      if (!this.healthy) {
-        this.healthy = true;
-      }
+      this.unhealthyCount = unhealthyCount;
     },
     toggleGroup() {
       this.collapsed = !this.collapsed;
@@ -87,7 +83,7 @@ export default {
   },
   data() {
     return {
-      healthy: true,
+      unhealthyCount: 0,
       collapsed: sessionStorage.getItem(`gatus:endpoint-group:${this.name}:collapsed`) === "true"
     }
   }


### PR DESCRIPTION
Hi, Gatus is awesome.

I implemented a simple change to show a number of failing checks instead of just an icon.

Please let me know if interested; then I'll finish the tests, etc.



<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->



## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [ ] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
