### PR TITLE
docs(alerting): Remove warning for Splunk alerting provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -2098,8 +2098,6 @@ Here's an example of what the notifications look like:
 
 #### Configuring Splunk alerts
 
-> ⚠️ **WARNING**: This alerting provider has not been tested yet. If you've tested it and confirmed that it works, please remove this warning and create a pull request, or comment on [#1223](https://github.com/TwiN/gatus/discussions/1223) with whether the provider works as intended. Thank you for your cooperation.
-
 | Parameter                           | Description                                                                                | Default         |
 |:------------------------------------|:-------------------------------------------------------------------------------------------|:----------------|
 | `alerting.splunk`                   | Configuration for alerts of type `splunk`                                                  | `{}`            |


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary

Removed warning about untested Splunk alerting provider from README.

https://github.com/TwiN/gatus/discussions/1223#discussioncomment-15383390

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [ ] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Updated documentation in `README.md`, if applicable.
