### PR TITLE
fix(web): Allow configuration of read-buffer-size

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,57 +206,58 @@ If you want to test it locally, see [Docker](#docker).
 ## Configuration
 | Parameter                                       | Description                                                                                                                                 | Default                    |
 |:------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------|
-| `debug`                                         | Whether to enable debug logs.                                                                                                                   | `false`                    |
-| `metrics`                                       | Whether to expose metrics at /metrics.                                                                                                          | `false`                    |
-| `storage`                                       | [Storage configuration](#storage)                                                                                                               | `{}`                       |
-| `endpoints`                                     | List of endpoints to monitor.                                                                                                                   | Required `[]`              |
-| `endpoints[].enabled`                           | Whether to monitor the endpoint.                                                                                                                | `true`                     |
-| `endpoints[].name`                              | Name of the endpoint. Can be anything.                                                                                                          | Required `""`              |
-| `endpoints[].group`                             | Group name. Used to group multiple endpoints together on the dashboard. <br />See [Endpoint groups](#endpoint-groups).                          | `""`                       |
-| `endpoints[].url`                               | URL to send the request to.                                                                                                                     | Required `""`              |
-| `endpoints[].method`                            | Request method.                                                                                                                                 | `GET`                      |
-| `endpoints[].conditions`                        | Conditions used to determine the health of the endpoint. <br />See [Conditions](#conditions).                                                   | `[]`                       |
-| `endpoints[].interval`                          | Duration to wait between every status check.                                                                                                    | `60s`                      |
-| `endpoints[].graphql`                           | Whether to wrap the body in a query param (`{"query":"$body"}`).                                                                                | `false`                    |
-| `endpoints[].body`                              | Request body.                                                                                                                                   | `""`                       |
-| `endpoints[].headers`                           | Request headers.                                                                                                                                | `{}`                       |
-| `endpoints[].dns`                               | Configuration for an endpoint of type DNS. <br />See [Monitoring an endpoint using DNS queries](#monitoring-an-endpoint-using-dns-queries).     | `""`                       |
-| `endpoints[].dns.query-type`                    | Query type (e.g. MX)                                                                                                                            | `""`                       |
-| `endpoints[].dns.query-name`                    | Query name (e.g. example.com)                                                                                                                   | `""`                       |
-| `endpoints[].ssh`                               | Configuration for an endpoint of type SSH. <br />See [Monitoring an endpoint using SSH](#monitoring-an-endpoint-using-ssh). | `""`                       |
+| `debug`                                         | Whether to enable debug logs.                                                                                                               | `false`                    |
+| `metrics`                                       | Whether to expose metrics at /metrics.                                                                                                      | `false`                    |
+| `storage`                                       | [Storage configuration](#storage)                                                                                                           | `{}`                       |
+| `endpoints`                                     | List of endpoints to monitor.                                                                                                               | Required `[]`              |
+| `endpoints[].enabled`                           | Whether to monitor the endpoint.                                                                                                            | `true`                     |
+| `endpoints[].name`                              | Name of the endpoint. Can be anything.                                                                                                      | Required `""`              |
+| `endpoints[].group`                             | Group name. Used to group multiple endpoints together on the dashboard. <br />See [Endpoint groups](#endpoint-groups).                      | `""`                       |
+| `endpoints[].url`                               | URL to send the request to.                                                                                                                 | Required `""`              |
+| `endpoints[].method`                            | Request method.                                                                                                                             | `GET`                      |
+| `endpoints[].conditions`                        | Conditions used to determine the health of the endpoint. <br />See [Conditions](#conditions).                                               | `[]`                       |
+| `endpoints[].interval`                          | Duration to wait between every status check.                                                                                                | `60s`                      |
+| `endpoints[].graphql`                           | Whether to wrap the body in a query param (`{"query":"$body"}`).                                                                            | `false`                    |
+| `endpoints[].body`                              | Request body.                                                                                                                               | `""`                       |
+| `endpoints[].headers`                           | Request headers.                                                                                                                            | `{}`                       |
+| `endpoints[].dns`                               | Configuration for an endpoint of type DNS. <br />See [Monitoring an endpoint using DNS queries](#monitoring-an-endpoint-using-dns-queries). | `""`                       |
+| `endpoints[].dns.query-type`                    | Query type (e.g. MX)                                                                                                                        | `""`                       |
+| `endpoints[].dns.query-name`                    | Query name (e.g. example.com)                                                                                                               | `""`                       |
+| `endpoints[].ssh`                               | Configuration for an endpoint of type SSH. <br />See [Monitoring an endpoint using SSH](#monitoring-an-endpoint-using-ssh).                 | `""`                       |
 | `endpoints[].ssh.username`                      | SSH username (e.g. example)                                                                                                                 | Required `""`              |
 | `endpoints[].ssh.password`                      | SSH password (e.g. password)                                                                                                                | Required `""`              |
-| `endpoints[].alerts[].type`                     | Type of alert. <br />See [Alerting](#alerting) for all valid types.                                                                             | Required `""`              |
-| `endpoints[].alerts[].enabled`                  | Whether to enable the alert.                                                                                                                    | `true`                     |
-| `endpoints[].alerts[].failure-threshold`        | Number of failures in a row needed before triggering the alert.                                                                                 | `3`                        |
-| `endpoints[].alerts[].success-threshold`        | Number of successes in a row before an ongoing incident is marked as resolved.                                                                  | `2`                        |
-| `endpoints[].alerts[].send-on-resolved`         | Whether to send a notification once a triggered alert is marked as resolved.                                                                    | `false`                    |
-| `endpoints[].alerts[].description`              | Description of the alert. Will be included in the alert sent.                                                                                   | `""`                       |
-| `endpoints[].client`                            | [Client configuration](#client-configuration).                                                                                                  | `{}`                       |
-| `endpoints[].ui`                                | UI configuration at the endpoint level.                                                                                                         | `{}`                       |
-| `endpoints[].ui.hide-hostname`                  | Whether to hide the hostname in the result.                                                                                                     | `false`                    |
-| `endpoints[].ui.hide-url`                       | Whether to ensure the URL is not displayed in the results. Useful if the URL contains a token.                                                  | `false`                    |
-| `endpoints[].ui.dont-resolve-failed-conditions` | Whether to resolve failed conditions for the UI.                                                                                                | `false`                    |
-| `endpoints[].ui.badge.reponse-time`             | List of response time thresholds. Each time a threshold is reached, the badge has a different color.                                            | `[50, 200, 300, 500, 750]` |
-| `alerting`                                      | [Alerting configuration](#alerting).                                                                                                            | `{}`                       |
-| `security`                                      | [Security configuration](#security).                                                                                                            | `{}`                       |
-| `disable-monitoring-lock`                       | Whether to [disable the monitoring lock](#disable-monitoring-lock).                                                                             | `false`                    |
-| `skip-invalid-config-update`                    | Whether to ignore invalid configuration update. <br />See [Reloading configuration on the fly](#reloading-configuration-on-the-fly).            | `false`                    |
-| `web`                                           | Web configuration.                                                                                                                              | `{}`                       |
-| `web.address`                                   | Address to listen on.                                                                                                                           | `0.0.0.0`                  |
-| `web.port`                                      | Port to listen on.                                                                                                                              | `8080`                     |
-| `web.tls.certificate-file`                      | Optional public certificate file for TLS in PEM format.                                                                                         | ``                         |
-| `web.tls.private-key-file`                      | Optional private key file for TLS in PEM format.                                                                                                | ``                         |
-| `ui`                                            | UI configuration.                                                                                                                               | `{}`                       |
-| `ui.title`                                      | [Title of the document](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title).                                                       | `Health Dashboard ǀ Gatus` |
-| `ui.description`                                | Meta description for the page.                                                                                                                  | `Gatus is an advanced...`. |
-| `ui.header`                                     | Header at the top of the dashboard.                                                                                                             | `Health Status`            |
-| `ui.logo`                                       | URL to the logo to display.                                                                                                                     | `""`                       |
-| `ui.link`                                       | Link to open when the logo is clicked.                                                                                                          | `""`                       |
-| `ui.buttons`                                    | List of buttons to display below the header.                                                                                                    | `[]`                       |
-| `ui.buttons[].name`                             | Text to display on the button.                                                                                                                  | Required `""`              |
-| `ui.buttons[].link`                             | Link to open when the button is clicked.                                                                                                        | Required `""`              |
-| `maintenance`                                   | [Maintenance configuration](#maintenance).                                                                                                      | `{}`                       |
+| `endpoints[].alerts[].type`                     | Type of alert. <br />See [Alerting](#alerting) for all valid types.                                                                         | Required `""`              |
+| `endpoints[].alerts[].enabled`                  | Whether to enable the alert.                                                                                                                | `true`                     |
+| `endpoints[].alerts[].failure-threshold`        | Number of failures in a row needed before triggering the alert.                                                                             | `3`                        |
+| `endpoints[].alerts[].success-threshold`        | Number of successes in a row before an ongoing incident is marked as resolved.                                                              | `2`                        |
+| `endpoints[].alerts[].send-on-resolved`         | Whether to send a notification once a triggered alert is marked as resolved.                                                                | `false`                    |
+| `endpoints[].alerts[].description`              | Description of the alert. Will be included in the alert sent.                                                                               | `""`                       |
+| `endpoints[].client`                            | [Client configuration](#client-configuration).                                                                                              | `{}`                       |
+| `endpoints[].ui`                                | UI configuration at the endpoint level.                                                                                                     | `{}`                       |
+| `endpoints[].ui.hide-hostname`                  | Whether to hide the hostname in the result.                                                                                                 | `false`                    |
+| `endpoints[].ui.hide-url`                       | Whether to ensure the URL is not displayed in the results. Useful if the URL contains a token.                                              | `false`                    |
+| `endpoints[].ui.dont-resolve-failed-conditions` | Whether to resolve failed conditions for the UI.                                                                                            | `false`                    |
+| `endpoints[].ui.badge.reponse-time`             | List of response time thresholds. Each time a threshold is reached, the badge has a different color.                                        | `[50, 200, 300, 500, 750]` |
+| `alerting`                                      | [Alerting configuration](#alerting).                                                                                                        | `{}`                       |
+| `security`                                      | [Security configuration](#security).                                                                                                        | `{}`                       |
+| `disable-monitoring-lock`                       | Whether to [disable the monitoring lock](#disable-monitoring-lock).                                                                         | `false`                    |
+| `skip-invalid-config-update`                    | Whether to ignore invalid configuration update. <br />See [Reloading configuration on the fly](#reloading-configuration-on-the-fly).        | `false`                    |
+| `web`                                           | Web configuration.                                                                                                                          | `{}`                       |
+| `web.address`                                   | Address to listen on.                                                                                                                       | `0.0.0.0`                  |
+| `web.port`                                      | Port to listen on.                                                                                                                          | `8080`                     |
+| `web.read-buffer-size`                          | Buffer size for reading requests from a connection. Also limit for the maximum header size.                                                 | `8192`                     |
+| `web.tls.certificate-file`                      | Optional public certificate file for TLS in PEM format.                                                                                     | ``                         |
+| `web.tls.private-key-file`                      | Optional private key file for TLS in PEM format.                                                                                            | ``                         |
+| `ui`                                            | UI configuration.                                                                                                                           | `{}`                       |
+| `ui.title`                                      | [Title of the document](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title).                                                   | `Health Dashboard ǀ Gatus` |
+| `ui.description`                                | Meta description for the page.                                                                                                              | `Gatus is an advanced...`. |
+| `ui.header`                                     | Header at the top of the dashboard.                                                                                                         | `Health Status`            |
+| `ui.logo`                                       | URL to the logo to display.                                                                                                                 | `""`                       |
+| `ui.link`                                       | Link to open when the logo is clicked.                                                                                                      | `""`                       |
+| `ui.buttons`                                    | List of buttons to display below the header.                                                                                                | `[]`                       |
+| `ui.buttons[].name`                             | Text to display on the button.                                                                                                              | Required `""`              |
+| `ui.buttons[].link`                             | Link to open when the button is clicked.                                                                                                    | Required `""`              |
+| `maintenance`                                   | [Maintenance configuration](#maintenance).                                                                                                  | `{}`                       |
 
 
 ### Conditions
@@ -1907,6 +1908,17 @@ endpoints:
       - "[BODY].status == UP"
 ```
 </details>
+
+
+### How to fix 431 Request Header Fields Too Large error
+Depending on where your environment is deployed and what kind of middleware or reverse proxy sits in front of Gatus,
+you may run into this issue. This could be because the request headers are too large, e.g. big cookies.
+
+By default, `web.read-buffer-size` is set to `8192`, but increasing this value like so will increase the read buffer size:
+```yaml
+web:
+  read-buffer-size: 32768
+```
 
 
 ### Badges

--- a/api/api.go
+++ b/api/api.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/TwiN/gatus/v5/config"
+	"github.com/TwiN/gatus/v5/config/web"
 	static "github.com/TwiN/gatus/v5/web"
 	"github.com/TwiN/health"
 	fiber "github.com/gofiber/fiber/v2"
@@ -26,6 +27,10 @@ type API struct {
 
 func New(cfg *config.Config) *API {
 	api := &API{}
+	if cfg.Web == nil {
+		log.Println("[api.New] nil web config passed as parameter. This should only happen in tests. Using default web configuration")
+		cfg.Web = web.GetDefaultConfig()
+	}
 	api.router = api.createRouter(cfg)
 	return api
 }
@@ -40,7 +45,8 @@ func (a *API) createRouter(cfg *config.Config) *fiber.App {
 			log.Printf("[api.ErrorHandler] %s", err.Error())
 			return fiber.DefaultErrorHandler(c, err)
 		},
-		Network: fiber.NetworkTCP,
+		ReadBufferSize: cfg.Web.ReadBufferSize,
+		Network:        fiber.NetworkTCP,
 	})
 	if os.Getenv("ENVIRONMENT") == "dev" {
 		app.Use(cors.New(cors.Config{


### PR DESCRIPTION
## Summary
This fixes the `431 Request Header Fields Too Large` error

By default, the read-buffer-size is 8192, up from fiber's default of 4096.

Fixes #674
Fixes #636
Supersedes #637
Supersedes #663


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Updated documentation in `README.md`, if applicable.
