### PR TITLE
feat(config): add automatic reload for TLS certificates on file change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1920,6 +1920,9 @@ web:
     private-key-file: "private.key"
 ```
 
+#### Automatic Certificate Reload
+Gatus automatically monitors TLS certificate files for changes and reloads them without requiring a manual restart.
+
 
 ### Metrics
 To enable metrics, you must set `metrics` to `true`. Doing so will expose Prometheus-friendly metrics at the `/metrics`

--- a/config/config.go
+++ b/config/config.go
@@ -101,6 +101,9 @@ type Config struct {
 
 	configPath      string    // path to the file or directory from which config was loaded
 	lastFileModTime time.Time // last modification time
+
+	tlsCertModTime       time.Time // certificate file last modification time
+	tlsPrivateKeyModTime time.Time // private key file last modification time
 }
 
 func (config *Config) GetEndpointByKey(key string) *endpoint.Endpoint {
@@ -146,6 +149,52 @@ func (config *Config) HasLoadedConfigurationBeenModified() bool {
 // UpdateLastFileModTime refreshes Config.lastFileModTime
 func (config *Config) UpdateLastFileModTime() {
 	config.lastFileModTime = time.Now()
+}
+
+// HasTLSCertificatesBeenModified returns whether the TLS certificate files have been modified since they were last read
+func (config *Config) HasTLSCertificatesBeenModified() bool {
+	if config.Web == nil || config.Web.TLS == nil {
+		return false
+	}
+
+	tls := config.Web.TLS
+	if len(tls.CertificateFile) == 0 || len(tls.PrivateKeyFile) == 0 {
+		return false
+	}
+
+	if certInfo, err := os.Stat(tls.CertificateFile); err == nil {
+		if !certInfo.ModTime().IsZero() && config.tlsCertModTime.Unix() < certInfo.ModTime().Unix() {
+			return true
+		}
+	}
+
+	if keyInfo, err := os.Stat(tls.PrivateKeyFile); err == nil {
+		if !keyInfo.ModTime().IsZero() && config.tlsPrivateKeyModTime.Unix() < keyInfo.ModTime().Unix() {
+			return true
+		}
+	}
+
+	return false
+}
+
+// UpdateTLSCertificatesModTime refreshes the TLS certificate file modification times
+func (config *Config) UpdateTLSCertificatesModTime() {
+	if config.Web == nil || config.Web.TLS == nil {
+		return
+	}
+
+	tls := config.Web.TLS
+	if len(tls.CertificateFile) == 0 || len(tls.PrivateKeyFile) == 0 {
+		return
+	}
+
+	if certInfo, err := os.Stat(tls.CertificateFile); err == nil {
+		config.tlsCertModTime = certInfo.ModTime()
+	}
+
+	if keyInfo, err := os.Stat(tls.PrivateKeyFile); err == nil {
+		config.tlsPrivateKeyModTime = keyInfo.ModTime()
+	}
 }
 
 // LoadConfiguration loads the full configuration composed of the main configuration file
@@ -208,6 +257,7 @@ func LoadConfiguration(configPath string) (*Config, error) {
 	}
 	config.configPath = usedConfigPath
 	config.UpdateLastFileModTime()
+	config.UpdateTLSCertificatesModTime()
 	return config, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -171,8 +171,17 @@ func initializeStorage(cfg *config.Config) {
 func listenToConfigurationFileChanges(cfg *config.Config) {
 	for {
 		time.Sleep(30 * time.Second)
-		if cfg.HasLoadedConfigurationBeenModified() {
-			logr.Info("[main.listenToConfigurationFileChanges] Configuration file has been modified")
+		configModified := cfg.HasLoadedConfigurationBeenModified()
+		tlsModified := cfg.HasTLSCertificatesBeenModified()
+
+		if configModified || tlsModified {
+			if configModified {
+				logr.Info("[main.listenToConfigurationFileChanges] Configuration file has been modified")
+			}
+			if tlsModified {
+				logr.Info("[main.listenToConfigurationFileChanges] TLS certificate files have been modified")
+			}
+
 			stop(cfg)
 			time.Sleep(time.Second) // Wait a bit to make sure everything is done.
 			save()
@@ -183,6 +192,9 @@ func listenToConfigurationFileChanges(cfg *config.Config) {
 					logr.Error("[main.listenToConfigurationFileChanges] The configuration file was updated, but it is not valid. The old configuration will continue being used.")
 					// Update the last file modification time to avoid trying to process the same invalid configuration again
 					cfg.UpdateLastFileModTime()
+					if tlsModified {
+						cfg.UpdateTLSCertificatesModTime()
+					}
 					continue
 				} else {
 					panic(err)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
#1153

This PR adds automatic TLS certificate reload functionality to Gatus, similar to the existing configuration file auto-reload feature.

**Done:**
- Added TLS certificate\key file modification time tracking to `Config` struct
- Automatically restart server when certificate or private key are modified
- Added tests for certificate modification detection
- Updated README.md about the auto-reload feature


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable.
