### PR TITLE
refactor: periodic operations to use `time.Ticker`

### DIFF
--- a/storage/store/store.go
+++ b/storage/store/store.go
@@ -133,12 +133,14 @@ func Initialize(cfg *storage.Config) error {
 
 // autoSave automatically calls the Save function of the provider at every interval
 func autoSave(ctx context.Context, store Store, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			logr.Info("[store.autoSave] Stopping active job")
 			return
-		case <-time.After(interval):
+		case <-ticker.C:
 			logr.Info("[store.autoSave] Saving")
 			if err := store.Save(); err != nil {
 				logr.Errorf("[store.autoSave] Save failed: %s", err.Error())

--- a/watchdog/watchdog.go
+++ b/watchdog/watchdog.go
@@ -41,12 +41,14 @@ func monitor(ep *endpoint.Endpoint, alertingConfig *alerting.Config, maintenance
 	// Run it immediately on start
 	execute(ep, alertingConfig, maintenanceConfig, connectivityConfig, disableMonitoringLock, enabledMetrics)
 	// Loop for the next executions
+	ticker := time.NewTicker(ep.Interval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			logr.Warnf("[watchdog.monitor] Canceling current execution of group=%s; endpoint=%s; key=%s", ep.Group, ep.Name, ep.Key())
 			return
-		case <-time.After(ep.Interval):
+		case <-ticker.C:
 			execute(ep, alertingConfig, maintenanceConfig, connectivityConfig, disableMonitoringLock, enabledMetrics)
 		}
 	}


### PR DESCRIPTION
- Use `time.Ticker` instead of `time.After` for periodic operations in `autoSave` function
- Use `time.Ticker` instead of `time.After` for periodic operations in `monitor` function

## Summary

This PR includes the following changes:

* Replaced `time.After(interval)` with `time.NewTicker(interval)` in both storage/store/store.go and watchdog/watchdog.go.
* This change ensures that the automatic save and monitoring operations are executed regularly and that the ticker is properly stopped when the context is done.

