### PR TITLE
feat(altering): Ntfy click link placeholder support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1634,6 +1634,10 @@ The JSON payload sent to the n8n webhook will include:
 [ntfy](https://github.com/binwiederhier/ntfy) is an amazing project that allows you to subscribe to desktop
 and mobile notifications, making it an awesome addition to Gatus.
 
+The following placeholders are supported in `click`:
+- `[ENDPOINT_URL]` - Resolved from `endpoints[].url`
+- `[ENDPOINT_KEY]` - Resolved from internal endpoint key
+
 Example:
 ```yaml
 alerting:

--- a/alerting/provider/ntfy/ntfy.go
+++ b/alerting/provider/ntfy/ntfy.go
@@ -171,6 +171,17 @@ type Body struct {
 	Click    string   `json:"click,omitempty"`
 }
 
+func resolveEndpointPlaceholders(data string, ep *endpoint.Endpoint) string {
+	placeholders := map[string]string{
+		"[ENDPOINT_URL]": ep.URL,
+		"[ENDPOINT_KEY]": ep.Key(),
+	}
+	for placeholder, value := range placeholders {
+		data = strings.ReplaceAll(data, placeholder, value)
+	}
+	return data
+}
+
 // buildRequestBody builds the request body for the provider
 func (provider *AlertProvider) buildRequestBody(cfg *Config, ep *endpoint.Endpoint, alert *alert.Alert, result *endpoint.Result, resolved bool) []byte {
 	var message, formattedConditionResults, tag string
@@ -201,7 +212,7 @@ func (provider *AlertProvider) buildRequestBody(cfg *Config, ep *endpoint.Endpoi
 		Tags:     []string{tag},
 		Priority: cfg.Priority,
 		Email:    cfg.Email,
-		Click:    cfg.Click,
+		Click:    resolveEndpointPlaceholders(cfg.Click, ep),
 	})
 	return body
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
Simple addition to allow placeholders in the click link. This way it's easy to add a generic click link that links to the correct gatus endpoint details view:
```yaml
alerting:
  ntfy:
    url: "http://ntfy"
    topic: "gatus-alerts"
    click: "https://${GATUS_DOMAIN}/endpoints/[ENDPOINT_KEY]"
```

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable.
