### PR TITLE
docs: demonstrate use of environment variables in config

### DIFF
--- a/.examples/docker-compose-postgres-storage/config/config.yaml
+++ b/.examples/docker-compose-postgres-storage/config/config.yaml
@@ -1,6 +1,6 @@
 storage:
   type: postgres
-  path: "postgres://username:password@postgres:5432/gatus?sslmode=disable"
+  path: "postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable"
 
 endpoints:
   - name: back-end

--- a/.examples/docker-compose-postgres-storage/docker-compose.yml
+++ b/.examples/docker-compose-postgres-storage/docker-compose.yml
@@ -18,6 +18,10 @@ services:
     restart: always
     ports:
       - "8080:8080"
+    environment:
+      - POSTGRES_DB=gatus
+      - POSTGRES_USER=username
+      - POSTGRES_PASSWORD=password
     volumes:
       - ./config:/config
     networks:

--- a/.examples/docker-compose-postgres-storage/docker-compose.yml
+++ b/.examples/docker-compose-postgres-storage/docker-compose.yml
@@ -19,9 +19,9 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - POSTGRES_DB=gatus
       - POSTGRES_USER=username
       - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=gatus
     volumes:
       - ./config:/config
     networks:

--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ subdirectories are merged like so:
     - To clarify, this also means that you could not define `alerting.slack.webhook-url` in two files with different values. All files are merged into one before they are processed. This is by design.
 
 > 💡 You can also use environment variables in the configuration file (e.g. `$DOMAIN`, `${DOMAIN}`)
+> 
+> See [examples/docker-compose-postgres-storage/config/config.yaml](.examples/docker-compose-postgres-storage/config/config.yaml) for an example.
 
 If you want to test it locally, see [Docker](#docker).
 


### PR DESCRIPTION
## Summary
The example for Postgres shows the database credentials in plain text in `config.yaml`, which isn't an ideal way to provide credentials. I didn't initaly realise environment variables could be used in config files until I saw #75 . I later noticed the note in the README. Hopefully this makes it clearer and provides a better example for configuring database connections.


## Checklist
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Updated documentation in `README.md`, if applicable.
