### PR TITLE
Fix request header fields too large

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Have any feedback or questions? [Create a discussion](https://github.com/TwiN/ga
   - [API](#api)
   - [Installing as binary](#installing-as-binary)
   - [High level design overview](#high-level-design-overview)
+  - [How to solve `Request Header Fields Too Large` error?](#how-to-solve-request-header-fields-too-large-error)
 - [Sponsors](#sponsors)
 
 
@@ -2020,3 +2021,6 @@ go install github.com/TwiN/gatus/v5@latest
 
 ### High level design overview
 ![Gatus diagram](.github/assets/gatus-diagram.jpg)
+
+### How to solve `Request Header Fields Too Large` error?
+If your headers exceed default 4096 buffer size limit (large `Cookie` header as an example) you can tweak that with `GATUS_API_READ_BUFFER_SIZE` environment variable

--- a/api/api.go
+++ b/api/api.go
@@ -40,6 +40,7 @@ func (a *API) createRouter(cfg *config.Config) *fiber.App {
 			log.Printf("[api.ErrorHandler] %s", err.Error())
 			return fiber.DefaultErrorHandler(c, err)
 		},
+		ReadBufferSize: getReadBufferSize(),
 		Network: fiber.NetworkTCP,
 	})
 	if os.Getenv("ENVIRONMENT") == "dev" {
@@ -110,4 +111,17 @@ func (a *API) createRouter(cfg *config.Config) *fiber.App {
 	protectedAPIRouter.Get("/v1/endpoints/statuses", EndpointStatuses(cfg))
 	protectedAPIRouter.Get("/v1/endpoints/:key/statuses", EndpointStatus)
 	return app
+}
+
+func getReadBufferSize() int {
+	bufferSizeStr, exists := os.LookupEnv("GATUS_API_READ_BUFFER_SIZE")
+	if !exists {
+		return 4096 // Default value
+	}
+	bufferSize, err := strconv.Atoi(bufferSizeStr)
+	if err != nil {
+		log.Printf("Error converting GATUS_API_READ_BUFFER_SIZE to integer: %s", err.Error())
+		return 4096 // Default value in case of conversion error
+	}
+	return bufferSize
 }


### PR DESCRIPTION
I cannot edit on the previous PR so that I copy and open the new PR #637 
> ## Summary
> This PR adds option to setup custom parameter `GATUS_API_READ_BUFFER_SIZE`. This param tweaks fiber `ReadBufferSize` that control max header size (read more here https://github.com/gofiber/fiber/blob/master/docs/api/fiber.md#config).
> 
> The problem occurred in my company cause we use gatus on the same domain as app and this causes sending large cookies.
> 
> Issue: #636
> 
> ## Checklist
> * [x]  Tested and/or added tests to validate that the changes work as intended, if applicable.
> * [x]  Updated documentation in `README.md`, if applicable.

