### PR TITLE
feat(alerting): Add token authorization for ntfy

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,6 +733,7 @@ endpoints:
 | `alerting.ntfy`               | Configuration for alerts of type `ntfy`                                                    | `{}`              |
 | `alerting.ntfy.topic`         | Topic at which the alert will be sent                                                      | Required `""`     |
 | `alerting.ntfy.url`           | The URL of the target server                                                               | `https://ntfy.sh` |
+| `alerting.ntfy.token`         | [Access token](https://docs.ntfy.sh/publish/#access-tokens) for restricted topics          | `""`              |
 | `alerting.ntfy.priority`      | The priority of the alert                                                                  | `3`               |
 | `alerting.ntfy.default-alert` | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert) | N/A               |
 
@@ -745,6 +746,7 @@ alerting:
   ntfy:
     topic: "gatus-test-topic"
     priority: 2
+    token: faketoken
     default-alert:
       failure-threshold: 3
       send-on-resolved: true

--- a/alerting/provider/ntfy/ntfy.go
+++ b/alerting/provider/ntfy/ntfy.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/TwiN/gatus/v5/alerting/alert"
 	"github.com/TwiN/gatus/v5/client"
@@ -23,6 +24,7 @@ type AlertProvider struct {
 	Topic    string `yaml:"topic"`
 	URL      string `yaml:"url,omitempty"`      // Defaults to DefaultURL
 	Priority int    `yaml:"priority,omitempty"` // Defaults to DefaultPriority
+	Token    string `yaml:"token,omitempty"`    // Defaults to ""
 
 	// DefaultAlert is the default alert configuration to use for endpoints with an alert of the appropriate type
 	DefaultAlert *alert.Alert `yaml:"default-alert,omitempty"`
@@ -36,7 +38,11 @@ func (provider *AlertProvider) IsValid() bool {
 	if provider.Priority == 0 {
 		provider.Priority = DefaultPriority
 	}
-	return len(provider.URL) > 0 && len(provider.Topic) > 0 && provider.Priority > 0 && provider.Priority < 6
+	tokenValid := true
+	if len(provider.Token) > 0 {
+		tokenValid = strings.HasPrefix(provider.Token, "tk_")
+	}
+	return len(provider.URL) > 0 && len(provider.Topic) > 0 && provider.Priority > 0 && provider.Priority < 6 && tokenValid
 }
 
 // Send an alert using the provider
@@ -47,6 +53,10 @@ func (provider *AlertProvider) Send(endpoint *core.Endpoint, alert *alert.Alert,
 		return err
 	}
 	request.Header.Set("Content-Type", "application/json")
+	if len(provider.Token) > 0 {
+		authString := fmt.Sprintf("Bearer %s", provider.Token)
+		request.Header.Set("Authorization", authString)
+	}
 	response, err := client.GetHTTPClient(nil).Do(request)
 	if err != nil {
 		return err

--- a/alerting/provider/ntfy/ntfy.go
+++ b/alerting/provider/ntfy/ntfy.go
@@ -38,11 +38,11 @@ func (provider *AlertProvider) IsValid() bool {
 	if provider.Priority == 0 {
 		provider.Priority = DefaultPriority
 	}
-	tokenValid := true
+	isTokenValid := true
 	if len(provider.Token) > 0 {
-		tokenValid = strings.HasPrefix(provider.Token, "tk_")
+		isTokenValid = strings.HasPrefix(provider.Token, "tk_")
 	}
-	return len(provider.URL) > 0 && len(provider.Topic) > 0 && provider.Priority > 0 && provider.Priority < 6 && tokenValid
+	return len(provider.URL) > 0 && len(provider.Topic) > 0 && provider.Priority > 0 && provider.Priority < 6 && isTokenValid
 }
 
 // Send an alert using the provider
@@ -54,8 +54,7 @@ func (provider *AlertProvider) Send(endpoint *core.Endpoint, alert *alert.Alert,
 	}
 	request.Header.Set("Content-Type", "application/json")
 	if len(provider.Token) > 0 {
-		authString := fmt.Sprintf("Bearer %s", provider.Token)
-		request.Header.Set("Authorization", authString)
+		request.Header.Set("Authorization", "Bearer "+provider.Token)
 	}
 	response, err := client.GetHTTPClient(nil).Do(request)
 	if err != nil {

--- a/alerting/provider/ntfy/ntfy_test.go
+++ b/alerting/provider/ntfy/ntfy_test.go
@@ -25,6 +25,16 @@ func TestAlertDefaultProvider_IsValid(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "valid-with-token",
+			provider: AlertProvider{Topic: "example", Priority: 1, Token: "tk_faketoken"},
+			expected: true,
+		},
+		{
+			name:     "invalid-token",
+			provider: AlertProvider{Topic: "example", Priority: 1, Token: "xx_faketoken"},
+			expected: false,
+		},
+		{
 			name:     "invalid-topic",
 			provider: AlertProvider{URL: "https://ntfy.sh", Topic: "", Priority: 1},
 			expected: false,


### PR DESCRIPTION
<!-- Thank you for contributing! -->
Hi, I hope I got everything right. Let me know if I need to fix something before this can be merged.

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
I've added the ability to use [access tokens](https://docs.ntfy.sh/publish/#access-tokens) in the ntfy alert module.
This _should_ fix #419, though I have not implemented user-password based auth. Ntfy makes it really simple to use tokens, so I did not want to complicate the code any more than necessary. (And I'm lazy.)

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Updated documentation in `README.md`, if applicable.
