### PR TITLE
feat: Add metrics for domain expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2516,6 +2516,7 @@ endpoint on the same port your application is configured to run on (`web.port`).
 | gatus_results_connected_total                | counter | Total number of results in which a connection was successfully established | key, group, name, type          | All                     |
 | gatus_results_duration_seconds               | gauge   | Duration of the request in seconds                                         | key, group, name, type          | All                     |
 | gatus_results_certificate_expiration_seconds | gauge   | Number of seconds until the certificate expires                            | key, group, name, type          | HTTP, STARTTLS          |
+| gatus_results_domain_expiration_seconds      | gauge   | Number of seconds until the domains expires                                | key, group, name, type          | HTTP, STARTTLS          |
 | gatus_results_endpoint_success               | gauge   | Displays whether or not the endpoint was a success (0 failure, 1 success)  | key, group, name, type          | All                     |
 
 See [examples/docker-compose-grafana-prometheus](.examples/docker-compose-grafana-prometheus) for further documentation as well as an example.

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -47,6 +47,9 @@ func TestInitializePrometheusMetrics(t *testing.T) {
 	if resultCertificateExpirationSeconds == nil {
 		t.Error("resultCertificateExpirationSeconds metric not initialized")
 	}
+	if resultDomainExpirationSeconds == nil {
+		t.Error("resultDomainExpirationSeconds metric not initialized")
+	}
 	if resultEndpointSuccess == nil {
 		t.Error("resultEndpointSuccess metric not initialized")
 	}
@@ -119,9 +122,11 @@ func TestPublishMetricsForEndpoint(t *testing.T) {
 		ConditionResults: []*endpoint.ConditionResult{
 			{Condition: "[STATUS] == 200", Success: true},
 			{Condition: "[CERTIFICATE_EXPIRATION] > 48h", Success: true},
+			{Condition: "[DOMAIN_EXPIRATION] > 24h", Success: true},
 		},
 		Success:               true,
 		CertificateExpiration: 49 * time.Hour,
+		DomainExpiration:      25 * time.Hour,
 	}, []string{})
 	err := testutil.GatherAndCompare(reg, bytes.NewBufferString(`
 # HELP gatus_results_code_total Total number of results by code
@@ -139,6 +144,9 @@ gatus_results_total{group="http-ep-group",key="http-ep-group_http-ep-name",name=
 # HELP gatus_results_certificate_expiration_seconds Number of seconds until the certificate expires
 # TYPE gatus_results_certificate_expiration_seconds gauge
 gatus_results_certificate_expiration_seconds{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP"} 176400
+# HELP gatus_results_domain_expiration_seconds Number of seconds until the domain expires
+# TYPE gatus_results_domain_expiration_seconds gauge
+gatus_results_domain_expiration_seconds{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP"} 90000
 # HELP gatus_results_endpoint_success Displays whether or not the endpoint was a success
 # TYPE gatus_results_endpoint_success gauge
 gatus_results_endpoint_success{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP"} 1
@@ -153,9 +161,11 @@ gatus_results_endpoint_success{group="http-ep-group",key="http-ep-group_http-ep-
 		ConditionResults: []*endpoint.ConditionResult{
 			{Condition: "[STATUS] == 200", Success: true},
 			{Condition: "[CERTIFICATE_EXPIRATION] > 47h", Success: false},
+			{Condition: "[DOMAIN_EXPIRATION] > 24h", Success: true},
 		},
 		Success:               false,
 		CertificateExpiration: 47 * time.Hour,
+		DomainExpiration:      24 * time.Hour,
 	}, []string{})
 	err = testutil.GatherAndCompare(reg, bytes.NewBufferString(`
 # HELP gatus_results_code_total Total number of results by code
@@ -174,6 +184,9 @@ gatus_results_total{group="http-ep-group",key="http-ep-group_http-ep-name",name=
 # HELP gatus_results_certificate_expiration_seconds Number of seconds until the certificate expires
 # TYPE gatus_results_certificate_expiration_seconds gauge
 gatus_results_certificate_expiration_seconds{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP"} 169200
+# HELP gatus_results_domain_expiration_seconds Number of seconds until the domain expires
+# TYPE gatus_results_domain_expiration_seconds gauge
+gatus_results_domain_expiration_seconds{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP"} 86400
 # HELP gatus_results_endpoint_success Displays whether or not the endpoint was a success
 # TYPE gatus_results_endpoint_success gauge
 gatus_results_endpoint_success{group="http-ep-group",key="http-ep-group_http-ep-name",name="http-ep-name",type="HTTP"} 0


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
This PR exposes new Prometheus metric **results_domain_expiration_seconds** , similar to **results_certificate_expiration_seconds**. 

It can be used in prometheus and later on in Grafana dashboard to display the _Domain Expiration_ for different endpoints.

<img width="1183" height="478" alt="image" src="https://github.com/user-attachments/assets/433a537b-b8d0-4cc8-905f-a30d05b894ec" />




## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable.
