### PR TITLE
build(docker): Non tidy go mods fail image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:alpine AS builder
 RUN apk --update add ca-certificates
 WORKDIR /app
 COPY . ./
-RUN go mod tidy
+RUN go mod tidy -diff
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o gatus .
 
 # Run Tests inside docker image if you don't have a configured go environment


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
The Dockerfile to build gatus runs `go mod tidy` which might modify the go.mod and go.sum files inside the build stage image without failing if changes to those files are required to match the module source code.

Not failing the build in a situation like this might be a decision made on purpose for a reason that I do not know about or don't understand but as far as my current understanding goes it does not make sense to allow a build to succeed when the files are changed implicitly inside the build stage.

What are your thoughts on this?

If there speaks nothing against it I would suggest adding the diff flag which will make the build fail in those situations as explained [here](https://go.dev/ref/mod#go-mod-tidy):
> The -diff flag causes go mod tidy not to modify go.mod or go.sum but instead print the necessary changes as a unified diff. It exits with a non-zero code if the diff is not empty.

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
  - Locally modified go.mod to not match module source code and tried to build image -> Build failed with diff output
- [x] (n/a) Updated documentation in `README.md`, if applicable.
