### PR TITLE
feat(endpoint): add "[EXTERNAL_IP]" placeholder.

### DIFF
--- a/config/endpoint/condition.go
+++ b/config/endpoint/condition.go
@@ -28,6 +28,9 @@ const (
 	// Values that could replace the placeholder: NOERROR, FORMERR, SERVFAIL, NXDOMAIN, NOTIMP, REFUSED
 	DNSRCodePlaceholder = "[DNS_RCODE]"
 
+	// ExternalIPPlaceHolder is a placeholder for dynamically-fetched external IP.
+	ExternalIPPlaceholder = "[EXTERNAL_IP]"
+
 	// ResponseTimePlaceholder is a placeholder for the request response time, in milliseconds.
 	//
 	// Values that could replace the placeholder: 1, 500, 1000, ...
@@ -174,6 +177,12 @@ func (c Condition) hasIPPlaceholder() bool {
 	return strings.Contains(string(c), IPPlaceholder)
 }
 
+// hasExternalIPPlaceholder checks whether the condition has an ExternalIPPlaceholder
+// Used for determining whether my IP lookup is necessary
+func (c Condition) hasExternalIPPlaceholder() bool {
+	return strings.Contains(string(c), ExternalIPPlaceholder)
+}
+
 // isEqual compares two strings.
 //
 // Supports the "pat" and the "any" functions.
@@ -255,6 +264,8 @@ func sanitizeAndResolve(elements []string, result *Result) ([]string, []string) 
 			element = body
 		case DNSRCodePlaceholder:
 			element = result.DNSRCode
+		case ExternalIPPlaceholder:
+			element = string(result.ExternalIP)
 		case ConnectedPlaceholder:
 			element = strconv.FormatBool(result.Connected)
 		case CertificateExpirationPlaceholder:

--- a/config/endpoint/condition_test.go
+++ b/config/endpoint/condition_test.go
@@ -24,6 +24,7 @@ func TestCondition_Validate(t *testing.T) {
 		{condition: "[CONNECTED] == true", expectedErr: nil},
 		{condition: "[RESPONSE_TIME] < 500", expectedErr: nil},
 		{condition: "[IP] == 127.0.0.1", expectedErr: nil},
+		{condition: "[IP] == [EXTERNAL_IP]", expectedErr: nil},
 		{condition: "[BODY] == 1", expectedErr: nil},
 		{condition: "[BODY].test == wat", expectedErr: nil},
 		{condition: "[BODY].test.wat == wat", expectedErr: nil},
@@ -489,6 +490,13 @@ func TestCondition_evaluate(t *testing.T) {
 			Result:          &Result{CertificateExpiration: 24 * time.Hour},
 			ExpectedSuccess: false,
 			ExpectedOutput:  "[CERTIFICATE_EXPIRATION] (86400000) > 48h (172800000)",
+		},
+		{
+			Name:            "external-ip-failure",
+			Condition:       Condition("[BODY] == [EXTERNAL_IP]"),
+			Result:          &Result{Body: []byte("1.2.3.4"), ExternalIP: []byte("5.6.7.8")},
+			ExpectedSuccess: false,
+			ExpectedOutput:  "[BODY] (1.2.3.4) == [EXTERNAL_IP] (5.6.7.8)",
 		},
 		{
 			Name:            "no-placeholders",

--- a/config/endpoint/endpoint_test.go
+++ b/config/endpoint/endpoint_test.go
@@ -865,7 +865,7 @@ func TestIntegrationEvaluateHealthForICMP(t *testing.T) {
 		t.Error("Because the connection has been established, result.Connected should've been true")
 	}
 	if !result.Success {
-		t.Error("Because all conditions passed, this should have been a success")
+		t.Error("Because all conditions passed, this should have been a success", result)
 	}
 }
 

--- a/config/endpoint/result.go
+++ b/config/endpoint/result.go
@@ -44,6 +44,11 @@ type Result struct {
 	// DomainExpiration is the duration before the domain expires
 	DomainExpiration time.Duration `json:"-"`
 
+	// Result of external IP lookup
+	//
+	// Note that this field is not persisted in the storage.
+	ExternalIP []byte `json:"-"`
+
 	// Body is the response body
 	//
 	// Note that this field is not persisted in the storage.


### PR DESCRIPTION
The external IP is fetched on demand from "ifconfig.me" and cached for an hour.

<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->

#1201
I opened this issue, and would like to have this in a non-forked version.

A user can use [EXTERNAL_IP] as follows:

1. check that a global DNS query points to itself: `[BODY] == [EXTERNAL_IP]`
2. check that its external IP remains constant: `[EXTERNAL_IP] == 1.2.3.4`

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
