### PR TITLE
feat(alerting): discord provider message content config

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ alerting:
   discord:
     webhook-url: "https://discord.com/api/webhooks/**********/**********"
     title: "Example Title"
-    content: "Hey <@123456789012345678" look!"
+    content: "Hey <@123456789012345678> look!"
 
 endpoints:
   - name: website

--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ ignored.
 | `alerting.discord`                         | Configuration for alerts of type `discord`                                                 | `{}`          |
 | `alerting.discord.webhook-url`             | Discord Webhook URL                                                                        | Required `""` |
 | `alerting.discord.title`                   | Title of the notification                                                                  |  `":helmet_with_white_cross: Gatus"`         |
+| `alerting.discord.content`                 | Content of the notification, allows ping mentions                                          | `""`          |
 | `alerting.discord.default-alert`           | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert) | N/A           |
 | `alerting.discord.overrides`               | List of overrides that may be prioritized over the default configuration                   | `[]`          |
 | `alerting.discord.overrides[].group`       | Endpoint group for which the configuration will be overridden by this configuration        | `""`          |
@@ -481,6 +482,9 @@ ignored.
 alerting:
   discord:
     webhook-url: "https://discord.com/api/webhooks/**********/**********"
+    title: "Example Title"
+    content: "Hey <@123456789012345678" look!"
+
 
 endpoints:
   - name: website

--- a/README.md
+++ b/README.md
@@ -485,7 +485,6 @@ alerting:
     title: "Example Title"
     content: "Hey <@123456789012345678" look!"
 
-
 endpoints:
   - name: website
     url: "https://twin.sh/health"

--- a/alerting/provider/discord/discord.go
+++ b/alerting/provider/discord/discord.go
@@ -24,6 +24,9 @@ type AlertProvider struct {
 
 	// Title is the title of the message that will be sent
 	Title string `yaml:"title,omitempty"`
+
+        // Content is the content of the message that will be sent
+        Content string `yaml:"content,omitempty"`
 }
 
 // Override is a case under which the default integration is overridden
@@ -109,11 +112,15 @@ func (provider *AlertProvider) buildRequestBody(endpoint *core.Endpoint, alert *
 		description = ":\n> " + alertDescription
 	}
 	title := ":helmet_with_white_cross: Gatus"
+        content := "You can configure a ping mention with content"
 	if provider.Title != "" {
 		title = provider.Title
 	}
+	if provider.Content != "" {
+		content = provider.Content
+	}
 	body, _ := json.Marshal(Body{
-		Content: "",
+		Content: content,
 		Embeds: []Embed{
 			{
 				Title:       title,

--- a/alerting/provider/discord/discord.go
+++ b/alerting/provider/discord/discord.go
@@ -112,7 +112,7 @@ func (provider *AlertProvider) buildRequestBody(endpoint *core.Endpoint, alert *
 		description = ":\n> " + alertDescription
 	}
 	title := ":helmet_with_white_cross: Gatus"
-        content := "You can configure a ping mention with content"
+        content := ""
 	if provider.Title != "" {
 		title = provider.Title
 	}


### PR DESCRIPTION
## Summary
Discord provider config entry for the Content field when posting messages to the service.

Discord limitations don't allow mentions inside embeds to ping/highlight.

Using the content field allows a mention to:
- Ping the user/role with an alert
- Increase the notification counter on the server/channel
- Add a message to the notification inbox

## Checklist
- [ ] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Updated documentation in `README.md`, if applicable.
