### PR TITLE
docs: Remove ECS Fargate section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ Have any feedback or questions? [Create a discussion](https://github.com/TwiN/ga
   - [Helm Chart](#helm-chart)
   - [Terraform](#terraform)
     - [Kubernetes](#kubernetes)
-    - [ECS Fargate](#ecs-fargate)
 - [Running the tests](#running-the-tests)
 - [Using in Production](#using-in-production)
 - [FAQ](#faq)
@@ -2808,10 +2807,6 @@ To get more details, please check [chart's configuration](https://github.com/Twi
 #### Kubernetes
 
 Gatus can be deployed on Kubernetes using Terraform by using the following module: [terraform-kubernetes-gatus](https://github.com/TwiN/terraform-kubernetes-gatus).
-
-#### ECS Fargate
-
-Gatus can be deployed on ECS Fargate using Terraform by using the following module: [terraform-aws-gatus-ecs](https://github.com/GiamPy5/terraform-aws-gatus-ecs).
 
 ## Running the tests
 ```console


### PR DESCRIPTION
Removed ECS Fargate deployment section from README.

<!-- Thank you for contributing! -->

## Summary
I am sorry but due to intellectual property reasons that I am not allowed to disclose due to NDA, we need to remove this module from the README. I have already removed the repository from GitHub. I am really sorry for the hassle. @TwiN 

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Updated documentation in `README.md`, if applicable.
