### PR TITLE
fix(api): Escape endpoint key in URL for raw APIs

### DIFF
--- a/api/raw.go
+++ b/api/raw.go
@@ -3,6 +3,7 @@ package api
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/TwiN/gatus/v5/storage/store"
@@ -25,7 +26,10 @@ func UptimeRaw(c *fiber.Ctx) error {
 	default:
 		return c.Status(400).SendString("Durations supported: 30d, 7d, 24h, 1h")
 	}
-	key := c.Params("key")
+	key, err := url.QueryUnescape(c.Params("key"))
+	if err != nil {
+		return c.Status(400).SendString("invalid key encoding")
+	}
 	uptime, err := store.Get().GetUptimeByKey(key, from, time.Now())
 	if err != nil {
 		if errors.Is(err, common.ErrEndpointNotFound) {
@@ -57,7 +61,10 @@ func ResponseTimeRaw(c *fiber.Ctx) error {
 	default:
 		return c.Status(400).SendString("Durations supported: 30d, 7d, 24h, 1h")
 	}
-	key := c.Params("key")
+	key, err := url.QueryUnescape(c.Params("key"))
+	if err != nil {
+		return c.Status(400).SendString("invalid key encoding")
+	}
 	responseTime, err := store.Get().GetAverageResponseTimeByKey(key, from, time.Now())
 	if err != nil {
 		if errors.Is(err, common.ErrEndpointNotFound) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->

The raw API endpoints don't escape the endpoint key in the URL properly, while the other API endpoints (badges/chart) do. This results in cases where:
```
curl "http://myserver/api/v1/endpoints/group_東京/uptimes/1h"
```
is a 404 but
```
curl "http://myserver/api/v1/endpoints/group_東京/uptimes/1h/badges.svg"
```
returns a 200.

This change just copies the previous fix from #1114 and applies it to the raw API endpoins as well.

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
    - Built and deployed locally with an endpoint name of `東京` and confirmed API was now returning successfully.
- [X] Updated documentation in `README.md`, if applicable.
    - No documentation update needed
