### PR TITLE
fix(alerting): Add missing support for default-alert on teams-workflows

### DIFF
--- a/alerting/alert/type.go
+++ b/alerting/alert/type.go
@@ -62,6 +62,9 @@ const (
 	// TypeTeams is the Type for the teams alerting provider
 	TypeTeams Type = "teams"
 
+	// TypeTeamsWorkflows is the Type for the teams-workflows alerting provider
+	TypeTeamsWorkflows Type = "teams-workflows"
+
 	// TypeTelegram is the Type for the telegram alerting provider
 	TypeTelegram Type = "telegram"
 

--- a/config/config.go
+++ b/config/config.go
@@ -413,6 +413,7 @@ func validateAlertingConfig(alertingConfig *alerting.Config, endpoints []*endpoi
 		alert.TypePushover,
 		alert.TypeSlack,
 		alert.TypeTeams,
+		alert.TypeTeamsWorkflows,
 		alert.TypeTelegram,
 		alert.TypeTwilio,
 		alert.TypeZulip,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
I noticed some weird behaviour where I wasn't getting alert resolved notifications through the new teams-workflows provider, while other alerting providers were working with the same config.

I went spelunking and while doing so, noticed teams-workflows was missing from the configuredProviders list at startup, even though it was sending alerts. This led me on the path to making the changes in the PR, which seem to have resolved the default-alerts issue.

Example config where aws-ses was working, while teams-workflow was not.

```yaml
alerting:
  teams-workflows:
    webhook-url: "xxx"
    default-alert:
      description: "healthcheck failed 3 times in a row"
      send-on-resolved: true
  aws-ses:
    region: "xxx"
    from: "xxx"
    to: "xxx"
    default-alert:
      description: "healthcheck failed 3 times in a row"
      send-on-resolved: true

app-default: &app-default
  group: "apps"
  interval: "30s"
  conditions:
    - "[STATUS] == 200"
  alerts:
    - type: aws-ses
    - type: teams-workflows

endpoints:
  - name: "teams test"
    <<: *app-default
    url: "https://microsoftzzzzzzz.com"
```

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable.
