### PR TITLE
fix: Use privileged mode for ICMP only on Windows

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -238,12 +238,8 @@ func Ping(address string, config *Config) (bool, time.Duration) {
 	pinger := ping.New(address)
 	pinger.Count = 1
 	pinger.Timeout = config.Timeout
-	// Set the pinger's privileged mode to true for every GOOS except darwin
-	// See https://github.com/TwiN/gatus/issues/132
-	//
-	// Note that for this to work on Linux, Gatus must run with sudo privileges.
-	// See https://github.com/prometheus-community/pro-bing#linux
-	pinger.SetPrivileged(runtime.GOOS != "darwin")
+	// See https://github.com/TwiN/gatus/issues/132 and https://github.com/TwiN/gatus/issues/697
+	pinger.SetPrivileged(runtime.GOOS == "windows")
 	pinger.SetNetwork(config.Network)
 	err := pinger.Run()
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->

Use privileged mode for ICMP only on Windows

Fixes #697 

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [ ] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
