### PR TITLE
feat(api-tokens): add optional api-tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Have any feedback or questions? [Create a discussion](https://github.com/TwiN/ga
   - [Security](#security)
     - [Basic Authentication](#basic-authentication)
     - [OIDC](#oidc)
+    - [API Tokens](#api-tokens)
   - [TLS Encryption](#tls-encryption)
   - [Metrics](#metrics)
     - [Custom Labels](#custom-labels)
@@ -2601,6 +2602,7 @@ endpoints:
 | `security`       | Security configuration       | `{}`    |
 | `security.basic` | HTTP Basic configuration     | `{}`    |
 | `security.oidc`  | OpenID Connect configuration | `{}`    |
+| `security.api`   | API token configuration      | `{}`    |
 
 
 #### Basic Authentication
@@ -2649,6 +2651,53 @@ security:
 ```
 
 Confused? Read [Securing Gatus with OIDC using Auth0](https://twin.sh/articles/56/securing-gatus-with-oidc-using-auth0).
+
+
+#### API Tokens
+| Parameter              | Description                                                               | Default                 |
+|:-----------------------|:--------------------------------------------------------------------------|:------------------------|
+| `security.api`         | API token configuration                                                   | `{}`                    |
+| `security.api.tokens`  | List of valid API tokens for Bearer authentication. Supports environment variables. | `[]`          |
+
+API tokens provide a simple authentication method using Bearer tokens. Tokens can be plain text strings or environment variables.
+
+The example below configures two API tokens:
+```yaml
+security:
+  api:
+    tokens:
+      - "my-secret-token-123"
+      - "${API_TOKEN_FROM_ENV}"
+```
+
+To authenticate, include the token in the `Authorization` header:
+```bash
+curl -H "Authorization: Bearer my-secret-token-123" https://status.example.com/api/v1/endpoints/statuses
+```
+
+**Key characteristics:**
+- API tokens work as an **alternative** to Basic or OIDC authentication (any valid method succeeds)
+- Tokens are stored only in the YAML configuration file (never persisted to database)
+- Full support for environment variable substitution using `${VAR_NAME}` syntax
+- Uses standard `Authorization: Bearer <token>` header (case-sensitive, "Bearer" prefix required)
+- All tokens have full access (no per-token permissions)
+
+**Combining authentication methods:**
+
+You can configure API tokens alongside Basic or OIDC authentication. Requests will be authenticated if **any** valid method is provided:
+
+```yaml
+security:
+  api:
+    tokens:
+      - "my-api-token"
+  basic:
+    username: "admin"
+    password-bcrypt-base64: "JDJhJDEwJHRiMnRFakxWazZLdXBzRERQazB1TE8vckRLY05Yb1hSdnoxWU0yQ1FaYXZRSW1McmladDYu"
+```
+
+With this configuration, users can authenticate using either:
+- A valid API token: `Authorization: Bearer my-api-token`
 
 
 ### TLS Encryption

--- a/README.md
+++ b/README.md
@@ -2696,8 +2696,8 @@ security:
     password-bcrypt-base64: "JDJhJDEwJHRiMnRFakxWazZLdXBzRERQazB1TE8vckRLY05Yb1hSdnoxWU0yQ1FaYXZRSW1McmladDYu"
 ```
 
-With this configuration, users can authenticate using either:
-- A valid API token: `Authorization: Bearer my-api-token`
+With this configuration, users can authenticate using a valid API token:
+`Authorization: Bearer my-api-token`
 
 
 ### TLS Encryption

--- a/security/api-tokens.go
+++ b/security/api-tokens.go
@@ -1,6 +1,9 @@
 package security
 
-import "errors"
+import (
+	"errors"
+	"slices"
+)
 
 var (
 	ErrAPITokensEmpty = errors.New("security.api.tokens must not contain empty tokens")
@@ -31,10 +34,5 @@ func (c *APIConfig) IsValid(token string) bool {
 	if c == nil || len(c.Tokens) == 0 || len(token) == 0 {
 		return false
 	}
-	for _, validToken := range c.Tokens {
-		if validToken == token {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(c.Tokens, token)
 }

--- a/security/api-tokens.go
+++ b/security/api-tokens.go
@@ -1,0 +1,40 @@
+package security
+
+import "errors"
+
+var (
+	ErrAPITokensEmpty = errors.New("security.api.tokens must not contain empty tokens")
+)
+
+// APIConfig is the configuration for API token authentication
+type APIConfig struct {
+	// Tokens is a list of valid API tokens for authentication
+	Tokens []string `yaml:"tokens"`
+}
+
+// Validate validates the APIConfig
+func (c *APIConfig) Validate() error {
+	if c == nil {
+		return nil
+	}
+	// Ensure no empty tokens are configured
+	for _, token := range c.Tokens {
+		if len(token) == 0 {
+			return ErrAPITokensEmpty
+		}
+	}
+	return nil
+}
+
+// IsValid checks if a given token is valid
+func (c *APIConfig) IsValid(token string) bool {
+	if c == nil || len(c.Tokens) == 0 || len(token) == 0 {
+		return false
+	}
+	for _, validToken := range c.Tokens {
+		if validToken == token {
+			return true
+		}
+	}
+	return false
+}

--- a/security/api-tokens_test.go
+++ b/security/api-tokens_test.go
@@ -1,0 +1,227 @@
+package security
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+func TestAPIConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *APIConfig
+		wantErr bool
+	}{
+		{
+			name:    "nil config should be valid",
+			config:  nil,
+			wantErr: false,
+		},
+		{
+			name: "valid tokens",
+			config: &APIConfig{
+				Tokens: []string{"token1", "token2"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty token list should be valid",
+			config: &APIConfig{
+				Tokens: []string{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty token string should be invalid",
+			config: &APIConfig{
+				Tokens: []string{"valid-token", ""},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("APIConfig.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && err != ErrAPITokensEmpty {
+				t.Errorf("APIConfig.Validate() error = %v, expected %v", err, ErrAPITokensEmpty)
+			}
+		})
+	}
+}
+
+func TestAPIConfig_IsValid(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *APIConfig
+		token  string
+		want   bool
+	}{
+		{
+			name:   "nil config",
+			config: nil,
+			token:  "any-token",
+			want:   false,
+		},
+		{
+			name: "empty token list",
+			config: &APIConfig{
+				Tokens: []string{},
+			},
+			token: "any-token",
+			want:  false,
+		},
+		{
+			name: "empty token string",
+			config: &APIConfig{
+				Tokens: []string{"valid-token"},
+			},
+			token: "",
+			want:  false,
+		},
+		{
+			name: "valid token matches",
+			config: &APIConfig{
+				Tokens: []string{"token1", "token2", "token3"},
+			},
+			token: "token2",
+			want:  true,
+		},
+		{
+			name: "token does not match",
+			config: &APIConfig{
+				Tokens: []string{"token1", "token2"},
+			},
+			token: "invalid-token",
+			want:  false,
+		},
+		{
+			name: "partial token match should not work",
+			config: &APIConfig{
+				Tokens: []string{"my-secret-token"},
+			},
+			token: "my-secret",
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.config.IsValid(tt.token); got != tt.want {
+				t.Errorf("APIConfig.IsValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfig_IsAuthenticated_WithAPITokens(t *testing.T) {
+	c := &Config{
+		API: &APIConfig{
+			Tokens: []string{"valid-token-123"},
+		},
+	}
+	app := fiber.New()
+
+	// Simulate /api/v1/config endpoint behavior
+	app.Get("/api/v1/config", func(ctx *fiber.Ctx) error {
+		isAuthenticated := c.IsAuthenticated(ctx)
+		response := map[string]interface{}{
+			"authenticated": isAuthenticated,
+			"oidc":          false,
+		}
+		return ctx.JSON(response)
+	})
+
+	// Test with valid API token
+	t.Run("valid api token returns authenticated true", func(t *testing.T) {
+		request := httptest.NewRequest("GET", "/api/v1/config", http.NoBody)
+		request.Header.Set("Authorization", "Bearer valid-token-123")
+		response, err := app.Test(request)
+		if err != nil {
+			t.Fatal("expected no error, got", err)
+		}
+		if response.StatusCode != 200 {
+			t.Error("expected code to be 200, but was", response.StatusCode)
+		}
+
+		var result map[string]interface{}
+		if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+			t.Fatal("failed to decode response:", err)
+		}
+
+		if result["authenticated"] != true {
+			t.Error("expected authenticated to be true with valid token, but was", result["authenticated"])
+		}
+	})
+
+	// Test with invalid API token
+	t.Run("invalid api token returns authenticated false", func(t *testing.T) {
+		request := httptest.NewRequest("GET", "/api/v1/config", http.NoBody)
+		request.Header.Set("Authorization", "Bearer invalid-token")
+		response, err := app.Test(request)
+		if err != nil {
+			t.Fatal("expected no error, got", err)
+		}
+		if response.StatusCode != 200 {
+			t.Error("expected code to be 200, but was", response.StatusCode)
+		}
+
+		var result map[string]interface{}
+		if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+			t.Fatal("failed to decode response:", err)
+		}
+
+		if result["authenticated"] != false {
+			t.Error("expected authenticated to be false with invalid token, but was", result["authenticated"])
+		}
+	})
+
+	// Test without Authorization header
+	t.Run("no authorization header returns authenticated false", func(t *testing.T) {
+		request := httptest.NewRequest("GET", "/api/v1/config", http.NoBody)
+		response, err := app.Test(request)
+		if err != nil {
+			t.Fatal("expected no error, got", err)
+		}
+		if response.StatusCode != 200 {
+			t.Error("expected code to be 200, but was", response.StatusCode)
+		}
+
+		var result map[string]interface{}
+		if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+			t.Fatal("failed to decode response:", err)
+		}
+
+		if result["authenticated"] != false {
+			t.Error("expected authenticated to be false without auth header, but was", result["authenticated"])
+		}
+	})
+
+	// Test with malformed Bearer header
+	t.Run("malformed bearer header returns authenticated false", func(t *testing.T) {
+		request := httptest.NewRequest("GET", "/api/v1/config", http.NoBody)
+		request.Header.Set("Authorization", "bearer valid-token-123")
+		response, err := app.Test(request)
+		if err != nil {
+			t.Fatal("expected no error, got", err)
+		}
+		if response.StatusCode != 200 {
+			t.Error("expected code to be 200, but was", response.StatusCode)
+		}
+
+		var result map[string]interface{}
+		if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+			t.Fatal("failed to decode response:", err)
+		}
+
+		if result["authenticated"] != false {
+			t.Error("expected authenticated to be false with lowercase bearer, but was", result["authenticated"])
+		}
+	})
+}

--- a/security/config.go
+++ b/security/config.go
@@ -58,8 +58,8 @@ func (c *Config) ApplySecurityMiddleware(router fiber.Router) error {
 		router.Use(func(ctx *fiber.Ctx) error {
 			// Check for Bearer token
 			authHeader := ctx.Get("Authorization")
-			if strings.HasPrefix(authHeader, "Bearer ") {
-				token := strings.TrimSpace(strings.TrimPrefix(authHeader, "Bearer "))
+			if after, ok := strings.CutPrefix(authHeader, "Bearer "); ok {
+				token := strings.TrimSpace(after)
 				if c.API.IsValid(token) {
 					// Valid API token - mark as authenticated and skip other auth middleware
 					ctx.Locals("api_token_authenticated", true)
@@ -137,8 +137,8 @@ func (c *Config) IsAuthenticated(ctx *fiber.Ctx) bool {
 	// Check for API token authentication first
 	if c.API != nil && len(c.API.Tokens) > 0 {
 		authHeader := ctx.Get("Authorization")
-		if strings.HasPrefix(authHeader, "Bearer ") {
-			token := strings.TrimSpace(strings.TrimPrefix(authHeader, "Bearer "))
+		if after, ok := strings.CutPrefix(authHeader, "Bearer "); ok {
+			token := strings.TrimSpace(after)
 			if c.API.IsValid(token) {
 				return true
 			}

--- a/security/config.go
+++ b/security/config.go
@@ -3,6 +3,7 @@ package security
 import (
 	"encoding/base64"
 	"net/http"
+	"strings"
 
 	g8 "github.com/TwiN/g8/v2"
 	"github.com/TwiN/logr"
@@ -22,13 +23,14 @@ const (
 type Config struct {
 	Basic *BasicConfig `yaml:"basic,omitempty"`
 	OIDC  *OIDCConfig  `yaml:"oidc,omitempty"`
+	API   *APIConfig   `yaml:"api,omitempty"`
 
 	gate *g8.Gate
 }
 
 // ValidateAndSetDefaults returns whether the security configuration is valid or not and sets default values.
 func (c *Config) ValidateAndSetDefaults() bool {
-	return (c.Basic != nil && c.Basic.isValid()) || (c.OIDC != nil && c.OIDC.ValidateAndSetDefaults())
+	return (c.Basic != nil && c.Basic.isValid()) || (c.OIDC != nil && c.OIDC.ValidateAndSetDefaults()) || (c.API != nil && c.API.Validate() == nil && len(c.API.Tokens) > 0)
 }
 
 // RegisterHandlers registers all handlers required based on the security configuration
@@ -46,7 +48,30 @@ func (c *Config) RegisterHandlers(router fiber.Router) error {
 // ApplySecurityMiddleware applies an authentication middleware to the router passed.
 // The router passed should be a sub-router in charge of handlers that require authentication.
 func (c *Config) ApplySecurityMiddleware(router fiber.Router) error {
-	if c.OIDC != nil {
+	// Use a wrapper middleware that checks for API token first, then delegates to existing auth
+	hasAPITokens := c.API != nil && len(c.API.Tokens) > 0
+	hasOIDC := c.OIDC != nil
+	hasBasic := c.Basic != nil
+
+	// If we have API tokens, add a pre-check middleware
+	if hasAPITokens {
+		router.Use(func(ctx *fiber.Ctx) error {
+			// Check for Bearer token
+			authHeader := ctx.Get("Authorization")
+			if strings.HasPrefix(authHeader, "Bearer ") {
+				token := strings.TrimSpace(strings.TrimPrefix(authHeader, "Bearer "))
+				if c.API.IsValid(token) {
+					// Valid API token - mark as authenticated and skip other auth middleware
+					ctx.Locals("api_token_authenticated", true)
+					return ctx.Next()
+				}
+			}
+			// No valid Bearer token, continue to next middleware
+			return ctx.Next()
+		})
+	}
+
+	if hasOIDC {
 		// We're going to use g8 for session handling
 		clientProvider := g8.NewClientProvider(func(token string) *g8.Client {
 			if _, exists := sessions.Get(token); exists {
@@ -64,8 +89,15 @@ func (c *Config) ApplySecurityMiddleware(router fiber.Router) error {
 		// TODO: g8: Add a way to update cookie after? would need the writer
 		authorizationService := g8.NewAuthorizationService().WithClientProvider(clientProvider)
 		c.gate = g8.New().WithAuthorizationService(authorizationService).WithCustomTokenExtractor(customTokenExtractorFunc)
-		router.Use(adaptor.HTTPMiddleware(c.gate.Protect))
-	} else if c.Basic != nil {
+
+		// Wrap the g8 middleware to skip if already authenticated via API token
+		router.Use(func(ctx *fiber.Ctx) error {
+			if ctx.Locals("api_token_authenticated") == true {
+				return ctx.Next()
+			}
+			return adaptor.HTTPMiddleware(c.gate.Protect)(ctx)
+		})
+	} else if hasBasic {
 		var decodedBcryptHash []byte
 		if len(c.Basic.PasswordBcryptHashBase64Encoded) > 0 {
 			var err error
@@ -74,20 +106,27 @@ func (c *Config) ApplySecurityMiddleware(router fiber.Router) error {
 				return err
 			}
 		}
-		router.Use(basicauth.New(basicauth.Config{
-			Authorizer: func(username, password string) bool {
-				if len(c.Basic.PasswordBcryptHashBase64Encoded) > 0 {
-					if username != c.Basic.Username || bcrypt.CompareHashAndPassword(decodedBcryptHash, []byte(password)) != nil {
-						return false
+
+		// Wrap the basicauth middleware to skip if already authenticated via API token
+		router.Use(func(ctx *fiber.Ctx) error {
+			if ctx.Locals("api_token_authenticated") == true {
+				return ctx.Next()
+			}
+			return basicauth.New(basicauth.Config{
+				Authorizer: func(username, password string) bool {
+					if len(c.Basic.PasswordBcryptHashBase64Encoded) > 0 {
+						if username != c.Basic.Username || bcrypt.CompareHashAndPassword(decodedBcryptHash, []byte(password)) != nil {
+							return false
+						}
 					}
-				}
-				return true
-			},
-			Unauthorized: func(ctx *fiber.Ctx) error {
-				ctx.Set("WWW-Authenticate", "Basic")
-				return ctx.Status(401).SendString("Unauthorized")
-			},
-		}))
+					return true
+				},
+				Unauthorized: func(ctx *fiber.Ctx) error {
+					ctx.Set("WWW-Authenticate", "Basic")
+					return ctx.Status(401).SendString("Unauthorized")
+				},
+			})(ctx)
+		})
 	}
 	return nil
 }
@@ -95,6 +134,18 @@ func (c *Config) ApplySecurityMiddleware(router fiber.Router) error {
 // IsAuthenticated checks whether the user is authenticated
 // If the Config does not warrant authentication, it will always return true.
 func (c *Config) IsAuthenticated(ctx *fiber.Ctx) bool {
+	// Check for API token authentication first
+	if c.API != nil && len(c.API.Tokens) > 0 {
+		authHeader := ctx.Get("Authorization")
+		if strings.HasPrefix(authHeader, "Bearer ") {
+			token := strings.TrimSpace(strings.TrimPrefix(authHeader, "Bearer "))
+			if c.API.IsValid(token) {
+				return true
+			}
+		}
+	}
+
+	// Check for OIDC session
 	if c.gate != nil {
 		// TODO: Update g8 to support fasthttp natively? (see g8's fasthttp branch)
 		request, err := adaptor.ConvertRequest(ctx, false)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->

Attempt 2!

This PR aims to implement optional API tokens used to access the API when basic or OIDC auth is enabled.

Example configuration:

```yaml
security:
  api:
    tokens:
      - "my-secret-token-123"
      - "${API_TOKEN_FROM_ENV}"
      - "my-secret-token-2
```

This allows you to provide one of those tokens to API calls with the `Authorization` header:
```
curl http://localhost:8080/api/v1/config
{"announcements":[],"authenticated":false,"oidc":false}⏎

curl http://localhost:8080/api/v1/config -H "Authorization: Bearer my-secret-token-123"
{"announcements":[],"authenticated":true,"oidc":false}⏎

curl http://localhost:8080/api/v1/config -H "Authorization: Bearer my-secret-token-2"
{"announcements":[],"authenticated":true,"oidc":false}
```

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Updated documentation in `README.md`, if applicable.
