### PR TITLE
fix: Limit the pageSize to maximum-number-of-results on first page

### DIFF
--- a/api/util.go
+++ b/api/util.go
@@ -34,11 +34,13 @@ func extractPageAndPageSizeFromRequest(c *fiber.Ctx, maximumNumberOfResults int)
 		if err != nil {
 			pageSize = DefaultPageSize
 		}
-		if pageSize > maximumNumberOfResults {
-			pageSize = maximumNumberOfResults
-		} else if pageSize < 1 {
-			pageSize = DefaultPageSize
-		}
+	}
+	if page == 1 && pageSize > maximumNumberOfResults {
+		// If the page is 1 and the page size is greater than the maximum number of results, return
+		// no more than the maximum number of results
+		pageSize = maximumNumberOfResults
+	} else if pageSize < 1 {
+		pageSize = DefaultPageSize
 	}
 	return
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
Limit the pageSize to maximum-number-of-results on first page


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [ ] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
