### PR TITLE
docs(alerting): Fix the homeassistant event structure example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1070,13 +1070,13 @@ automation:
     action:
       - service: notify.notify
         data_template:
-          title: "Gatus Alert: {{ trigger.event.data.endpoint }}"
+          title: "Gatus Alert: {{ trigger.event.data.event_data.endpoint }}"
           message: >
-            Status: {{ trigger.event.data.status }}
-            {% if trigger.event.data.description %}
-            Description: {{ trigger.event.data.description }}
+            Status: {{ trigger.event.data.event_data.status }}
+            {% if trigger.event.data.event_data.description %}
+            Description: {{ trigger.event.data.event_data.description }}
             {% endif %}
-            {% for condition in trigger.event.data.conditions %}
+            {% for condition in trigger.event.data.event_data.conditions %}
             {{ '✅' if condition.success else '❌' }} {{ condition.condition }}
             {% endfor %}
 ```


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
To get the actual data from the event, it seems to be needed to read them from the `event_data` structure.

Tested with Home Assistant `2025.8.2`


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Updated documentation in `README.md`, if applicable.
