### PR TITLE
ci: Add workflow to regenerate static assets

### DIFF
--- a/.github/workflows/regenerate-static-assets.yml
+++ b/.github/workflows/regenerate-static-assets.yml
@@ -20,6 +20,7 @@ jobs:
           command: "/regenerate-static-assets"
           permissions: "write,admin" # The allowed permission levels to invoke this command
           allow_forks: true
+          allow_drafts: true
           skip_ci: true
           skip_completing: true
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
Closes #1454. This workflow will never work if the pull request author has set the PR option `Allow edits and access to secrets by maintainers` to false.

I am currently not sure how to easily test if the permissions are given to push to the feature branch of the PR in the forked repo when the workflow runs in the base repo.

If there are no checkout or push permission issues the workflow works. I already tested it with PRs in my fork with the base in the same repository.

## TODO

- [x] Make sure only trusted sources can trigger workflow, e.g. a specific actor or only people with write access! -> covered by github/command action

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] (n/a) Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] (n/a) Updated documentation in `README.md`, if applicable.
