### PR TITLE
Feature/cert chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1551,7 +1551,7 @@ then automatically roll it back.
 
 Furthermore, you may use the following placeholders in the body (`alerting.custom.body`) and in the url (`alerting.custom.url`):
 - `[ALERT_DESCRIPTION]` (resolved from `endpoints[].alerts[].description`)
-- `[ENDPOINT_NAME]` (resolved from `endpoints[].name`) 
+- `[ENDPOINT_NAME]` (resolved from `endpoints[].name`)
 - `[ENDPOINT_GROUP]` (resolved from `endpoints[].group`)
 - `[ENDPOINT_URL]` (resolved from `endpoints[].url`)
 - `[RESULT_ERRORS]` (resolved from the health evaluation of a given health check)
@@ -2553,12 +2553,30 @@ Gatus will check the expiration of all certificates in the certificate chain, in
 You can use the `[CERTIFICATE_EXPIRATION]` placeholder in your conditions to check the expiration time of the leaf certificate:
 
 ```yaml
+metrics: true  # Enable Prometheus metrics endpoint
+
 endpoints:
-  - name: check-certificate-expiration
-    url: https://example.com
-    interval: 30m
+  # Test HTTPS endpoint (will check the entire cert chain)
+  - name: google-cert-chain
+    url: https://google.com
+    interval: 1m
     conditions:
-      - "[CERTIFICATE_EXPIRATION] > 48h"  # Alert if leaf certificate expires in less than 48 hours
+      - "[CERTIFICATE_EXPIRATION] > 48h"
+      - "[CONNECTED] == true"
+
+  - name: gmail-starttls-chain
+    url: "starttls://smtp.gmail.com:587"
+    interval: 1m
+    conditions:
+      - "[CONNECTED] == true"
+      - "[CERTIFICATE_EXPIRATION] > 48h"
+
+  - name: cloudflare-tls-chain
+    url: "tls://1.1.1.1:853"
+    interval: 1m
+    conditions:
+      - "[CONNECTED] == true"
+      - "[CERTIFICATE_EXPIRATION] > 48h"
 ```
 
 The certificate chain information is also exposed via Prometheus metrics:

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -154,13 +154,13 @@ func TestCanPerformStartTLS(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			connected, _, err := CanPerformStartTLS(tt.args.address, &Config{Insecure: tt.args.insecure, Timeout: 5 * time.Second})
-			if (err != nil) != tt.wantErr {
-				t.Errorf("CanPerformStartTLS() err=%v, wantErr=%v", err, tt.wantErr)
+			info := CanPerformStartTLS(tt.args.address, &Config{Insecure: tt.args.insecure, Timeout: 5 * time.Second})
+			if (info.Error != nil) != tt.wantErr {
+				t.Errorf("CanPerformStartTLS() err=%v, wantErr=%v", info.Error, tt.wantErr)
 				return
 			}
-			if connected != tt.wantConnected {
-				t.Errorf("CanPerformStartTLS() connected=%v, wantConnected=%v", connected, tt.wantConnected)
+			if info.Connected != tt.wantConnected {
+				t.Errorf("CanPerformStartTLS() connected=%v, wantConnected=%v", info.Connected, tt.wantConnected)
 			}
 		})
 	}
@@ -223,13 +223,13 @@ func TestCanPerformTLS(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			connected, _, err := CanPerformTLS(tt.args.address, &Config{Insecure: tt.args.insecure, Timeout: 5 * time.Second})
-			if (err != nil) != tt.wantErr {
-				t.Errorf("CanPerformTLS() err=%v, wantErr=%v", err, tt.wantErr)
+			info := CanPerformTLS(tt.args.address, &Config{Insecure: tt.args.insecure, Timeout: 5 * time.Second})
+			if (info.Error != nil) != tt.wantErr {
+				t.Errorf("CanPerformTLS() err=%v, wantErr=%v", info.Error, tt.wantErr)
 				return
 			}
-			if connected != tt.wantConnected {
-				t.Errorf("CanPerformTLS() connected=%v, wantConnected=%v", connected, tt.wantConnected)
+			if info.Connected != tt.wantConnected {
+				t.Errorf("CanPerformTLS() connected=%v, wantConnected=%v", info.Connected, tt.wantConnected)
 			}
 		})
 	}

--- a/config/endpoint/result.go
+++ b/config/endpoint/result.go
@@ -4,6 +4,18 @@ import (
 	"time"
 )
 
+// CertificateInfo stores information about a certificate in the chain
+type CertificateInfo struct {
+	// Subject is the certificate subject
+	Subject string `json:"subject"`
+	// Issuer is the certificate issuer
+	Issuer string `json:"issuer"`
+	// NotAfter is when the certificate expires
+	NotAfter time.Time `json:"not_after"`
+	// ExpiresIn is the duration until the certificate expires
+	ExpiresIn time.Duration `json:"-"`
+}
+
 // Result of the evaluation of a Endpoint
 type Result struct {
 	// HTTPStatus is the HTTP response status code
@@ -49,6 +61,9 @@ type Result struct {
 	// Note that this field is not persisted in the storage.
 	// It is used for health evaluation as well as debugging purposes.
 	Body []byte `json:"-"`
+
+	// CertificateChain contains information about all certificates in the chain
+	CertificateChain []CertificateInfo `json:"certificate_chain,omitempty"`
 
 	///////////////////////////////////////////////////////////////////////
 	// Below is used only for the UI and is not persisted in the storage //

--- a/config/endpoint/result.go
+++ b/config/endpoint/result.go
@@ -6,13 +6,9 @@ import (
 
 // CertificateInfo stores information about a certificate in the chain
 type CertificateInfo struct {
-	// Subject is the certificate subject
-	Subject string `json:"subject"`
-	// Issuer is the certificate issuer
-	Issuer string `json:"issuer"`
-	// NotAfter is when the certificate expires
-	NotAfter time.Time `json:"not_after"`
-	// ExpiresIn is the duration until the certificate expires
+	Subject   string        `json:"subject"`
+	Issuer    string        `json:"issuer"`
+	NotAfter  time.Time     `json:"not_after"`
 	ExpiresIn time.Duration `json:"-"`
 }
 
@@ -61,9 +57,6 @@ type Result struct {
 	// Note that this field is not persisted in the storage.
 	// It is used for health evaluation as well as debugging purposes.
 	Body []byte `json:"-"`
-
-	// CertificateChain contains information about all certificates in the chain
-	CertificateChain []CertificateInfo `json:"certificate_chain,omitempty"`
 
 	///////////////////////////////////////////////////////////////////////
 	// Below is used only for the UI and is not persisted in the storage //


### PR DESCRIPTION
## Summary
https://github.com/TwiN/gatus/issues/1117
Enhanced certificate monitoring to check the entire certificate chain (leaf, intermediate, and root certificates) instead of just the leaf certificate.
Added new metrics `gatus_results_certificate_chain_expiration_seconds` with subject and issuer labels to track expiration times for each certificate in the chain.
Updated the endpoint evaluation logic in `evaluateSTARTTLS` and `evaluateTLS ` functions to store and expose the full certificate chain information, maintaining backward compatibility with existing [CERTIFICATE_EXPIRATION] placeholder.



## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [ ] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
