### PR TITLE
fix(client): Use libcap to fix icmp not working in containers as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 # Build the go application into a binary
 FROM golang:alpine AS builder
-RUN apk --update add ca-certificates
+RUN apk --update add ca-certificates libcap-setcap
 WORKDIR /app
 COPY . ./
 RUN go mod tidy
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o gatus .
+RUN setcap CAP_NET_RAW+ep gatus
 
 # Run Tests inside docker image if you don't have a configured go environment
 #RUN apk update && apk add --virtual build-dependencies build-base gcc


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
Fixes #697

This PR modifies the Gatus binary in the container to have the CAP_NET_RAW capability.  Gatus can now perform ICMP monitoring without running as a privileged or root container.

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable.
