### PR TITLE
fix(maintenance): timezone handling offset issue

### DIFF
--- a/config/maintenance/maintenance.go
+++ b/config/maintenance/maintenance.go
@@ -111,7 +111,6 @@ func (c *Config) IsUnderMaintenance() bool {
 		now = now.In(c.TimezoneLocation)
 	}
 	var dayWhereMaintenancePeriodWouldStart time.Time
-
 	adjustedDate := now.Day()
 	if now.Hour() < int(c.durationToStartFromMidnight.Hours()) {
 		// if time in maintenance window is later than now, treat it as yesterday
@@ -119,7 +118,6 @@ func (c *Config) IsUnderMaintenance() bool {
 	}
 	// Set to midnight prior to adding duration
 	dayWhereMaintenancePeriodWouldStart = time.Date(now.Year(), now.Month(), adjustedDate, 0, 0, 0, 0, now.Location())
-
 	hasMaintenanceEveryDay := len(c.Every) == 0
 	hasMaintenancePeriodScheduledToStartOnThatWeekday := c.hasDay(dayWhereMaintenancePeriodWouldStart.Weekday().String())
 	if !hasMaintenanceEveryDay && !hasMaintenancePeriodScheduledToStartOnThatWeekday {

--- a/config/maintenance/maintenance.go
+++ b/config/maintenance/maintenance.go
@@ -111,11 +111,15 @@ func (c *Config) IsUnderMaintenance() bool {
 		now = now.In(c.TimezoneLocation)
 	}
 	var dayWhereMaintenancePeriodWouldStart time.Time
-	if now.Hour() >= int(c.durationToStartFromMidnight.Hours()) {
-		dayWhereMaintenancePeriodWouldStart = now.Truncate(24 * time.Hour)
-	} else {
-		dayWhereMaintenancePeriodWouldStart = now.Add(-c.Duration).Truncate(24 * time.Hour)
+
+	adjustedDate := now.Day()
+	if now.Hour() < int(c.durationToStartFromMidnight.Hours()) {
+		// if time in maintenance window is later than now, treat it as yesterday
+		adjustedDate--
 	}
+	// Set to midnight prior to adding duration
+	dayWhereMaintenancePeriodWouldStart = time.Date(now.Year(), now.Month(), adjustedDate, 0, 0, 0, 0, now.Location())
+
 	hasMaintenanceEveryDay := len(c.Every) == 0
 	hasMaintenancePeriodScheduledToStartOnThatWeekday := c.hasDay(dayWhereMaintenancePeriodWouldStart.Weekday().String())
 	if !hasMaintenanceEveryDay && !hasMaintenancePeriodScheduledToStartOnThatWeekday {

--- a/config/maintenance/maintenance.go
+++ b/config/maintenance/maintenance.go
@@ -110,14 +110,13 @@ func (c *Config) IsUnderMaintenance() bool {
 	if c.TimezoneLocation != nil {
 		now = now.In(c.TimezoneLocation)
 	}
-	var dayWhereMaintenancePeriodWouldStart time.Time
 	adjustedDate := now.Day()
 	if now.Hour() < int(c.durationToStartFromMidnight.Hours()) {
 		// if time in maintenance window is later than now, treat it as yesterday
 		adjustedDate--
 	}
 	// Set to midnight prior to adding duration
-	dayWhereMaintenancePeriodWouldStart = time.Date(now.Year(), now.Month(), adjustedDate, 0, 0, 0, 0, now.Location())
+	dayWhereMaintenancePeriodWouldStart := time.Date(now.Year(), now.Month(), adjustedDate, 0, 0, 0, 0, now.Location())
 	hasMaintenanceEveryDay := len(c.Every) == 0
 	hasMaintenancePeriodScheduledToStartOnThatWeekday := c.hasDay(dayWhereMaintenancePeriodWouldStart.Weekday().String())
 	if !hasMaintenanceEveryDay && !hasMaintenancePeriodScheduledToStartOnThatWeekday {

--- a/config/maintenance/maintenance_test.go
+++ b/config/maintenance/maintenance_test.go
@@ -265,6 +265,15 @@ func TestConfig_IsUnderMaintenance(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "under-maintenance-perth-timezone-starting-now-for-2h",
+			cfg: &Config{
+				Start:    fmt.Sprintf("%02d:00", inTimezone(now, "Australia/Perth", t).Hour()),
+				Duration: 2 * time.Hour,
+				Timezone: "Australia/Perth",
+			},
+			expected: true,
+		},
+		{
 			name: "under-maintenance-utc-timezone-starting-now-for-2h",
 			cfg: &Config{
 				Start:    fmt.Sprintf("%02d:00", now.Hour()),
@@ -339,4 +348,13 @@ func normalizeHour(hour int) int {
 		return hour + 24
 	}
 	return hour
+}
+
+func inTimezone(passedTime time.Time, timezone string, t *testing.T) time.Time {
+	timezoneLocation, err := time.LoadLocation(timezone)
+
+	if err != nil {
+		t.Fatalf("timezone %s did not load", timezone)
+	}
+	return passedTime.In(timezoneLocation)
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->

Fixes an issue with the timezone handling in Maintenance blocks
https://github.com/TwiN/gatus/issues/911

The problem was with using Truncate, which always operates in UTC. Switching to constructing the date from component parts (`0, 0, 0, 0` for midnight) fixes this issue and makes the time always midnight for the timezone the maintenance window refers to.

I've added a test for this too - the previous test didn't catch the problem because it was only an hour out from UTC, and the window covered a 2 hour period. I've using UTC+8 (Australia/Perth) for a large enough gap to catch the issue. This test fails without the code changes, and passes now.


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable. (Not applicable - bugfixing existing behavior)
