### PR TITLE
feat(alerting): custom - replace placeholders in header contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1309,7 +1309,8 @@ leveraging Gatus, you could have Gatus call that application endpoint when an en
 would then check if the endpoint that started failing was part of the recently deployed application, and if it was,
 then automatically roll it back.
 
-Furthermore, you may use the following placeholders in the body (`alerting.custom.body`) and in the url (`alerting.custom.url`):
+Furthermore, you may use the following placeholders in the body (`alerting.custom.body`),
+url (`alerting.custom.url`) and header contents (`alerting.custom.headers`):
 - `[ALERT_DESCRIPTION]` (resolved from `endpoints[].alerts[].description`)
 - `[ENDPOINT_NAME]` (resolved from `endpoints[].name`)
 - `[ENDPOINT_GROUP]` (resolved from `endpoints[].group`)

--- a/alerting/provider/custom/custom_test.go
+++ b/alerting/provider/custom/custom_test.go
@@ -112,27 +112,31 @@ func TestAlertProvider_Send(t *testing.T) {
 
 func TestAlertProvider_buildHTTPRequest(t *testing.T) {
 	customAlertProvider := &AlertProvider{
-		URL:  "https://example.com/[ENDPOINT_GROUP]/[ENDPOINT_NAME]?event=[ALERT_TRIGGERED_OR_RESOLVED]&description=[ALERT_DESCRIPTION]&url=[ENDPOINT_URL]",
-		Body: "[ENDPOINT_NAME],[ENDPOINT_GROUP],[ALERT_DESCRIPTION],[ENDPOINT_URL],[ALERT_TRIGGERED_OR_RESOLVED]",
+		URL:     "https://example.com/[ENDPOINT_GROUP]/[ENDPOINT_NAME]?event=[ALERT_TRIGGERED_OR_RESOLVED]&description=[ALERT_DESCRIPTION]&url=[ENDPOINT_URL]",
+		Body:    "[ENDPOINT_NAME],[ENDPOINT_GROUP],[ALERT_DESCRIPTION],[ENDPOINT_URL],[ALERT_TRIGGERED_OR_RESOLVED]",
+		Headers: map[string]string{"Test": "[ENDPOINT_NAME],[ENDPOINT_GROUP],[ALERT_DESCRIPTION],[ENDPOINT_URL],[ALERT_TRIGGERED_OR_RESOLVED]"},
 	}
 	alertDescription := "alert-description"
 	scenarios := []struct {
-		AlertProvider *AlertProvider
-		Resolved      bool
-		ExpectedURL   string
-		ExpectedBody  string
+		AlertProvider  *AlertProvider
+		Resolved       bool
+		ExpectedURL    string
+		ExpectedBody   string
+		ExpectedHeader string
 	}{
 		{
-			AlertProvider: customAlertProvider,
-			Resolved:      true,
-			ExpectedURL:   "https://example.com/endpoint-group/endpoint-name?event=RESOLVED&description=alert-description&url=https://example.com",
-			ExpectedBody:  "endpoint-name,endpoint-group,alert-description,https://example.com,RESOLVED",
+			AlertProvider:  customAlertProvider,
+			Resolved:       true,
+			ExpectedURL:    "https://example.com/endpoint-group/endpoint-name?event=RESOLVED&description=alert-description&url=https://example.com",
+			ExpectedBody:   "endpoint-name,endpoint-group,alert-description,https://example.com,RESOLVED",
+			ExpectedHeader: "endpoint-name,endpoint-group,alert-description,https://example.com,RESOLVED",
 		},
 		{
-			AlertProvider: customAlertProvider,
-			Resolved:      false,
-			ExpectedURL:   "https://example.com/endpoint-group/endpoint-name?event=TRIGGERED&description=alert-description&url=https://example.com",
-			ExpectedBody:  "endpoint-name,endpoint-group,alert-description,https://example.com,TRIGGERED",
+			AlertProvider:  customAlertProvider,
+			Resolved:       false,
+			ExpectedURL:    "https://example.com/endpoint-group/endpoint-name?event=TRIGGERED&description=alert-description&url=https://example.com",
+			ExpectedBody:   "endpoint-name,endpoint-group,alert-description,https://example.com,TRIGGERED",
+			ExpectedHeader: "endpoint-name,endpoint-group,alert-description,https://example.com,TRIGGERED",
 		},
 	}
 	for _, scenario := range scenarios {
@@ -149,6 +153,10 @@ func TestAlertProvider_buildHTTPRequest(t *testing.T) {
 			if string(body) != scenario.ExpectedBody {
 				t.Error("expected body to be", scenario.ExpectedBody, "got", string(body))
 			}
+			header := request.Header.Get("Test")
+			if header != scenario.ExpectedHeader {
+				t.Error("expected header to be", scenario.ExpectedHeader, "got", header)
+			}
 		})
 	}
 }
