### PR TITLE
fix(alerting): Escape custom result errors

### DIFF
--- a/alerting/provider/custom/custom.go
+++ b/alerting/provider/custom/custom.go
@@ -108,8 +108,9 @@ func (provider *AlertProvider) buildHTTPRequest(cfg *Config, ep *endpoint.Endpoi
 	url = strings.ReplaceAll(url, "[ENDPOINT_GROUP]", ep.Group)
 	body = strings.ReplaceAll(body, "[ENDPOINT_URL]", ep.URL)
 	url = strings.ReplaceAll(url, "[ENDPOINT_URL]", ep.URL)
-	body = strings.ReplaceAll(body, "[RESULT_ERRORS]", strings.Join(result.Errors, ","))
-	url = strings.ReplaceAll(url, "[RESULT_ERRORS]", strings.Join(result.Errors, ","))
+	resultErrors := strings.ReplaceAll(strings.Join(result.Errors, ","), "\"", "\\\"")
+	body = strings.ReplaceAll(body, "[RESULT_ERRORS]", resultErrors)
+	url = strings.ReplaceAll(url, "[RESULT_ERRORS]", resultErrors)
 	if resolved {
 		body = strings.ReplaceAll(body, "[ALERT_TRIGGERED_OR_RESOLVED]", provider.GetAlertStatePlaceholderValue(cfg, true))
 		url = strings.ReplaceAll(url, "[ALERT_TRIGGERED_OR_RESOLVED]", provider.GetAlertStatePlaceholderValue(cfg, true))

--- a/alerting/provider/custom/custom_test.go
+++ b/alerting/provider/custom/custom_test.go
@@ -179,6 +179,13 @@ func TestAlertProviderWithResultErrors_buildHTTPRequest(t *testing.T) {
 			ExpectedBody:  "endpoint-name,endpoint-group,alert-description,https://example.com,TRIGGERED,error1,error2",
 			Errors:        []string{"error1", "error2"},
 		},
+		{
+			AlertProvider: alertProvider,
+			Resolved:      false,
+			ExpectedURL:   "https://example.com/endpoint-group/endpoint-name?event=TRIGGERED&description=alert-description&url=https://example.com&error=test \\\"error with quotes\\\"",
+			ExpectedBody:  "endpoint-name,endpoint-group,alert-description,https://example.com,TRIGGERED,test \\\"error with quotes\\\"",
+			Errors:        []string{"test \"error with quotes\""},
+		},
 	}
 	for _, scenario := range scenarios {
 		t.Run(fmt.Sprintf("resolved-%v-with-default-placeholders-and-result-errors", scenario.Resolved), func(t *testing.T) {


### PR DESCRIPTION
This is my first PR so probably might be missing some detail

## Summary
https://github.com/TwiN/gatus/issues/951
Escape `"`  in the result errors

## Checklist
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Updated documentation in `README.md`, if applicable.
