### PR TITLE
fix(config): Ignore config files with double dot in it (#696)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -176,6 +176,10 @@ func LoadConfiguration(configPath string) (*Config, error) {
 			if err != nil {
 				return fmt.Errorf("error walking path %s: %w", path, err)
 			}
+			if strings.Contains(path, "..") {
+				logr.Warnf("[config.LoadConfiguration] Ignoring configuration from %s", path)
+				return nil
+			}
 			logr.Infof("[config.LoadConfiguration] Reading configuration from %s", path)
 			data, err := os.ReadFile(path)
 			if err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
Ignore config files with double dot in it, permit to mount Kubernetes ConfigMap as directory and ignore hidden files like `..date/filename.yaml`.


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [ ] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
