### PR TITLE
feat(ci): Add functionality to disable pushing image to dockerhub

### DIFF
--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -23,6 +23,7 @@ jobs:
           echo DOCKER_IMAGE_REPOSITORY=$(echo ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
           echo GHCR_IMAGE_REPOSITORY=$(echo ghcr.io/${{ github.actor }}/${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
       - name: Login to Docker Registry
+        if: vars.DISABLE_DOCKERHUB_PUBLISH != 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -33,13 +34,26 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Compose images
+        id: compose_images
+        env:
+          DOCKER_IMAGE_REPOSITORY: ${{ env.DOCKER_IMAGE_REPOSITORY }}
+          GHCR_IMAGE_REPOSITORY: ${{ env.GHCR_IMAGE_REPOSITORY }}
+        run: |
+          if [ "${{ vars.DISABLE_DOCKERHUB_PUBLISH }}" = "true" ]; then
+            echo "images=$GHCR_IMAGE_REPOSITORY" >> $GITHUB_OUTPUT
+          else
+            # multi-line output: both registries, one per line
+            echo "images<<EOF" >> $GITHUB_OUTPUT
+            echo "$DOCKER_IMAGE_REPOSITORY" >> $GITHUB_OUTPUT
+            echo "$GHCR_IMAGE_REPOSITORY" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: |
-            ${{ env.DOCKER_IMAGE_REPOSITORY }}
-            ${{ env.GHCR_IMAGE_REPOSITORY }}
+          images: ${{ steps.compose_images.outputs.images }}
           tags: |
             type=raw,value=latest
       - name: Build and push Docker image

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Get the release
         run: echo RELEASE=${GITHUB_REF/refs\/tags\//} >> $GITHUB_ENV
       - name: Login to Docker Registry
+        if: vars.DISABLE_DOCKERHUB_PUBLISH != 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -30,13 +31,26 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Compose images
+        id: compose_images
+        env:
+          DOCKER_IMAGE_REPOSITORY: ${{ env.DOCKER_IMAGE_REPOSITORY }}
+          GHCR_IMAGE_REPOSITORY: ${{ env.GHCR_IMAGE_REPOSITORY }}
+        run: |
+          if [ "${{ vars.DISABLE_DOCKERHUB_PUBLISH }}" = "true" ]; then
+            echo "images=$GHCR_IMAGE_REPOSITORY" >> $GITHUB_OUTPUT
+          else
+            # multi-line output: both registries, one per line
+            echo "images<<EOF" >> $GITHUB_OUTPUT
+            echo "$DOCKER_IMAGE_REPOSITORY" >> $GITHUB_OUTPUT
+            echo "$GHCR_IMAGE_REPOSITORY" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: |
-            ${{ env.DOCKER_IMAGE_REPOSITORY }}
-            ${{ env.GHCR_IMAGE_REPOSITORY }}
+          images: ${{ steps.compose_images.outputs.images }}
           tags: |
             type=raw,value=${{ env.RELEASE }}
             type=raw,value=stable


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->

Adds functionality to disable publishing image to dockerhub for all workflows in the repository by setting action variable `DISABLE_DOCKERHUB_PUBLISH` to `true` in repository settings.

I will be using this in my fork to be able to use all relevant workflows without having to setup dockerhub credentials.

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
  - I tested if the new functionality I need works 
- [ ] I am not able to verify if the default behavior (publish to both ghcr and dockerhub)  is still functional as expected because I have no dockerhub credentials to test it with. If there is interest to merge this I'd appreciate it if someone else could verify that the default behaviour is not broken
- [x] (n/a) Updated documentation in `README.md`, if applicable.