### PR TITLE
fix(client): Honor client.insecure when doing TLS checks

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -142,14 +142,20 @@ func CanPerformStartTLS(address string, config *Config) (connected bool, certifi
 
 // CanPerformTLS checks whether a connection can be established to an address using the TLS protocol
 func CanPerformTLS(address string, config *Config) (connected bool, certificate *x509.Certificate, err error) {
-	connection, err := tls.DialWithDialer(&net.Dialer{Timeout: config.Timeout}, "tcp", address, nil)
+	connection, err := tls.DialWithDialer(&net.Dialer{Timeout: config.Timeout}, "tcp", address, &tls.Config{
+		InsecureSkipVerify: config.Insecure,
+	})
 	if err != nil {
 		return
 	}
 	defer connection.Close()
 	verifiedChains := connection.ConnectionState().VerifiedChains
+	// If config.Insecure is set to true, verifiedChains will be an empty list []
+	// We should get the parsed certificates from PeerCertificates, it can't be empty on the client side
+	// Reference: https://pkg.go.dev/crypto/tls#PeerCertificates
 	if len(verifiedChains) == 0 || len(verifiedChains[0]) == 0 {
-		return
+		peerCertificates := connection.ConnectionState().PeerCertificates
+		return true, peerCertificates[0], nil
 	}
 	return true, verifiedChains[0][0], nil
 }

--- a/config.yaml
+++ b/config.yaml
@@ -51,3 +51,13 @@ endpoints:
     interval: 1h
     conditions:
       - "[DOMAIN_EXPIRATION] > 720h"
+
+  - name: tls-example
+    url: "tls://127.0.0.1:8095"
+    interval: 1m
+    client:
+      timeout: 5s
+      insecure: true
+    conditions:
+      - "[CONNECTED] == true"
+      - "[CERTIFICATE_EXPIRATION] > 48h"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
This PR enables gatus to honor client.insecure in the TLS checking
it will detect client.insecure in config.yaml and perform the relevant operation like ignore bad certificate and unknown certificates authority and so on.

Fixes #541 

## Checklist
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Updated documentation in `README.md`, if applicable.
