### PR TITLE
fix(alerting): Adjust minimum reminder config parsing

### DIFF
--- a/alerting/provider/provider.go
+++ b/alerting/provider/provider.go
@@ -84,6 +84,9 @@ func MergeProviderDefaultAlertIntoEndpointAlert(providerDefaultAlert, endpointAl
 	if endpointAlert.SuccessThreshold == 0 {
 		endpointAlert.SuccessThreshold = providerDefaultAlert.SuccessThreshold
 	}
+	if endpointAlert.MinimumReminderInterval == 0 {
+		endpointAlert.MinimumReminderInterval = providerDefaultAlert.MinimumReminderInterval
+	}
 }
 
 var (

--- a/alerting/provider/provider_test.go
+++ b/alerting/provider/provider_test.go
@@ -24,6 +24,7 @@ func TestParseWithDefaultAlert(t *testing.T) {
 				Description:      &firstDescription,
 				FailureThreshold: 5,
 				SuccessThreshold: 10,
+				MinimumReminderInterval: 30 * time.Second,
 			},
 			EndpointAlert: &alert.Alert{
 				Type: alert.TypeDiscord,
@@ -35,6 +36,7 @@ func TestParseWithDefaultAlert(t *testing.T) {
 				Description:      &firstDescription,
 				FailureThreshold: 5,
 				SuccessThreshold: 10,
+				MinimumReminderInterval: 30 * time.Second,
 			},
 		},
 		{

--- a/alerting/provider/provider_test.go
+++ b/alerting/provider/provider_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"testing"
+	"time"
 
 	"github.com/TwiN/gatus/v5/alerting/alert"
 )
@@ -149,6 +150,9 @@ func TestParseWithDefaultAlert(t *testing.T) {
 			}
 			if scenario.EndpointAlert.SuccessThreshold != scenario.ExpectedOutputAlert.SuccessThreshold {
 				t.Errorf("expected EndpointAlert.SuccessThreshold to be %v, got %v", scenario.ExpectedOutputAlert.SuccessThreshold, scenario.EndpointAlert.SuccessThreshold)
+			}
+			if int(scenario.EndpointAlert.MinimumReminderInterval) != int(scenario.ExpectedOutputAlert.MinimumReminderInterval) {
+				t.Errorf("expected EndpointAlert.MinimumReminderInterval to be %v, got %v", scenario.ExpectedOutputAlert.MinimumReminderInterval, scenario.EndpointAlert.MinimumReminderInterval)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
Fixes #379

I had tried this and it wasn't working:

```
alerting:
  slack:
    webhook-url: xyz
    default-alert:
      description: "Health Check"
      send-on-resolved: true
      failure-threshold: 2
      success-threshold: 2
      minimum-reminder-interval: 48h
```

It does work if you put it with each endpoint specifically though

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