@@ -157,7 +165,7 @@ func TestAlertProvider_buildHTTPRequestWithCustomPlaceholder(t *testing.T) {
 	customAlertProvider := &AlertProvider{
 		URL:     "https://example.com/[ENDPOINT_GROUP]/[ENDPOINT_NAME]?event=[ALERT_TRIGGERED_OR_RESOLVED]&description=[ALERT_DESCRIPTION]",
 		Body:    "[ENDPOINT_NAME],[ENDPOINT_GROUP],[ALERT_DESCRIPTION],[ALERT_TRIGGERED_OR_RESOLVED]",
-		Headers: nil,
+		Headers: map[string]string{"Test": "[ENDPOINT_NAME],[ENDPOINT_GROUP],[ALERT_DESCRIPTION],[ALERT_TRIGGERED_OR_RESOLVED]"},
 		Placeholders: map[string]map[string]string{
 			"ALERT_TRIGGERED_OR_RESOLVED": {
 				"RESOLVED":  "fixed",
@@ -167,22 +175,25 @@ func TestAlertProvider_buildHTTPRequestWithCustomPlaceholder(t *testing.T) {
 	}
 	alertDescription := "alert-description"
 	scenarios := []struct {
-		AlertProvider *AlertProvider
-		Resolved      bool
-		ExpectedURL   string
-		ExpectedBody  string
+		AlertProvider  *AlertProvider
+		Resolved       bool
+		ExpectedURL    string
+		ExpectedBody   string
+		ExpectedHeader string
 	}{
 		{
-			AlertProvider: customAlertProvider,
-			Resolved:      true,
-			ExpectedURL:   "https://example.com/endpoint-group/endpoint-name?event=fixed&description=alert-description",
-			ExpectedBody:  "endpoint-name,endpoint-group,alert-description,fixed",
+			AlertProvider:  customAlertProvider,
+			Resolved:       true,
+			ExpectedURL:    "https://example.com/endpoint-group/endpoint-name?event=fixed&description=alert-description",
+			ExpectedBody:   "endpoint-name,endpoint-group,alert-description,fixed",
+			ExpectedHeader: "endpoint-name,endpoint-group,alert-description,fixed",
 		},
 		{
-			AlertProvider: customAlertProvider,
-			Resolved:      false,
-			ExpectedURL:   "https://example.com/endpoint-group/endpoint-name?event=boom&description=alert-description",
-			ExpectedBody:  "endpoint-name,endpoint-group,alert-description,boom",
+			AlertProvider:  customAlertProvider,
+			Resolved:       false,
+			ExpectedURL:    "https://example.com/endpoint-group/endpoint-name?event=boom&description=alert-description",
+			ExpectedBody:   "endpoint-name,endpoint-group,alert-description,boom",
+			ExpectedHeader: "endpoint-name,endpoint-group,alert-description,boom",
 		},
 	}
 	for _, scenario := range scenarios {
@@ -198,6 +209,10 @@ func TestAlertProvider_buildHTTPRequestWithCustomPlaceholder(t *testing.T) {
 			body, _ := io.ReadAll(request.Body)
 			if string(body) != scenario.ExpectedBody {
 				t.Error("expected body to be", scenario.ExpectedBody, "got", string(body))
+			}
+			header := request.Header.Get("Test")
+			if header != scenario.ExpectedHeader {
+				t.Error("expected header to be", scenario.ExpectedHeader, "got", header)
 			}
 		})
 	}
@@ -222,5 +237,48 @@ func TestAlertProvider_GetDefaultAlert(t *testing.T) {
 	}
 	if (&AlertProvider{DefaultAlert: nil}).GetDefaultAlert() != nil {
 		t.Error("expected default alert to be nil")
+	}
+}
+
+func TestAlertProvider_ReplacePlaceholder(t *testing.T) {
+	placeholder := "[TEST]"
+	content := "replaced"
+	scenarios := []struct {
+		URL            string
+		Body           string
+		Header         map[string]string
+		ExpectedURL    string
+		ExpectedBody   string
+		ExpectedHeader string
+	}{
+		{
+			URL:            "https://[TEST]/",
+			Body:           "body to be [TEST].",
+			Header:         map[string]string{"Test": "header to be [TEST]."},
+			ExpectedURL:    "https://replaced/",
+			ExpectedBody:   "body to be replaced.",
+			ExpectedHeader: "header to be replaced.",
+		},
+		{
+			URL:            "https://TEST/",
+			Body:           "body to be TEST.",
+			Header:         map[string]string{"Test": "header to be TEST."},
+			ExpectedURL:    "https://TEST/",
+			ExpectedBody:   "body to be TEST.",
+			ExpectedHeader: "header to be TEST.",
+		},
+	}
+	for _, scenario := range scenarios {
+		a := &AlertProvider{}
+		a.ReplacePlaceholder(placeholder, content, &scenario.Body, &scenario.URL, scenario.Header)
+		if scenario.Body != scenario.ExpectedBody {
+			t.Error("expected body to be", scenario.ExpectedBody, "got", scenario.Body)
+		}
+		if scenario.URL != scenario.ExpectedURL {
+			t.Error("expected URL to be", scenario.ExpectedURL, "got", scenario.URL)
+		}
+		if scenario.Header["Test"] != scenario.ExpectedHeader {
+			t.Error("expected header to be", scenario.ExpectedHeader, "got", scenario.Header["Test"])
+		}
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->

This PR allows customizing headers with placeholder contents, e.g., based on `ALERT_TRIGGERED_OR_RESOLVED`.  
Also, implemented `ReplacePlaceholder` to avoid repeating replace in body, url, and in a loop for the headers. 

Example use case customizing ntfy:

```yaml
alerting:
  custom:
    url: "https://ntfy.sh/mytopic"
    method: POST
    body: |
      Alert for [ENDPOINT_URL] with description:
      [ALERT_DESCRIPTION]
    headers:
      Firebase: "no"
      Title: "[ENDPOINT_GROUP] - [ENDPOINT_NAME]"
      Tags: "[ALERT_TRIGGERED_OR_RESOLVED]"
      Priority: 4
    placeholders:
      ALERT_TRIGGERED_OR_RESOLVED:
        TRIGGERED: "rotating_light"
        RESOLVED: "white_check_mark"
    default-alert:
      failure-threshold: 2
      success-threshold: 3
      send-on-resolved: true
```

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable.
