### PR TITLE
docs: complete unfinished sentence in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Where:
 - `{key}` has the pattern `<GROUP_NAME>_<ENDPOINT_NAME>` in which both variables have ` `, `/`, `_`, `,`, `.`, `#`, `+` and `&` replaced by `-`.
   - Using the example configuration above, the key would be `core_ext-ep-test`.
 - `{success}` is a boolean (`true` or `false`) value indicating whether the health check was successful or not.
-- `{error}` (optional): a string describing the reason for a failed health check. If {success} is false, this should contain the error message; if the check is successful.
+- `{error}` (optional): a string describing the reason for a failed health check. If {success} is false, this should contain the error message; if the check is successful, this will be ignored.
 - `{duration}` (optional): the time that the request took as a duration string (e.g. 10s).
 
 You must also pass the token as a `Bearer` token in the `Authorization` header.


### PR DESCRIPTION
## Summary

This completes a dangling sentence in the section of the README discussing external endpoints:

> {error} (optional): a string describing the reason for a failed health check. If {success} is false, this should contain the error message; if the check is successful.

The sentence is completed as

> ...; if the check is successful, this will be ignored.

Fixes #1398

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [ ] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
