### PR TITLE
Add the URL label to metrics securely

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"net/url"
 	"strconv"
 
 	"github.com/TwiN/gatus/v5/config/endpoint"
@@ -25,27 +26,27 @@ func initializePrometheusMetrics() {
 		Namespace: namespace,
 		Name:      "results_total",
 		Help:      "Number of results per endpoint",
-	}, []string{"key", "group", "name", "type", "success"})
+	}, []string{"key", "group", "name", "type", "success", "url"})
 	resultDurationSeconds = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: namespace,
 		Name:      "results_duration_seconds",
 		Help:      "Duration of the request in seconds",
-	}, []string{"key", "group", "name", "type"})
+	}, []string{"key", "group", "name", "type", "url"})
 	resultConnectedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Name:      "results_connected_total",
 		Help:      "Total number of results in which a connection was successfully established",
-	}, []string{"key", "group", "name", "type"})
+	}, []string{"key", "group", "name", "type", "url"})
 	resultCodeTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Name:      "results_code_total",
 		Help:      "Total number of results by code",
-	}, []string{"key", "group", "name", "type", "code"})
+	}, []string{"key", "group", "name", "type", "code", "url"})
 	resultCertificateExpirationSeconds = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: namespace,
 		Name:      "results_certificate_expiration_seconds",
 		Help:      "Number of seconds until the certificate expires",
-	}, []string{"key", "group", "name", "type"})
+	}, []string{"key", "group", "name", "type", "url"})
 }
 
 // PublishMetricsForEndpoint publishes metrics for the given endpoint and its result.
@@ -56,18 +57,34 @@ func PublishMetricsForEndpoint(ep *endpoint.Endpoint, result *endpoint.Result) {
 		initializedMetrics = true
 	}
 	endpointType := ep.Type()
