### PR TITLE
docs: Update Telegram User ID to Chat ID in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2193,7 +2193,7 @@ Here's an example of what the notifications look like:
 |:--------------------------------------|:-------------------------------------------------------------------------------------------|:---------------------------|
 | `alerting.telegram`                   | Configuration for alerts of type `telegram`                                                | `{}`                       |
 | `alerting.telegram.token`             | Telegram Bot Token                                                                         | Required `""`              |
-| `alerting.telegram.id`                | Telegram User ID                                                                           | Required `""`              |
+| `alerting.telegram.id`                | Telegram Chat ID                                                                           | Required `""`              |
 | `alerting.telegram.topic-id`          | Telegram Topic ID in a group corresponds to `message_thread_id` in the Telegram API        | `""`                       |
 | `alerting.telegram.api-url`           | Telegram API URL                                                                           | `https://api.telegram.org` |
 | `alerting.telegram.client`            | Client configuration. <br />See [Client configuration](#client-configuration).             | `{}`                       |


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary

I was confused when reading the README regarding what the ID meant - the `.id` is the target chat ID, not a user ID.

https://github.com/TwiN/gatus/blob/d42c5f899e5a33cac4eeb4bc089dd1eeb497707a/alerting/provider/telegram/telegram.go#L155



## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [ ] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Updated documentation in `README.md`, if applicable.
