### PR TITLE
Allow configuration of config reload duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ If you want to test it locally, see [Docker](#docker).
 | `security`                   | [Security configuration](#security).                                                                                                 | `{}`                       |
 | `disable-monitoring-lock`    | Whether to [disable the monitoring lock](#disable-monitoring-lock).                                                                  | `false`                    |
 | `skip-invalid-config-update` | Whether to ignore invalid configuration update. <br />See [Reloading configuration on the fly](#reloading-configuration-on-the-fly). | `false`                    |
+| `configReloadCheckDuration`  | Duration between checking for config changes, e.g. 10s. <br />See [Reloading configuration on the fly](#reloading-configuration-on-the-fly). | `30s`                    |
 | `web`                        | Web configuration.                                                                                                                   | `{}`                       |
 | `web.address`                | Address to listen on.                                                                                                                | `0.0.0.0`                  |
 | `web.port`                   | Port to listen on.                                                                                                                   | `8080`                     |
@@ -2229,6 +2230,7 @@ the same as restarting the application.
 
 > 📝 Updates may not be detected if the config file is bound instead of the config folder. See [#151](https://github.com/TwiN/gatus/issues/151).
 
+Config checks occur every 30 seconds, and can be configured with `configReloadCheckDuration`, e.g. `10s`.
 
 ### Endpoint groups
 Endpoint groups are used for grouping multiple endpoints together on the dashboard.

--- a/config/config.go
+++ b/config/config.go
@@ -101,6 +101,9 @@ type Config struct {
 
 	configPath      string    // path to the file or directory from which config was loaded
 	lastFileModTime time.Time // last modification time
+
+	// how often to check for config changes
+	ConfigReloadCheckDuration time.Duration `yaml:"configReloadCheckDuration,omitempty"`
 }
 
 func (config *Config) GetEndpointByKey(key string) *endpoint.Endpoint {
@@ -255,6 +258,10 @@ func parseAndValidateConfigBytes(yamlBytes []byte) (config *Config, err error) {
 			logr.Warn("WARNING: Please use the GATUS_LOG_LEVEL environment variable instead")
 		}
 		// XXX: End of v6.0.0 removals
+
+		if config.ConfigReloadCheckDuration == 0 {
+			config.ConfigReloadCheckDuration = 30 * time.Second
+		}
 		validateAlertingConfig(config.Alerting, config.Endpoints, config.ExternalEndpoints)
 		if err := validateSecurityConfig(config); err != nil {
 			return nil, err

--- a/main.go
+++ b/main.go
@@ -170,7 +170,10 @@ func initializeStorage(cfg *config.Config) {
 
 func listenToConfigurationFileChanges(cfg *config.Config) {
 	for {
-		time.Sleep(30 * time.Second)
+
+		logr.Debugf("[main.listenToConfigurationFileChanges] checking for config change in %s ", cfg.ConfigReloadCheckDuration)
+		time.Sleep(cfg.ConfigReloadCheckDuration)
+
 		if cfg.HasLoadedConfigurationBeenModified() {
 			logr.Info("[main.listenToConfigurationFileChanges] Configuration file has been modified")
 			stop(cfg)


### PR DESCRIPTION
## Summary

Adds a configuration option to set the duration between checks for config changes, when reloading configuration on the fly.

Example config: `configReloadCheckDuration: 10s`



## Checklist
- [ ] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Updated documentation in `README.md`, if applicable.
