### PR TITLE
refactor: sort extra metric labels alphabetically for determinism

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -105,6 +106,7 @@ type Config struct {
 // GetUniqueExtraMetricLabels returns a slice of unique metric labels from all enabled endpoints
 // in the configuration. It iterates through each endpoint, checks if it is enabled,
 // and then collects unique labels from the endpoint's labels map.
+// The returned labels are sorted alphabetically to ensure deterministic ordering.
 func (config *Config) GetUniqueExtraMetricLabels() []string {
 	labels := make([]string, 0)
 	for _, ep := range config.Endpoints {
@@ -118,6 +120,7 @@ func (config *Config) GetUniqueExtraMetricLabels() []string {
 			labels = append(labels, label)
 		}
 	}
+	sort.Strings(labels)
 	return labels
 }
 

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -91,8 +91,8 @@ func TestPublishMetricsForEndpoint_withExtraLabels(t *testing.T) {
 		Duration:   2340 * time.Millisecond,
 		Success:    true,
 	}
-	// Order of extraLabels as per GetUniqueExtraMetricLabels is ["foo", "bar"]
-	PublishMetricsForEndpoint(ep, result, []string{"foo", "bar"})
+	// Order of extraLabels as per GetUniqueExtraMetricLabels is ["bar", "foo"] (alphabetical)
+	PublishMetricsForEndpoint(ep, result, []string{"bar", "foo"})
 
 	expected := `
 # HELP gatus_results_total Number of results per endpoint


### PR DESCRIPTION
- Ensure unique extra metric labels are sorted alphabetically for deterministic ordering
- Update test to reflect the new alphabetical order of extra metric labels

<!-- Thank you for contributing! -->

## Summary

Fixed the flaky test by making `GetUniqueExtraMetricLabels()` return labels in deterministic alphabetical order. This eliminates the race condition caused by Go's non-deterministic map iteration, ensuring the test passes consistently while maintaining backward compatibility.

fix https://github.com/TwiN/gatus/pull/1191 partially

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
