### PR TITLE
config: suites: use suite group and name to generate key

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -561,9 +561,9 @@ func ValidateUniqueKeys(config *Config) error {
 			return fmt.Errorf("duplicate key '%s': suite '%s' conflicts with %s", suiteKey, suite.Key(), existing)
 		}
 		keyMap[suiteKey] = fmt.Sprintf("suite '%s'", suite.Key())
-		// Check endpoints within suites (they generate keys using suite group + endpoint name)
+		// Check endpoints within suites (they generate keys using suite group + suite name + endpoint name)
 		for _, ep := range suite.Endpoints {
-			epKey := key.ConvertGroupAndNameToKey(suite.Group, ep.Name)
+			epKey := key.ConvertGroupAndNameToKey(suite.Key(), ep.Name)
 			if existing, exists := keyMap[epKey]; exists {
 				return fmt.Errorf("duplicate key '%s': endpoint '%s' in suite '%s' conflicts with %s", epKey, epKey, suite.Key(), existing)
 			}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2188,9 +2188,7 @@ suites:
           - "[STATUS] == 200"`,
 		},
 		{
-			name:        "endpoint-conflicting-with-suite-endpoint",
-			shouldError: true,
-			expectedErr: "duplicate key 'backend_api-health': endpoint 'backend_api-health' in suite 'backend_integration-suite' conflicts with endpoint 'backend_api-health'",
+			name: "endpoint-with-same-name-as-suite-endpoint",
 			config: `
 endpoints:
   - name: api-health


### PR DESCRIPTION
This allows us to have more generic configs:
```yaml
suites:
  - name: node1-1
    group: XXX
    <<: *default-suite-config
    endpoints:
      - name: HTTP check
        url: https://example.com
        <<: *default-http

      - name: Write check
        url: wss://example.com
        <<: *default-write

      - name: Read check
        url: wss://example.com
        <<: *default-read
        
  - name: node1-2
    group: XXX
    <<: *default-suite-config
    endpoints:
      - name: HTTP check
        url: https://foo.bar
        <<: *default-http

      - name: Write check
        url: wss://foo.bar
        <<: *default-write

      - name: Read check
        url: wss://foo.bar
        <<: *default-read
```