### PR TITLE
Make twilio alert provider SMS customizable

### DIFF
--- a/alerting/provider/twilio/twilio.go
+++ b/alerting/provider/twilio/twilio.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/TwiN/gatus/v5/alerting/alert"
 	"github.com/TwiN/gatus/v5/client"
@@ -27,6 +28,11 @@ type Config struct {
 	Token string `yaml:"token"`
 	From  string `yaml:"from"`
 	To    string `yaml:"to"`
+
+	// Strings used in the SMS body and subject
+	// These fields are optional and will be replaced with default values if not set
+	TextTwilioTriggered string `yaml:"text-twilio-triggered,omitempty"`
+	TextTwilioResolved  string `yaml:"text-twilio-resolved,omitempty"`
 }
 
 func (cfg *Config) Validate() error {
@@ -57,6 +63,12 @@ func (cfg *Config) Merge(override *Config) {
 	}
 	if len(override.To) > 0 {
 		cfg.To = override.To
+	}
+	if len(override.TextTwilioTriggered) > 0 {
+		cfg.TextTwilioTriggered = override.TextTwilioTriggered
+	}
+	if len(override.TextTwilioResolved) > 0 {
+		cfg.TextTwilioResolved = override.TextTwilioResolved
 	}
 }
 
@@ -102,9 +114,17 @@ func (provider *AlertProvider) Send(ep *endpoint.Endpoint, alert *alert.Alert, r
 func (provider *AlertProvider) buildRequestBody(cfg *Config, ep *endpoint.Endpoint, alert *alert.Alert, result *endpoint.Result, resolved bool) string {
 	var message string
 	if resolved {
-		message = fmt.Sprintf("RESOLVED: %s - %s", ep.DisplayName(), alert.GetDescription())
+		if len(cfg.TextTwilioResolved) > 0 {
+			message = strings.Replace(strings.Replace(cfg.TextTwilioResolved, "{endpoint}", ep.DisplayName(), 1), "{description}", alert.GetDescription(), 1)
+		} else {
+			message = fmt.Sprintf("RESOLVED: %s - %s", ep.DisplayName(), alert.GetDescription())
+		}
 	} else {
-		message = fmt.Sprintf("TRIGGERED: %s - %s", ep.DisplayName(), alert.GetDescription())
+		if len(cfg.TextTwilioTriggered) > 0 {
+			message = strings.Replace(strings.Replace(cfg.TextTwilioTriggered, "{endpoint}", ep.DisplayName(), 1), "{description}", alert.GetDescription(), 1)
+		} else {
+			message = fmt.Sprintf("TRIGGERED: %s - %s", ep.DisplayName(), alert.GetDescription())
+		}
 	}
 	return url.Values{
 		"To":   {cfg.To},


### PR DESCRIPTION
## Summary
Now, we can override Twilio SMS messages texts via provider-override settings, like this:

```
        provider-override:
          text-twilio-triggered: "Error detected on endpoint: {endpoint} - Error description: {description}"
          text-twilio-resolved: "Error resolved on the following endpoint: {endpoint}"
```
All fields are optional, and backwards compatible.

## Checklist
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.