### PR TITLE
fix(alerting): Set Content-Type to application/json by default for custom provider if none are defined

### DIFF
--- a/alerting/provider/custom/custom.go
+++ b/alerting/provider/custom/custom.go
@@ -75,6 +75,9 @@ func (provider *AlertProvider) buildHTTPRequest(endpoint *core.Endpoint, alert *
 	for k, v := range provider.Headers {
 		request.Header.Set(k, v)
 	}
+	if len(provider.Headers["Content-Type"]) == 0 {
+		request.Header.Set("Content-Type", "application/json")
+	}
 	return request
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
In #310, I said that by default, if you don't specify any header with the name Content-Type, the Content-Type header will default to application/json.

That statement was wrong, but after this is merged, it won't be.




## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [ ] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
