### PR TITLE
Feature/external endpoint data

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,13 +319,14 @@ external-endpoints:
 
 To push the status of an external endpoint, the request would have to look like this:
 ```
-POST /api/v1/endpoints/{key}/external?success={success}&error={error}
+POST /api/v1/endpoints/{key}/external?success={success}&error={error}&duration={duration}
 ```
 Where:
 - `{key}` has the pattern `<GROUP_NAME>_<ENDPOINT_NAME>` in which both variables have ` `, `/`, `_`, `,` and `.` replaced by `-`.
   - Using the example configuration above, the key would be `core_ext-ep-test`.
 - `{success}` is a boolean (`true` or `false`) value indicating whether the health check was successful or not.
 - `{error}`: a string describing the reason for a failed health check. If {success} is false, this should contain the error message; if the check is successful, it can be omitted or left empty.
+- `{duration}`: the time that the request took as a duration string. It can be omitted.
 
 You must also pass the token as a `Bearer` token in the `Authorization` header.
 

--- a/api/external_endpoint.go
+++ b/api/external_endpoint.go
@@ -46,6 +46,14 @@ func CreateExternalEndpointResult(cfg *config.Config) fiber.Handler {
 			Success:   c.QueryBool("success"),
 			Errors:    []string{},
 		}
+		if result.Success && c.Query("duration") != "" {
+			parsedDuration, err := time.ParseDuration(c.Query("duration"))
+			if err != nil {
+				logr.Errorf("[api.CreateExternalEndpointResult] Invalid duration from string=%s", c.Query("duration"))
+				return c.Status(400).SendString("invalid duration")
+			}
+			result.Duration = parsedDuration
+		}
 		if !result.Success && c.Query("error") != "" {
 			result.Errors = append(result.Errors, c.Query("error"))
 		}

--- a/api/external_endpoint_test.go
+++ b/api/external_endpoint_test.go
@@ -71,6 +71,12 @@ func TestCreateExternalEndpointResult(t *testing.T) {
 			ExpectedCode:                   400,
 		},
 		{
+			Name:                           "bad-duration-value",
+			Path:                           "/api/v1/endpoints/g_n/external?success=true&duration=invalid",
+			AuthorizationHeaderBearerToken: "Bearer token",
+			ExpectedCode:                   400,
+		},
+		{
 			Name:                           "good-token-success-true",
 			Path:                           "/api/v1/endpoints/g_n/external?success=true",
 			AuthorizationHeaderBearerToken: "Bearer token",
@@ -97,6 +103,12 @@ func TestCreateExternalEndpointResult(t *testing.T) {
 		{
 			Name:                           "good-token-success-false-with-error",
 			Path:                           "/api/v1/endpoints/g_n/external?success=false&error=failed",
+			AuthorizationHeaderBearerToken: "Bearer token",
+			ExpectedCode:                   200,
+		},
+		{
+			Name:                           "good-duration-success-true",
+			Path:                           "/api/v1/endpoints/g_n/external?success=true&duration=10s",
 			AuthorizationHeaderBearerToken: "Bearer token",
 			ExpectedCode:                   200,
 		},

--- a/api/external_endpoint_test.go
+++ b/api/external_endpoint_test.go
@@ -89,6 +89,12 @@ func TestCreateExternalEndpointResult(t *testing.T) {
 			ExpectedCode:                   200,
 		},
 		{
+			Name:                           "good-duration-success-true",
+			Path:                           "/api/v1/endpoints/g_n/external?success=true&duration=10s",
+			AuthorizationHeaderBearerToken: "Bearer token",
+			ExpectedCode:                   200,
+		},
+		{
 			Name:                           "good-token-success-false",
 			Path:                           "/api/v1/endpoints/g_n/external?success=false",
 			AuthorizationHeaderBearerToken: "Bearer token",
@@ -103,12 +109,6 @@ func TestCreateExternalEndpointResult(t *testing.T) {
 		{
 			Name:                           "good-token-success-false-with-error",
 			Path:                           "/api/v1/endpoints/g_n/external?success=false&error=failed",
-			AuthorizationHeaderBearerToken: "Bearer token",
-			ExpectedCode:                   200,
-		},
-		{
-			Name:                           "good-duration-success-true",
-			Path:                           "/api/v1/endpoints/g_n/external?success=true&duration=10s",
 			AuthorizationHeaderBearerToken: "Bearer token",
 			ExpectedCode:                   200,
 		},
@@ -130,7 +130,7 @@ func TestCreateExternalEndpointResult(t *testing.T) {
 		})
 	}
 	t.Run("verify-end-results", func(t *testing.T) {
-		endpointStatus, err := store.Get().GetEndpointStatus("g", "n", paging.NewEndpointStatusParams().WithResults(1, 10))
+		endpointStatus, err := store.Get().GetEndpointStatus("g", "n", paging.NewEndpointStatusParams().WithResults(1, 11))
 		if err != nil {
 			t.Errorf("failed to get endpoint status: %s", err.Error())
 			return
@@ -138,8 +138,8 @@ func TestCreateExternalEndpointResult(t *testing.T) {
 		if endpointStatus.Key != "g_n" {
 			t.Errorf("expected key to be g_n but got %s", endpointStatus.Key)
 		}
-		if len(endpointStatus.Results) != 5 {
-			t.Errorf("expected 3 results but got %d", len(endpointStatus.Results))
+		if len(endpointStatus.Results) != 6 {
+			t.Errorf("expected 6 results but got %d", len(endpointStatus.Results))
 		}
 		if !endpointStatus.Results[0].Success {
 			t.Errorf("expected first result to be successful")
@@ -150,16 +150,19 @@ func TestCreateExternalEndpointResult(t *testing.T) {
 		if len(endpointStatus.Results[1].Errors) > 0 {
 			t.Errorf("expected second result to have no errors")
 		}
-		if endpointStatus.Results[2].Success {
-			t.Errorf("expected third result to be unsuccessful")
+		if endpointStatus.Results[2].Duration == 0 || endpointStatus.Results[2].Duration.Seconds() != 10 {
+			t.Errorf("expected sixth result to have a duration of 10 seconds")
 		}
 		if endpointStatus.Results[3].Success {
-			t.Errorf("expected fourth result to be unsuccessful")
+			t.Errorf("expected third result to be unsuccessful")
 		}
 		if endpointStatus.Results[4].Success {
+			t.Errorf("expected fourth result to be unsuccessful")
+		}
+		if endpointStatus.Results[5].Success {
 			t.Errorf("expected fifth result to be unsuccessful")
 		}
-		if len(endpointStatus.Results[4].Errors) == 0 || endpointStatus.Results[4].Errors[0] != "failed" {
+		if len(endpointStatus.Results[5].Errors) == 0 || endpointStatus.Results[5].Errors[0] != "failed" {
 			t.Errorf("expected fifth result to have errors: failed")
 		}
 		externalEndpointFromConfig := cfg.GetExternalEndpointByKey("g_n")


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
External endpoints should be able to report and track health check duration similar to other endpoints.


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Updated documentation in `README.md`, if applicable.
