### PR TITLE
Mqtt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Have any feedback or questions? [Create a discussion](https://github.com/TwiN/ga
   - [Monitoring a WebSocket endpoint](#monitoring-a-websocket-endpoint)
   - [Monitoring an endpoint using ICMP](#monitoring-an-endpoint-using-icmp)
   - [Monitoring an endpoint using DNS queries](#monitoring-an-endpoint-using-dns-queries)
+  - [Monitoring an endpoint using MQTT](#monitoring-an-endpoint-using-mqtt)
   - [Monitoring an endpoint using SSH](#monitoring-an-endpoint-using-ssh)
   - [Monitoring an endpoint using STARTTLS](#monitoring-an-endpoint-using-starttls)
   - [Monitoring an endpoint using TLS](#monitoring-an-endpoint-using-tls)
@@ -2035,6 +2036,28 @@ There are two placeholders that can be used in the conditions for endpoints of t
 - The placeholder `[BODY]` resolves to the output of the query. For instance, a query of type `A` would return an IPv4.
 - The placeholder `[DNS_RCODE]` resolves to the name associated to the response code returned by the query, such as
 `NOERROR`, `FORMERR`, `SERVFAIL`, `NXDOMAIN`, etc.
+
+
+### Monitoring an endpoint using MQTT
+Defining an `mqtt` configuration in an endpoint will automatically mark said endpoint as an endpoint of type MQTT:
+```yaml
+endpoints:
+  - name: example-mqtt-query
+    url: "wss://example.com/mqtt"
+    mqtt:
+      topic: "my_topic"
+      username: "username" # Optional
+      password: "password" # Optional
+    body: "gatus check - {{ utcEpoch }}"
+    conditions:
+      - "[CONNECTED] == true"
+```
+
+The body can be plain text or a text/template.  If it is a text/template, the following functions are available:
+- `utcEpoch` returns the seconds since the unix epoch
+
+The following placeholders are supported for endpoints of type MQTT:
+- `[CONNECTED]` resolves to `true` if the MQTT message was published and the same message was consumed, `false` otherwise
 
 
 ### Monitoring an endpoint using SSH

--- a/README.md
+++ b/README.md
@@ -2048,13 +2048,13 @@ endpoints:
       topic: "my_topic"
       username: "username" # Optional
       password: "password" # Optional
-    body: "gatus check - {{ utcEpoch }}"
+    body: "gatus check - {{ uuidv4 }}"
     conditions:
       - "[CONNECTED] == true"
 ```
 
 The body can be plain text or a text/template.  If it is a text/template, the following functions are available:
-- `utcEpoch` returns the seconds since the unix epoch
+- `uuidv4` returns a UUID v4 universally unique ID
 
 The following placeholders are supported for endpoints of type MQTT:
 - `[CONNECTED]` resolves to `true` if the MQTT message was published and the same message was consumed, `false` otherwise

--- a/client/client.go
+++ b/client/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/TwiN/gocache/v2"
 	"github.com/TwiN/whois"
 	"github.com/eclipse/paho.mqtt.golang"
+	"github.com/google/uuid"
 	"github.com/ishidawataru/sctp"
 	"github.com/miekg/dns"
 	ping "github.com/prometheus-community/pro-bing"
@@ -37,8 +38,8 @@ var (
 	whoisExpirationDateCache = gocache.NewCache().WithMaxSize(10000).WithDefaultTTL(24 * time.Hour)
 
 	mqttTemplateEngine = template.New("base").Funcs(template.FuncMap{
-		"utcEpoch": func() int64 {
-			return time.Now().Unix()
+		"uuidv4": func() string {
+			return uuid.New().String()
 		},
 	})
 )

--- a/config/endpoint/endpoint.go
+++ b/config/endpoint/endpoint.go
@@ -386,7 +386,7 @@ func (e *Endpoint) call(result *Result) {
 		}
 		result.Duration = time.Since(startTime)
 	} else if endpointType == TypeMQTT {
-		result.Connected, result.Body, err = client.QueryMQTT(e.URL, e.MQTTConfig.Topic, e.MQTTConfig.Username, e.MQTTConfig.Password, e.Body, e.ClientConfig)
+		result.Connected, err = client.QueryMQTT(e.URL, e.MQTTConfig.Topic, e.MQTTConfig.Username, e.MQTTConfig.Password, e.Body, e.ClientConfig)
 		if err != nil {
 			result.AddError(err.Error())
 			return

--- a/config/endpoint/endpoint_test.go
+++ b/config/endpoint/endpoint_test.go
@@ -866,7 +866,7 @@ func TestIntegrationEvaluateHealthForMQTT(t *testing.T) {
 					Username: "gatus",
 					Password: "",
 				},
-				Body: "This is a test",
+				Body: "This is a test - {{ utcEpoch }}",
 			},
 			conditions: []Condition{Condition("[CONNECTED] == true")},
 			success:    false,

--- a/config/endpoint/endpoint_test.go
+++ b/config/endpoint/endpoint_test.go
@@ -866,7 +866,7 @@ func TestIntegrationEvaluateHealthForMQTT(t *testing.T) {
 					Username: "gatus",
 					Password: "",
 				},
-				Body: "This is a test - {{ utcEpoch }}",
+				Body: "This is a test: {{ uuidv4 }}",
 			},
 			conditions: []Condition{Condition("[CONNECTED] == true")},
 			success:    false,

--- a/config/endpoint/mqtt/mqtt.go
+++ b/config/endpoint/mqtt/mqtt.go
@@ -1,0 +1,24 @@
+package mqtt
+
+import (
+	"errors"
+)
+
+var (
+	// ErrEndpointWithoutMQTTTopic is the error with which Gatus will panic if an endpoint with MQTT monitoring is configured without a topic.
+	ErrEndpointWithoutMQTTTopic = errors.New("you must specify a topic for each MQTT endpoint")
+)
+
+type Config struct {
+	Topic    string `yaml:"topic,omitempty"`
+	Username string `yaml:"username,omitempty"`
+	Password string `yaml:"password,omitempty"`
+}
+
+// Validate the SSH configuration
+func (cfg *Config) Validate() error {
+	if len(cfg.Topic) == 0 {
+		return ErrEndpointWithoutMQTTTopic
+	}
+	return nil
+}

--- a/config/endpoint/mqtt/mqtt_test.go
+++ b/config/endpoint/mqtt/mqtt_test.go
@@ -1,0 +1,23 @@
+package mqtt
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestMQTT_validate(t *testing.T) {
+	cfg := &Config{}
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected an error")
+	} else if !errors.Is(err, ErrEndpointWithoutMQTTTopic) {
+		t.Errorf("expected error to be '%v', got '%v'", ErrEndpointWithoutMQTTTopic, err)
+	}
+	cfg.Username = "username"
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("expected no error, got '%v'", err)
+	}
+	cfg.Password = "password"
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("expected no error, got '%v'", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/TwiN/whois v1.1.9
 	github.com/aws/aws-sdk-go v1.55.5
 	github.com/coreos/go-oidc/v3 v3.11.0
+	github.com/eclipse/paho.mqtt.golang v1.5.0
 	github.com/gofiber/fiber/v2 v2.52.5
 	github.com/google/go-github/v48 v48.2.0
 	github.com/google/uuid v1.6.0
@@ -50,6 +51,7 @@ require (
 	github.com/google/s2a-go v0.1.8 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.0 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/davidmz/go-pageant v1.0.2 h1:bPblRCh5jGU+Uptpz6LgMZGD5hJoOt7otgT454Wv
 github.com/davidmz/go-pageant v1.0.2/go.mod h1:P2EDDnMqIwG5Rrp05dTRITj9z2zpGcD9efWSkTNKLIE=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/eclipse/paho.mqtt.golang v1.5.0 h1:EH+bUVJNgttidWFkLLVKaQPGmkTUfQQqjOsyvMGvD6o=
+github.com/eclipse/paho.mqtt.golang v1.5.0/go.mod h1:du/2qNQVqJf/Sqs4MEL77kR8QTqANF7XU7Fk0aOTAgk=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=
@@ -68,6 +70,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.4 h1:XYIDZApgAnrN1c855gT
 github.com/googleapis/enterprise-certificate-proxy v0.3.4/go.mod h1:YKe7cfqYXjKGpGvmSg28/fFvhNzinZQm8DGnaburhGA=
 github.com/googleapis/gax-go/v2 v2.14.0 h1:f+jMrjBPl+DL9nI4IQzLUxMq7XrAqFYB7hBPqMNIe8o=
 github.com/googleapis/gax-go/v2 v2.14.0/go.mod h1:lhBCnjdLrWRaPvLWhmc8IS24m9mr07qSYnHncrgo+zk=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=


### PR DESCRIPTION
## Summary
#803 - Add support for MQTT testing

MQTT Endpoints are similar to DNS Endpoints in that they are recognized by the presence of an `mqtt` config block.  This enables the endpoint to be configured with the required topic and the optional username/password.  The check will subscribe to the topic and wait for a message to come in that contains a payload that matches the BODY.  While the check is waiting for incoming messages it will public a message containing the BODY as the payload.  If the subscription gets the message containing the body= before the timeout publish, CONNECTED will be set to true.  Otherwise, it will be false. The body can also be a text/template with support for a `uuidv4` function.  This enables the body to be specified like `gatus check - {{ uuidv4 }}` and ensures that the subscription is getting the message that was just published.

## Checklist
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Updated documentation in `README.md`, if applicable.
