### PR TITLE
feat(client): Add client network configuration for ICMP endpoint clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,17 +426,6 @@ endpoints:
     conditions:
       - "[STATUS] == 200"
 ```
-
-This example shows how you can use the `client.network` configuration to enforce IPv6 for ICMP endpoints:
-```yaml
-endpoints:
-  - name: ping-example
-    url: "icmp://example.com"
-    client:
-      network: "ip6"
-    conditions:
-      - "[CONNECTED] == true"
-```
 > 📝 Note that Gatus will use the [gcloud default credentials](https://cloud.google.com/docs/authentication/application-default-credentials) within its environment to generate the token.
 
 ### Alerting

--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ the client used to send the request.
 | `client.oauth2.scopes[]`               | A list of `scopes` which should be used for the `Client credentials flow`.  | required `[""]` |
 | `client.identity-aware-proxy`          | Google Identity-Aware-Proxy client configuration.                           | `{}`            |
 | `client.identity-aware-proxy.audience` | The Identity-Aware-Proxy audience. (client-id of the IAP oauth2 credential) | required `""`   |
+| `client.network`                       | The network to use for ICMP endpoint client (`ip`, `ip4` or `ip6`).         | `"ip"`          |
 
 > 📝 Some of these parameters are ignored based on the type of endpoint. For instance, there's no certificate involved
 in ICMP requests (ping), therefore, setting `client.insecure` to `true` for an endpoint of that type will not do anything.
@@ -422,6 +423,17 @@ endpoints:
         audience: "XXXXXXXX-XXXXXXXXXXXX.apps.googleusercontent.com"
     conditions:
       - "[STATUS] == 200"
+```
+
+This example shows how you can use the `client.network` configuration to enforce IPv6 for ICMP endpoints:
+```yaml
+endpoints:
+  - name: ping-example
+    url: "icmp://example.com"
+    client:
+      network: "ip6"
+    conditions:
+      - "[CONNECTED] == true"
 ```
 > 📝 Note that Gatus will use the [gcloud default credentials](https://cloud.google.com/docs/authentication/application-default-credentials) within its environment to generate the token.
 

--- a/client/client.go
+++ b/client/client.go
@@ -235,10 +235,7 @@ func ExecuteSSHCommand(sshClient *ssh.Client, body string, config *Config) (bool
 //
 // Note that this function takes at least 100ms, even if the address is 127.0.0.1
 func Ping(address string, config *Config) (bool, time.Duration) {
-	pinger, err := ping.NewPinger(address)
-	if err != nil {
-		return false, 0
-	}
+	pinger := ping.New(address)
 	pinger.Count = 1
 	pinger.Timeout = config.Timeout
 	// Set the pinger's privileged mode to true for every GOOS except darwin
@@ -247,7 +244,8 @@ func Ping(address string, config *Config) (bool, time.Duration) {
 	// Note that for this to work on Linux, Gatus must run with sudo privileges.
 	// See https://github.com/prometheus-community/pro-bing#linux
 	pinger.SetPrivileged(runtime.GOOS != "darwin")
-	err = pinger.Run()
+	pinger.SetNetwork(config.Network)
+	err := pinger.Run()
 	if err != nil {
 		return false, 0
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -95,18 +95,6 @@ func TestPing(t *testing.T) {
 			t.Error("Round-trip time returned on failure should've been 0")
 		}
 	}
-	if success, rtt := Ping("ipv6.google.com", &Config{Timeout: 500 * time.Millisecond, Network: "ip6"}); !success {
-		t.Error("expected true, because the host is IPv6-only")
-		if rtt == 0 {
-			t.Error("Round-trip time returned on success should've higher than 0")
-		}
-	}
-	if success, rtt := Ping("ipv4.google.com", &Config{Timeout: 500 * time.Millisecond, Network: "ip4"}); !success {
-		t.Error("expected true, because the host is IPv4-only")
-		if rtt == 0 {
-			t.Error("Round-trip time returned on success should've higher than 0")
-		}
-	}
 }
 
 func TestCanPerformStartTLS(t *testing.T) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -85,6 +85,18 @@ func TestPing(t *testing.T) {
 	}
 	// Can't perform integration tests (e.g. pinging public targets by single-stacked hostname) here,
 	// because ICMP is blocked in the network of GitHub-hosted runners.
+	if success, rtt := Ping("127.0.0.1", &Config{Timeout: 500 * time.Millisecond, Network: "ip"}); !success {
+		t.Error("expected true")
+		if rtt == 0 {
+			t.Error("Round-trip time returned on failure should've been 0")
+		}
+	}
+	if success, rtt := Ping("::1", &Config{Timeout: 500 * time.Millisecond, Network: "ip"}); !success {
+		t.Error("expected true")
+		if rtt == 0 {
+			t.Error("Round-trip time returned on failure should've been 0")
+		}
+	}
 	if success, rtt := Ping("::1", &Config{Timeout: 500 * time.Millisecond, Network: "ip4"}); success {
 		t.Error("expected false, because the IP isn't an IPv4 address")
 		if rtt != 0 {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -83,6 +83,30 @@ func TestPing(t *testing.T) {
 			t.Error("Round-trip time returned on failure should've been 0")
 		}
 	}
+	if success, rtt := Ping("::1", &Config{Timeout: 500 * time.Millisecond, Network: "ip4"}); success {
+		t.Error("expected false, because the IP isn't an IPv4 address")
+		if rtt != 0 {
+			t.Error("Round-trip time returned on failure should've been 0")
+		}
+	}
+	if success, rtt := Ping("127.0.0.1", &Config{Timeout: 500 * time.Millisecond, Network: "ip6"}); success {
+		t.Error("expected false, because the IP isn't an IPv6 address")
+		if rtt != 0 {
+			t.Error("Round-trip time returned on failure should've been 0")
+		}
+	}
+	if success, rtt := Ping("ipv6.google.com", &Config{Timeout: 500 * time.Millisecond, Network: "ip6"}); !success {
+		t.Error("expected true, because the host is IPv6-only")
+		if rtt == 0 {
+			t.Error("Round-trip time returned on success should've higher than 0")
+		}
+	}
+	if success, rtt := Ping("ipv4.google.com", &Config{Timeout: 500 * time.Millisecond, Network: "ip4"}); !success {
+		t.Error("expected true, because the host is IPv4-only")
+		if rtt == 0 {
+			t.Error("Round-trip time returned on success should've higher than 0")
+		}
+	}
 }
 
 func TestCanPerformStartTLS(t *testing.T) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -83,6 +83,8 @@ func TestPing(t *testing.T) {
 			t.Error("Round-trip time returned on failure should've been 0")
 		}
 	}
+	// Can't perform integration tests (e.g. pinging public targets by single-stacked hostname) here,
+	// because ICMP is blocked in the network of GitHub-hosted runners.
 	if success, rtt := Ping("::1", &Config{Timeout: 500 * time.Millisecond, Network: "ip4"}); success {
 		t.Error("expected false, because the IP isn't an IPv4 address")
 		if rtt != 0 {

--- a/client/config.go
+++ b/client/config.go
@@ -30,6 +30,7 @@ var (
 		Insecure:       false,
 		IgnoreRedirect: false,
 		Timeout:        defaultTimeout,
+		Network:        "ip",
 	}
 )
 
@@ -64,6 +65,9 @@ type Config struct {
 	IAPConfig *IAPConfig `yaml:"identity-aware-proxy,omitempty"`
 
 	httpClient *http.Client
+
+	// Network (ip, ip4 or ip6) for the ICMP client
+	Network string `yaml:"network"`
 }
 
 // DNSResolverConfig is the parsed configuration from the DNSResolver config string.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
This PR adds support to explicitly specify the network to use for ICMP endpoint clients, e.g. IPv6.
In the future, this may be extended to also support HTTPS endpoints (requested https://github.com/TwiN/gatus/issues/185).

## Details
I decided to use `ping.NewPinger` instead of `ping.New`, because the latter automatically [resolves](https://github.com/prometheus-community/pro-bing/blob/6bee2459eb4c8ab44f90837a700ae8e1dc0e035c/ping.go#L336) the address before we can set the desired network.
I set `ip` as the default config value. This is technically not needed and could be an empty string, because [`SetNetwork`](https://github.com/prometheus-community/pro-bing/blob/6bee2459eb4c8ab44f90837a700ae8e1dc0e035c/ping.go#L374) takes care of it anyways, but I think it's a cleaner approach.

## Background
I am running Gatus on an IPv6-only machine. Sadly, `net.ResolveIPAddr` still returns a single IPv4 address, when being asked to resolve a dual-stacked host (see https://github.com/golang/go/issues/28666). Pinging the returned IPv4 address from Gatus will obviously fail on an IPv6-only host.
I confirmed this by:
- Adding `ipv6.google.com` as an ICMP endpoint: This works by default on an IPv6-only host, because this target is IPv6-only anyways
- Adding `google.com` as an ICMP endpoint: This doesn't work by default on an IPv6-only host, because this target is dual-stacked and Gatus tries to ping via IPv4. Adding `network: "ip6"` to the endpoints client config fixes this.

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable.
