### PR TITLE
Trigger ondemand monitoring check for an endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -124,7 +124,9 @@ func (a *API) createRouter(cfg *config.Config) *fiber.App {
 			panic(err)
 		}
 	}
+	protectedAPIRouter.Get("/v1/endpoints", GetAllEndpoints(cfg))
 	protectedAPIRouter.Get("/v1/endpoints/statuses", EndpointStatuses(cfg))
+	protectedAPIRouter.Post("/v1/endpoints/:key/ondemand", OnDemandTrigger(cfg))
 	protectedAPIRouter.Get("/v1/endpoints/:key/statuses", EndpointStatus)
 	return app
 }

--- a/api/endpoint.go
+++ b/api/endpoint.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/TwiN/gatus/v5/config"
+	"github.com/TwiN/gatus/v5/config/endpoint"
+	"github.com/TwiN/gatus/v5/watchdog"
+	"github.com/gofiber/fiber/v2"
+)
+
+func GetAllEndpoints(cfg *config.Config) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+
+		var s []endpoint.EndpointWithKey
+		for _, e := range cfg.Endpoints {
+			s = append(s, endpoint.EndpointWithKey{Endpoint: *e, Key: e.Key()})
+
+		}
+		return c.Status(200).JSON(s)
+
+	}
+}
+
+func OnDemandTrigger(cfg *config.Config) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		key := c.Params("key")
+		e := cfg.GetEndpointByKey(key)
+		if e == nil {
+			return c.Status(404).JSON(fiber.Map{"error": "endpoint not found"})
+		}
+		watchdog.OnDemandExecute(e, cfg.Alerting, cfg.Maintenance, cfg.Connectivity, cfg.DisableMonitoringLock, cfg.Metrics)
+		c.Set("Content-Type", "application/json")
+		return c.Status(200).
+			JSON(fiber.Map{"message": fmt.Sprintf("endpoint %s triggered", key)})
+
+	}
+}

--- a/config/endpoint/endpoint.go
+++ b/config/endpoint/endpoint.go
@@ -123,6 +123,12 @@ type Endpoint struct {
 	NumberOfSuccessesInARow int `yaml:"-"`
 }
 
+// EndpointWithKey is the Endpoint struct with the computed key field
+type EndpointWithKey struct {
+	Endpoint
+	Key string
+}
+
 // IsEnabled returns whether the endpoint is enabled or not
 func (e *Endpoint) IsEnabled() bool {
 	if e.Enabled == nil {

--- a/watchdog/watchdog.go
+++ b/watchdog/watchdog.go
@@ -87,6 +87,12 @@ func execute(ep *endpoint.Endpoint, alertingConfig *alerting.Config, maintenance
 	logr.Debugf("[watchdog.execute] Waiting for interval=%s before monitoring group=%s endpoint=%s (key=%s) again", ep.Interval, ep.Group, ep.Name, ep.Key())
 }
 
+// Performs an one time execution of the endpoint
+func OnDemandExecute(ep *endpoint.Endpoint, alertingConfig *alerting.Config, maintenanceConfig *maintenance.Config, connectivityConfig *connectivity.Config, disableMonitoringLock bool, enabledMetrics bool) {
+	logr.Debugf("[watchdog.OnDemandExecute] Executing group=%s; endpoint=%s; key=%s", ep.Group, ep.Name, ep.Key())
+	execute(ep, alertingConfig, maintenanceConfig, connectivityConfig, disableMonitoringLock, enabledMetrics)
+}
+
 // UpdateEndpointStatuses updates the slice of endpoint statuses
 func UpdateEndpointStatuses(ep *endpoint.Endpoint, result *endpoint.Result) {
 	if err := store.Get().Insert(ep, result); err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->

Adding a feature where in the user can trigger an adhoc monitoring check to Gatus. 



## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
