### PR TITLE
Fix Gitea issues not being closed

### DIFF
--- a/alerting/provider/gitea/gitea.go
+++ b/alerting/provider/gitea/gitea.go
@@ -140,7 +140,7 @@ func (provider *AlertProvider) Send(ep *endpoint.Endpoint, alert *alert.Alert, r
 			State:     gitea.StateOpen,
 			CreatedBy: cfg.username,
 			ListOptions: gitea.ListOptions{
-				Page: 100,
+				PageSize: 100,
 			},
 		},
 	)
@@ -153,7 +153,7 @@ func (provider *AlertProvider) Send(ep *endpoint.Endpoint, alert *alert.Alert, r
 			_, _, err = cfg.giteaClient.EditIssue(
 				cfg.repositoryOwner,
 				cfg.repositoryName,
-				issue.ID,
+				issue.Index,
 				gitea.EditIssueOption{
 					State: &stateClosed,
 				},


### PR DESCRIPTION
## Summary
Gitea issues created by Gatus were not closed when resolved, for two reasons fixed in this PR:
- do not ask for page 100, but pagesize (limit) 100
- URL/edit function must use Index, not ID.



## Checklist

-[x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
