### PR TITLE
fix(api): Add option to set custom fiber ReadBufferSize param

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Have any feedback or questions? [Create a discussion](https://github.com/TwiN/ga
   - [API](#api)
   - [Installing as binary](#installing-as-binary)
   - [High level design overview](#high-level-design-overview)
+- [Troubleshooting](#troubleshooting)
+  - [How to solve `Request Header Fields Too Large` error?](#how-to-solve-request-header-fields-too-large-error)
 - [Sponsors](#sponsors)
 
 
@@ -2015,3 +2017,7 @@ go install github.com/TwiN/gatus/v5@latest
 
 ### High level design overview
 ![Gatus diagram](.github/assets/gatus-diagram.jpg)
+
+## Troubleshooting
+### How to solve `Request Header Fields Too Large` error?
+If your headers exceed default 4096 buffer size limit (large `Cookie` header as an example) you can tweak that with `GATUS_API_READ_BUFFER_SIZE` environment variable

--- a/api/api.go
+++ b/api/api.go
@@ -40,13 +40,11 @@ func getReadBufferSize() int {
 	if !exists {
 		return 4096 // Default value
 	}
-
 	bufferSize, err := strconv.Atoi(bufferSizeStr)
 	if err != nil {
 		log.Printf("Error converting GATUS_API_READ_BUFFER_SIZE to integer: %s", err.Error())
 		return 4096 // Default value in case of conversion error
 	}
-
 	return bufferSize
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
This PR adds option to setup custom parameter `GATUS_API_READ_BUFFER_SIZE`. This param tweaks fiber `ReadBufferSize` that control max header size (read more here https://github.com/gofiber/fiber/blob/master/docs/api/fiber.md#config).

The problem occurred in my company cause we use gatus on the same domain as app and this causes sending large cookies.

Issue: https://github.com/TwiN/gatus/issues/636



## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable.