-	resultTotal.WithLabelValues(ep.Key(), ep.Group, ep.Name, string(endpointType), strconv.FormatBool(result.Success)).Inc()
-	resultDurationSeconds.WithLabelValues(ep.Key(), ep.Group, ep.Name, string(endpointType)).Set(result.Duration.Seconds())
+
+	// Remove any query parameters from the URL to prevent any secrets from leaking in metrics
+	url, err := url.Parse(ep.URL)
+	var baseURL string
+	if err != nil {
+		baseURL = "-"
+	} else {
+		url.RawQuery = ""
+		baseURL = url.String()
+	}
+
+	resultTotal.WithLabelValues(ep.Key(), ep.Group, ep.Name, string(endpointType), strconv.FormatBool(result.Success), baseURL).Inc()
+	resultDurationSeconds.WithLabelValues(ep.Key(), ep.Group, ep.Name, string(endpointType), baseURL).Set(result.Duration.Seconds())
 	if result.Connected {
-		resultConnectedTotal.WithLabelValues(ep.Key(), ep.Group, ep.Name, string(endpointType)).Inc()
+		switch endpointType {
+		case endpoint.TypeDNS:
+			resultConnectedTotal.WithLabelValues(ep.Key(), ep.Group, ep.Name, string(endpointType), ep.DNSConfig.QueryName).Inc()
+		default:
+			resultConnectedTotal.WithLabelValues(ep.Key(), ep.Group, ep.Name, string(endpointType), baseURL).Inc()
+		}
 	}
 	if result.DNSRCode != "" {
-		resultCodeTotal.WithLabelValues(ep.Key(), ep.Group, ep.Name, string(endpointType), result.DNSRCode).Inc()
+		resultCodeTotal.WithLabelValues(ep.Key(), ep.Group, ep.Name, string(endpointType), result.DNSRCode, ep.DNSConfig.QueryName).Inc()
 	}
 	if result.HTTPStatus != 0 {
-		resultCodeTotal.WithLabelValues(ep.Key(), ep.Group, ep.Name, string(endpointType), strconv.Itoa(result.HTTPStatus)).Inc()
+		resultCodeTotal.WithLabelValues(ep.Key(), ep.Group, ep.Name, string(endpointType), strconv.Itoa(result.HTTPStatus), baseURL).Inc()
 	}
 	if result.CertificateExpiration != 0 {
-		resultCertificateExpirationSeconds.WithLabelValues(ep.Key(), ep.Group, ep.Name, string(endpointType)).Set(result.CertificateExpiration.Seconds())
+		resultCertificateExpirationSeconds.WithLabelValues(ep.Key(), ep.Group, ep.Name, string(endpointType), baseURL).Set(result.CertificateExpiration.Seconds())
 	}
 }

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -27,19 +27,19 @@ func TestPublishMetricsForEndpoint(t *testing.T) {
 	err := testutil.GatherAndCompare(prometheus.Gatherers{prometheus.DefaultGatherer}, bytes.NewBufferString(`
 # HELP gatus_results_certificate_expiration_seconds Number of seconds until the certificate expires
 # TYPE gatus_results_certificate_expiration_seconds gauge
-gatus_results_certificate_expiration_seconds{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP"} 176400
+gatus_results_certificate_expiration_seconds{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP",url="https://example.org"} 176400
 # HELP gatus_results_code_total Total number of results by code
 # TYPE gatus_results_code_total counter
-gatus_results_code_total{code="200",group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP"} 1
+gatus_results_code_total{code="200",group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP",url="https://example.org"} 1
 # HELP gatus_results_connected_total Total number of results in which a connection was successfully established
 # TYPE gatus_results_connected_total counter
-gatus_results_connected_total{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP"} 1
+gatus_results_connected_total{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP",url="https://example.org"} 1
 # HELP gatus_results_duration_seconds Duration of the request in seconds
 # TYPE gatus_results_duration_seconds gauge
-gatus_results_duration_seconds{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP"} 0.123
+gatus_results_duration_seconds{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP",url="https://example.org"} 0.123
 # HELP gatus_results_total Number of results per endpoint
 # TYPE gatus_results_total counter
-gatus_results_total{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",success="true",type="HTTP"} 1
+gatus_results_total{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",success="true",type="HTTP",url="https://example.org"} 1
 `), "gatus_results_code_total", "gatus_results_connected_total", "gatus_results_duration_seconds", "gatus_results_total", "gatus_results_certificate_expiration_seconds")
 	if err != nil {
 		t.Errorf("Expected no errors but got: %v", err)
@@ -58,20 +58,20 @@ gatus_results_total{group="http-ep-group",key="http-ep-group_http-ep-name",name=
 	err = testutil.GatherAndCompare(prometheus.Gatherers{prometheus.DefaultGatherer}, bytes.NewBufferString(`
 # HELP gatus_results_certificate_expiration_seconds Number of seconds until the certificate expires
 # TYPE gatus_results_certificate_expiration_seconds gauge
-gatus_results_certificate_expiration_seconds{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP"} 169200
+gatus_results_certificate_expiration_seconds{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP",url="https://example.org"} 169200
 # HELP gatus_results_code_total Total number of results by code
 # TYPE gatus_results_code_total counter
-gatus_results_code_total{code="200",group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP"} 2
+gatus_results_code_total{code="200",group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP",url="https://example.org"} 2
 # HELP gatus_results_connected_total Total number of results in which a connection was successfully established
 # TYPE gatus_results_connected_total counter
-gatus_results_connected_total{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP"} 2
+gatus_results_connected_total{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP",url="https://example.org"} 2
 # HELP gatus_results_duration_seconds Duration of the request in seconds
 # TYPE gatus_results_duration_seconds gauge
-gatus_results_duration_seconds{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP"} 0.125
+gatus_results_duration_seconds{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP",url="https://example.org"} 0.125
 # HELP gatus_results_total Number of results per endpoint
 # TYPE gatus_results_total counter
-gatus_results_total{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",success="false",type="HTTP"} 1
-gatus_results_total{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",success="true",type="HTTP"} 1
+gatus_results_total{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",success="false",type="HTTP",url="https://example.org"} 1
+gatus_results_total{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",success="true",type="HTTP",url="https://example.org"} 1
 `), "gatus_results_code_total", "gatus_results_connected_total", "gatus_results_duration_seconds", "gatus_results_total", "gatus_results_certificate_expiration_seconds")
 	if err != nil {
 		t.Errorf("Expected no errors but got: %v", err)
@@ -92,24 +92,129 @@ gatus_results_total{group="http-ep-group",key="http-ep-group_http-ep-name",name=
 	err = testutil.GatherAndCompare(prometheus.Gatherers{prometheus.DefaultGatherer}, bytes.NewBufferString(`
 # HELP gatus_results_certificate_expiration_seconds Number of seconds until the certificate expires
 # TYPE gatus_results_certificate_expiration_seconds gauge
-gatus_results_certificate_expiration_seconds{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP"} 169200
+gatus_results_certificate_expiration_seconds{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP",url="https://example.org"} 169200
 # HELP gatus_results_code_total Total number of results by code
 # TYPE gatus_results_code_total counter
-gatus_results_code_total{code="200",group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP"} 2
-gatus_results_code_total{code="NOERROR",group="dns-ep-group",key="dns-ep-group_dns-ep-name",name="dns-ep-name",type="DNS"} 1
+gatus_results_code_total{code="200",group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP",url="https://example.org"} 2
+gatus_results_code_total{code="NOERROR",group="dns-ep-group",key="dns-ep-group_dns-ep-name",name="dns-ep-name",type="DNS",url="example.com."} 1
 # HELP gatus_results_connected_total Total number of results in which a connection was successfully established
 # TYPE gatus_results_connected_total counter
-gatus_results_connected_total{group="dns-ep-group",key="dns-ep-group_dns-ep-name",name="dns-ep-name",type="DNS"} 1
-gatus_results_connected_total{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP"} 2
+gatus_results_connected_total{group="dns-ep-group",key="dns-ep-group_dns-ep-name",name="dns-ep-name",type="DNS",url="example.com."} 1
+gatus_results_connected_total{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP",url="https://example.org"} 2
 # HELP gatus_results_duration_seconds Duration of the request in seconds
 # TYPE gatus_results_duration_seconds gauge
-gatus_results_duration_seconds{group="dns-ep-group",key="dns-ep-group_dns-ep-name",name="dns-ep-name",type="DNS"} 0.05
-gatus_results_duration_seconds{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP"} 0.125
+gatus_results_duration_seconds{group="dns-ep-group",key="dns-ep-group_dns-ep-name",name="dns-ep-name",type="DNS",url="8.8.8.8"} 0.05
+gatus_results_duration_seconds{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP",url="https://example.org"} 0.125
 # HELP gatus_results_total Number of results per endpoint
 # TYPE gatus_results_total counter
-gatus_results_total{group="dns-ep-group",key="dns-ep-group_dns-ep-name",name="dns-ep-name",success="true",type="DNS"} 1
-gatus_results_total{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",success="false",type="HTTP"} 1
-gatus_results_total{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",success="true",type="HTTP"} 1
+gatus_results_total{group="dns-ep-group",key="dns-ep-group_dns-ep-name",name="dns-ep-name",success="true",type="DNS",url="8.8.8.8"} 1
+gatus_results_total{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",success="false",type="HTTP",url="https://example.org"} 1
+gatus_results_total{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",success="true",type="HTTP",url="https://example.org"} 1
+`), "gatus_results_code_total", "gatus_results_connected_total", "gatus_results_duration_seconds", "gatus_results_total", "gatus_results_certificate_expiration_seconds")
+	if err != nil {
+		t.Errorf("Expected no errors but got: %v", err)
+	}
+}
+
+func TestPublishMetricsForEndpointWithQueryParameters(t *testing.T) {
+	httpEndpoint := &endpoint.Endpoint{Name: "http-ep-name", Group: "http-ep-group", URL: "https://example.org/auth?token=123456789&username=test"}
+	PublishMetricsForEndpoint(httpEndpoint, &endpoint.Result{
+		HTTPStatus: 200,
+		Connected:  true,
+		Duration:   123 * time.Millisecond,
+		ConditionResults: []*endpoint.ConditionResult{
+			{Condition: "[STATUS] == 200", Success: true},
+			{Condition: "[CERTIFICATE_EXPIRATION] > 48h", Success: true},
+		},
+		Success:               true,
+		CertificateExpiration: 49 * time.Hour,
+	})
+	err := testutil.GatherAndCompare(prometheus.Gatherers{prometheus.DefaultGatherer}, bytes.NewBufferString(`
+# HELP gatus_results_certificate_expiration_seconds Number of seconds until the certificate expires
+# TYPE gatus_results_certificate_expiration_seconds gauge
+gatus_results_certificate_expiration_seconds{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP",url="https://example.org/auth"} 176400
+# HELP gatus_results_code_total Total number of results by code
+# TYPE gatus_results_code_total counter
+gatus_results_code_total{code="200",group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP",url="https://example.org/auth"} 1
+# HELP gatus_results_connected_total Total number of results in which a connection was successfully established
+# TYPE gatus_results_connected_total counter
+gatus_results_connected_total{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP",url="https://example.org/auth"} 1
+# HELP gatus_results_duration_seconds Duration of the request in seconds
+# TYPE gatus_results_duration_seconds gauge
+gatus_results_duration_seconds{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP",url="https://example.org/auth"} 0.123
+# HELP gatus_results_total Number of results per endpoint
+# TYPE gatus_results_total counter
+gatus_results_total{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",success="true",type="HTTP",url="https://example.org/auth"} 1
+`), "gatus_results_code_total", "gatus_results_connected_total", "gatus_results_duration_seconds", "gatus_results_total", "gatus_results_certificate_expiration_seconds")
+	if err != nil {
+		t.Errorf("Expected no errors but got: %v", err)
+	}
+	PublishMetricsForEndpoint(httpEndpoint, &endpoint.Result{
+		HTTPStatus: 200,
+		Connected:  true,
+		Duration:   125 * time.Millisecond,
+		ConditionResults: []*endpoint.ConditionResult{
+			{Condition: "[STATUS] == 200", Success: true},
+			{Condition: "[CERTIFICATE_EXPIRATION] > 47h", Success: false},
+		},
+		Success:               false,
+		CertificateExpiration: 47 * time.Hour,
+	})
+	err = testutil.GatherAndCompare(prometheus.Gatherers{prometheus.DefaultGatherer}, bytes.NewBufferString(`
+# HELP gatus_results_certificate_expiration_seconds Number of seconds until the certificate expires
+# TYPE gatus_results_certificate_expiration_seconds gauge
+gatus_results_certificate_expiration_seconds{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP",url="https://example.org/auth"} 169200
+# HELP gatus_results_code_total Total number of results by code
+# TYPE gatus_results_code_total counter
+gatus_results_code_total{code="200",group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP",url="https://example.org/auth"} 2
+# HELP gatus_results_connected_total Total number of results in which a connection was successfully established
+# TYPE gatus_results_connected_total counter
+gatus_results_connected_total{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP",url="https://example.org/auth"} 2
+# HELP gatus_results_duration_seconds Duration of the request in seconds
+# TYPE gatus_results_duration_seconds gauge
+gatus_results_duration_seconds{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP",url="https://example.org/auth"} 0.125
+# HELP gatus_results_total Number of results per endpoint
+# TYPE gatus_results_total counter
+gatus_results_total{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",success="false",type="HTTP",url="https://example.org/auth"} 1
+gatus_results_total{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",success="true",type="HTTP",url="https://example.org/auth"} 1
+`), "gatus_results_code_total", "gatus_results_connected_total", "gatus_results_duration_seconds", "gatus_results_total", "gatus_results_certificate_expiration_seconds")
+	if err != nil {
+		t.Errorf("Expected no errors but got: %v", err)
+	}
+	dnsEndpoint := &endpoint.Endpoint{Name: "dns-ep-name", Group: "dns-ep-group", URL: "8.8.8.8", DNSConfig: &dns.Config{
+		QueryType: "A",
+		QueryName: "example.com.",
+	}}
+	PublishMetricsForEndpoint(dnsEndpoint, &endpoint.Result{
+		DNSRCode:  "NOERROR",
+		Connected: true,
+		Duration:  50 * time.Millisecond,
+		ConditionResults: []*endpoint.ConditionResult{
+			{Condition: "[DNS_RCODE] == NOERROR", Success: true},
+		},
+		Success: true,
+	})
+	err = testutil.GatherAndCompare(prometheus.Gatherers{prometheus.DefaultGatherer}, bytes.NewBufferString(`
+# HELP gatus_results_certificate_expiration_seconds Number of seconds until the certificate expires
+# TYPE gatus_results_certificate_expiration_seconds gauge
+gatus_results_certificate_expiration_seconds{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP",url="https://example.org/auth"} 169200
+# HELP gatus_results_code_total Total number of results by code
+# TYPE gatus_results_code_total counter
+gatus_results_code_total{code="200",group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP",url="https://example.org/auth"} 2
+gatus_results_code_total{code="NOERROR",group="dns-ep-group",key="dns-ep-group_dns-ep-name",name="dns-ep-name",type="DNS",url="example.com."} 1
+# HELP gatus_results_connected_total Total number of results in which a connection was successfully established
+# TYPE gatus_results_connected_total counter
+gatus_results_connected_total{group="dns-ep-group",key="dns-ep-group_dns-ep-name",name="dns-ep-name",type="DNS",url="example.com."} 1
+gatus_results_connected_total{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP",url="https://example.org/auth"} 2
+# HELP gatus_results_duration_seconds Duration of the request in seconds
+# TYPE gatus_results_duration_seconds gauge
+gatus_results_duration_seconds{group="dns-ep-group",key="dns-ep-group_dns-ep-name",name="dns-ep-name",type="DNS",url="8.8.8.8"} 0.05
+gatus_results_duration_seconds{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP",url="https://example.org/auth"} 0.125
+# HELP gatus_results_total Number of results per endpoint
+# TYPE gatus_results_total counter
+gatus_results_total{group="dns-ep-group",key="dns-ep-group_dns-ep-name",name="dns-ep-name",success="true",type="DNS",url="8.8.8.8"} 1
+gatus_results_total{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",success="false",type="HTTP",url="https://example.org/auth"} 1
+gatus_results_total{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",success="true",type="HTTP",url="https://example.org/auth"} 1
 `), "gatus_results_code_total", "gatus_results_connected_total", "gatus_results_duration_seconds", "gatus_results_total", "gatus_results_certificate_expiration_seconds")
 	if err != nil {
 		t.Errorf("Expected no errors but got: %v", err)


### PR DESCRIPTION
Small feature addition.

Sometimes is useful to have the endpoint URL in metrics labels so we can include that as part of alert messages when these metrics are scraped via prometheus.

This is related to https://github.com/TwiN/gatus/pull/875 with the requested addition of sanitizing the URL to prevent query parameters, which may contain secrets, from leaking to metrics.

Additionaly, added a new test to validate query parameters are not being exposed.