### PR TITLE
poc: custom scripts

### DIFF
--- a/core/condition.go
+++ b/core/condition.go
@@ -50,6 +50,10 @@ const (
 
 	// DomainExpirationPlaceholder is a placeholder for the duration before the domain expires, in milliseconds.
 	DomainExpirationPlaceholder = "[DOMAIN_EXPIRATION]"
+
+	ScriptExitCode = "[EXIT_CODE]"
+	ScriptStdOut   = "[STDOUT]"
+	ScriptStdErr   = "[STDERR]"
 )
 
 // Functions
@@ -261,6 +265,12 @@ func sanitizeAndResolve(elements []string, result *Result) ([]string, []string) 
 			element = strconv.FormatInt(result.CertificateExpiration.Milliseconds(), 10)
 		case DomainExpirationPlaceholder:
 			element = strconv.FormatInt(result.DomainExpiration.Milliseconds(), 10)
+		case ScriptExitCode:
+			element = strconv.FormatInt(int64(result.ScriptExitCode), 10)
+		case ScriptStdErr:
+			element = string(result.ScriptStderr)
+		case ScriptStdOut:
+			element = string(result.ScriptStdout)
 		default:
 			// if contains the BodyPlaceholder, then evaluate json path
 			if strings.Contains(element, BodyPlaceholder) {

--- a/core/result.go
+++ b/core/result.go
@@ -49,6 +49,11 @@ type Result struct {
 	// Note that this field is not persisted in the storage.
 	// It is used for health evaluation as well as debugging purposes.
 	Body []byte `json:"-"`
+
+	// for script
+	ScriptExitCode int    `json:"exitCode"`
+	ScriptStdout   []byte `json:"-"`
+	ScriptStderr   []byte `json:"-"`
 }
 
 // AddError adds an error to the result's list of errors.


### PR DESCRIPTION
Hi,

Using a custom script in a endpoint would allow anyone to support any custom target.

This MR is a poc to execute a custom script, and be able to check in conditions the exit code, the script stdout/stderr.

Example configuration : 
```yaml
  - name: custom script
    script:
      command: "echo -n HELLO"
    interval: 10s
    conditions:
      - "[EXIT_CODE] == 0"
      - "[STDOUT] == HELLO"
```

I did not implement tests yet, and the MR may not be clean.
Let me know what you think !

