### PR TITLE
fix(css): disable hover effects when not supported

### DIFF
--- a/web/app/tailwind.config.js
+++ b/web/app/tailwind.config.js
@@ -14,4 +14,7 @@ module.exports = {
     extend: {},
   },
   plugins: [],
+  future: {
+    hoverOnlyWhenSupported: true,
+  }
 }


### PR DESCRIPTION
## Summary
Hover effects only should been applied when they are supported.
For example on smartphones hover gets triggered on touch, which is unhandy if you click on the response times.

## Checklist
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable. => no need from my point of view