### PR TITLE
ci: Publish only if the workflow is not running on a fork

### DIFF
--- a/.github/workflows/publish-latest-to-ghcr.yml
+++ b/.github/workflows/publish-latest-to-ghcr.yml
@@ -5,12 +5,12 @@ on:
     branches: [master]
     types: [completed]
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.event.workflow_run.head_repository.full_name }}::${{ github.event.workflow_run.head_branch }} - ${{ github.workflow }}
   cancel-in-progress: true
 jobs:
   publish-latest-to-ghcr:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ (github.event.workflow_run.conclusion == 'success') && (github.event.pull_request.head.repo.full_name == github.repository) }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -5,12 +5,12 @@ on:
     branches: [master]
     types: [completed]
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.event.workflow_run.head_repository.full_name }}::${{ github.event.workflow_run.head_branch }} - ${{ github.workflow }}
   cancel-in-progress: true
 jobs:
   publish-latest:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ (github.event.workflow_run.conclusion == 'success') && (github.event.pull_request.head.repo.full_name == github.repository) }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
Otherwise, the workflow will attempt to publish on forks from contributors that are using the master branch


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [ ] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
