### PR TITLE
feat(config): support environment variable default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ subdirectories are merged like so:
 - Parameters with a primitive value (e.g. `metrics`, `alerting.slack.webhook-url`, etc.) may only be defined once to forcefully avoid any ambiguity
     - To clarify, this also means that you could not define `alerting.slack.webhook-url` in two files with different values. All files are merged into one before they are processed. This is by design.
 
-> 💡 You can also use environment variables in the configuration file (e.g. `$DOMAIN`, `${DOMAIN}`)
+> 💡 You can also use environment variables in the configuration file (e.g. `$DOMAIN`, `${DOMAIN}`, `${DOMAIN:-example.com}`)
 >
 > ⚠️ When your configuration parameter contains a `$` symbol, you have to escape `$` with `$$`.
 >

--- a/config/env_test.go
+++ b/config/env_test.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParseAndValidateConfigBytes_EnvDefault(t *testing.T) {
+	// Create a temporary YAML config with environment variable using default value syntax
+	yamlConfig := `
+endpoints:
+  - name: test-endpoint
+    group: core
+    url: "http://example.com"
+    interval: 5m
+    conditions:
+      - "[STATUS] == ${EXPECTED_STATUS:-201}"
+`
+
+	// Ensure the environment variable is NOT set
+	os.Unsetenv("EXPECTED_STATUS")
+
+	// Parse the configuration
+	cfg, err := parseAndValidateConfigBytes([]byte(yamlConfig))
+	if err != nil {
+		t.Fatalf("Failed to parse config: %v", err)
+	}
+
+	// Verify that the default value was applied
+	expectedCondition := "[STATUS] == 201"
+	if len(cfg.Endpoints) == 0 {
+		t.Fatal("No endpoints parsed")
+	}
+	actualCondition := string(cfg.Endpoints[0].Conditions[0])
+
+	if actualCondition != expectedCondition {
+		t.Errorf("Expected condition '%s', got '%s'", expectedCondition, actualCondition)
+	}
+}
+
+func TestParseAndValidateConfigBytes_EnvSet(t *testing.T) {
+	// Create a temporary YAML config with environment variable using default value syntax
+	yamlConfig := `
+endpoints:
+  - name: test-endpoint-set
+    group: core
+    url: "http://example.com"
+    interval: 5m
+    conditions:
+      - "[STATUS] == ${EXPECTED_STATUS_SET:-201}"
+`
+
+	// Ensure the environment variable IS set
+	os.Setenv("EXPECTED_STATUS_SET", "200")
+	defer os.Unsetenv("EXPECTED_STATUS_SET")
+
+	// Parse the configuration
+	cfg, err := parseAndValidateConfigBytes([]byte(yamlConfig))
+	if err != nil {
+		t.Fatalf("Failed to parse config: %v", err)
+	}
+
+	// Verify that the env value was applied (override default)
+	expectedCondition := "[STATUS] == 200"
+	if len(cfg.Endpoints) == 0 {
+		t.Fatal("No endpoints parsed")
+	}
+	actualCondition := string(cfg.Endpoints[0].Conditions[0])
+
+	if actualCondition != expectedCondition {
+		t.Errorf("Expected condition '%s', got '%s'", expectedCondition, actualCondition)
+	}
+}


### PR DESCRIPTION
This PR adds support for defining default values for environment variables in the configuration file using the standard shell syntax `${VAR:-default}`.

Fixes #1523

### Changes
- Implemented `expandEnv` function in `config/config.go` to handle default value parsing.
- Replaced `os.ExpandEnv` with `expandEnv`.
- Added unit tests in `config/env_test.go` to verify the functionality.
- Updated `README.md` to document the new feature.
