### PR TITLE
fix(client): Correctly parse hostname for ICMP endpoint when using IPv6

### DIFF
--- a/config/endpoint/endpoint.go
+++ b/config/endpoint/endpoint.go
@@ -264,6 +264,10 @@ func (e *Endpoint) EvaluateHealth() *Result {
 	// Parse or extract hostname from URL
 	if e.DNSConfig != nil {
 		result.Hostname = strings.TrimSuffix(e.URL, ":53")
+	} else if e.Type() == TypeICMP {
+		// To handle IPv6 addresses, we need to handle the hostname differently here. This is to avoid, for instance,
+		// "1111:2222:3333::4444" being displayed as "1111:2222:3333:" because :4444 would be interpreted as a port.
+		result.Hostname = strings.TrimPrefix(e.URL, "icmp://")
 	} else {
 		urlObject, err := url.Parse(e.URL)
 		if err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
Fixes #1042

See https://github.com/TwiN/gatus/issues/1042#issuecomment-2755892843 for explanation

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [ ] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
