### PR TITLE
feat(alerting): Add Alertmanager provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Have any feedback or questions? [Create a discussion](https://github.com/TwiN/ga
   - [Client configuration](#client-configuration)
   - [Tunneling](#tunneling)
   - [Alerting](#alerting)
+    - [Configuring Alertmanager alerts](#configuring-alertmanager-alerts)
     - [Configuring AWS SES alerts](#configuring-aws-ses-alerts)
     - [Configuring ClickUp alerts](#configuring-clickup-alerts)
     - [Configuring Datadog alerts](#configuring-datadog-alerts)
@@ -836,6 +837,7 @@ endpoints:
 
 | Parameter                  | Description                                                                                                                             | Default |
 |:---------------------------|:----------------------------------------------------------------------------------------------------------------------------------------|:--------|
+| `alerting.alertmanager`    | Configuration for alerts of type `alertmanager`. <br />See [Configuring Alertmanager alerts](#configuring-alertmanager-alerts).          | `{}`    |
 | `alerting.awsses`          | Configuration for alerts of type `awsses`. <br />See [Configuring AWS SES alerts](#configuring-aws-ses-alerts).                         | `{}`    |
 | `alerting.clickup`         | Configuration for alerts of type `clickup`. <br />See [Configuring ClickUp alerts](#configuring-clickup-alerts).                        | `{}`    |
 | `alerting.custom`          | Configuration for custom actions on failure or alerts. <br />See [Configuring Custom alerts](#configuring-custom-alerts).               | `{}`    |
@@ -877,6 +879,52 @@ endpoints:
 | `alerting.webex`           | Configuration for alerts of type `webex`. <br />See [Configuring Webex alerts](#configuring-webex-alerts).                              | `{}`    |
 | `alerting.zapier`          | Configuration for alerts of type `zapier`. <br />See [Configuring Zapier alerts](#configuring-zapier-alerts).                           | `{}`    |
 | `alerting.zulip`           | Configuration for alerts of type `zulip`. <br />See [Configuring Zulip alerts](#configuring-zulip-alerts).                              | `{}`    |
+
+
+#### Configuring Alertmanager alerts
+
+| Parameter                                    | Description                                                                                | Default       |
+|:---------------------------------------------|:-------------------------------------------------------------------------------------------|:--------------|
+| `alerting.alertmanager`                      | Configuration for alerts of type `alertmanager`                                            | `{}`          |
+| `alerting.alertmanager.urls`                 | List of Alertmanager API endpoint URLs                                                     | Required `[]` |
+| `alerting.alertmanager.default-severity`     | Default severity level for alerts                                                          | `critical`    |
+| `alerting.alertmanager.extra-labels`         | Additional labels to add to all alerts                                                     | `{}`          |
+| `alerting.alertmanager.extra-annotations`    | Additional annotations to add to all alerts                                                | `{}`          |
+| `alerting.alertmanager.client`               | Client configuration                                                                       | `{}`          |
+| `alerting.alertmanager.default-alert`        | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert) | N/A           |
+| `alerting.alertmanager.overrides`            | List of overrides that may be prioritized over the default configuration                   | `[]`          |
+| `alerting.alertmanager.overrides[].group`    | Endpoint group for which the configuration will be overridden by this configuration        | `""`          |
+| `alerting.alertmanager.overrides[].*`        | See `alerting.alertmanager.*` parameters                                                   | `{}`          |
+
+[Alertmanager](https://prometheus.io/docs/alerting/latest/alertmanager/) is the alert handling component of the Prometheus ecosystem. By routing Gatus alerts through Alertmanager, you can take advantage of its features such as silences, inhibition rules, and grouping, as well as forwarding alerts to any of its supported notification channels (Slack, PagerDuty, email, webhooks, etc.).
+
+Multiple URLs can be configured to support Alertmanager in high-availability mode. Alerts are sent to all configured instances and Alertmanager handles deduplication.
+
+It is highly recommended to set `endpoints[].alerts[].send-on-resolved` to `true` so that resolved notifications are sent to Alertmanager.
+
+```yaml
+alerting:
+  alertmanager:
+    urls:
+      - "http://alertmanager1:9093"
+      - "http://alertmanager2:9093"
+    default-severity: "critical"
+    extra-labels:
+      environment: "production"
+    extra-annotations:
+      runbook: "https://wiki.example.com/runbook"
+
+endpoints:
+  - name: website
+    url: "https://twin.sh/health"
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+    alerts:
+      - type: alertmanager
+        send-on-resolved: true
+        description: "healthcheck failed"
+```
 
 
 #### Configuring AWS SES alerts

--- a/README.md
+++ b/README.md
@@ -886,7 +886,7 @@ endpoints:
 | Parameter                                    | Description                                                                                | Default       |
 |:---------------------------------------------|:-------------------------------------------------------------------------------------------|:--------------|
 | `alerting.alertmanager`                      | Configuration for alerts of type `alertmanager`                                            | `{}`          |
-| `alerting.alertmanager.urls`                 | List of Alertmanager API endpoint URLs                                                     | Required `[]` |
+| `alerting.alertmanager.urls`                 | List of base Alertmanager URLs (e.g. `http://host:9093`). `/api/v2/alerts` is appended automatically. | Required `[]` |
 | `alerting.alertmanager.default-severity`     | Default severity level for alerts                                                          | `critical`    |
 | `alerting.alertmanager.extra-labels`         | Additional labels to add to all alerts                                                     | `{}`          |
 | `alerting.alertmanager.extra-annotations`    | Additional annotations to add to all alerts                                                | `{}`          |

--- a/alerting/alert/alert.go
+++ b/alerting/alert/alert.go
@@ -16,7 +16,7 @@ var (
 	// ErrAlertWithInvalidDescription is the error with which Gatus will panic if an alert has an invalid character
 	ErrAlertWithInvalidDescription = errors.New("alert description must not have \" or \\")
 
-	ErrAlertWithInvalidMinimumReminderInterval = errors.New("minimum-reminder-interval must be either omitted or be at least 5m")
+	ErrAlertWithInvalidMinimumReminderInterval = errors.New("minimum-reminder-interval must be either omitted or be at least 1m")
 )
 
 // Alert is endpoint.Endpoint's alert configuration
@@ -80,8 +80,11 @@ func (alert *Alert) ValidateAndSetDefaults() error {
 	if alert.SuccessThreshold <= 0 {
 		alert.SuccessThreshold = 2
 	}
-	if alert.MinimumReminderInterval != 0 && alert.MinimumReminderInterval < 5*time.Minute {
+	if alert.MinimumReminderInterval != 0 && alert.MinimumReminderInterval < time.Minute {
 		return ErrAlertWithInvalidMinimumReminderInterval
+	}
+	if alert.MinimumReminderInterval > 0 && alert.MinimumReminderInterval < 5*time.Minute && alert.Type != TypeAlertmanager {
+		logr.Warnf("[alert.ValidateAndSetDefaults] minimum-reminder-interval is set to %s, which is below the recommended 5m and may cause alert spam for most providers", alert.MinimumReminderInterval)
 	}
 	if strings.ContainsAny(alert.GetDescription(), "\"\\") {
 		return ErrAlertWithInvalidDescription

--- a/alerting/alert/alert.go
+++ b/alerting/alert/alert.go
@@ -83,8 +83,8 @@ func (alert *Alert) ValidateAndSetDefaults() error {
 	if alert.MinimumReminderInterval != 0 && alert.MinimumReminderInterval < time.Minute {
 		return ErrAlertWithInvalidMinimumReminderInterval
 	}
-	if alert.MinimumReminderInterval > 0 && alert.MinimumReminderInterval < 5*time.Minute && alert.Type != TypeAlertmanager {
-		logr.Warnf("[alert.ValidateAndSetDefaults] minimum-reminder-interval is set to %s, which is below the recommended 5m and may cause alert spam for most providers", alert.MinimumReminderInterval)
+	if alert.MinimumReminderInterval != 0 && alert.MinimumReminderInterval < 5*time.Minute {
+		logr.Warnf("[alert.ValidateAndSetDefaults] minimum-reminder-interval is set to %s, which is below the recommended 5m and may cause alert spam", alert.MinimumReminderInterval)
 	}
 	if strings.ContainsAny(alert.GetDescription(), "\"\\") {
 		return ErrAlertWithInvalidDescription

--- a/alerting/alert/alert_test.go
+++ b/alerting/alert/alert_test.go
@@ -71,13 +71,24 @@ func TestAlert_ValidateAndSetDefaults(t *testing.T) {
 			expectedSuccessThreshold: 5,
 		},
 		{
-			name: "invalid-minimum-reminder-interval-1m",
+			name: "valid-minimum-reminder-interval-1m",
 			alert: Alert{
 				MinimumReminderInterval: 1 * time.Minute,
 				FailureThreshold:        10,
 				SuccessThreshold:        5,
 			},
-			expectedError:            ErrAlertWithInvalidMinimumReminderInterval,
+			expectedError:            nil,
+			expectedFailureThreshold: 10,
+			expectedSuccessThreshold: 5,
+		},
+		{
+			name: "valid-minimum-reminder-interval-2m",
+			alert: Alert{
+				MinimumReminderInterval: 2 * time.Minute,
+				FailureThreshold:        10,
+				SuccessThreshold:        5,
+			},
+			expectedError:            nil,
 			expectedFailureThreshold: 10,
 			expectedSuccessThreshold: 5,
 		},

--- a/alerting/alert/type.go
+++ b/alerting/alert/type.go
@@ -5,6 +5,9 @@ package alert
 type Type string
 
 const (
+	// TypeAlertmanager is the Type for the alertmanager alerting provider
+	TypeAlertmanager Type = "alertmanager"
+
 	// TypeAWSSES is the Type for the awsses alerting provider
 	TypeAWSSES Type = "aws-ses"
 

--- a/alerting/config.go
+++ b/alerting/config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/TwiN/gatus/v5/alerting/alert"
 	"github.com/TwiN/gatus/v5/alerting/provider"
+	"github.com/TwiN/gatus/v5/alerting/provider/alertmanager"
 	"github.com/TwiN/gatus/v5/alerting/provider/awsses"
 	"github.com/TwiN/gatus/v5/alerting/provider/clickup"
 	"github.com/TwiN/gatus/v5/alerting/provider/custom"
@@ -52,6 +53,9 @@ import (
 
 // Config is the configuration for alerting providers
 type Config struct {
+	// Alertmanager is the configuration for the alertmanager alerting provider
+	Alertmanager *alertmanager.AlertProvider `yaml:"alertmanager,omitempty"`
+
 	// AWSSimpleEmailService is the configuration for the aws-ses alerting provider
 	AWSSimpleEmailService *awsses.AlertProvider `yaml:"aws-ses,omitempty"`
 

--- a/alerting/provider/alertmanager/alertmanager.go
+++ b/alerting/provider/alertmanager/alertmanager.go
@@ -1,0 +1,304 @@
+package alertmanager
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/TwiN/gatus/v5/alerting/alert"
+	"github.com/TwiN/gatus/v5/client"
+	"github.com/TwiN/gatus/v5/config/endpoint"
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	ErrURLsNotSet             = errors.New("urls not set")
+	ErrDuplicateGroupOverride = errors.New("duplicate group override")
+)
+
+// Config is the configuration for the Alertmanager provider
+type Config struct {
+	// URLs is a list of Alertmanager API endpoint URLs to send alerts to
+	URLs []string `yaml:"urls"`
+
+	// DefaultSeverity is the default severity level for alerts
+	DefaultSeverity string `yaml:"default-severity,omitempty"`
+
+	// ExtraLabels are additional labels to add to all alerts
+	ExtraLabels map[string]string `yaml:"extra-labels,omitempty"`
+
+	// ExtraAnnotations are additional annotations to add to all alerts
+	ExtraAnnotations map[string]string `yaml:"extra-annotations,omitempty"`
+
+	// ClientConfig is the configuration of the client used to communicate with Alertmanager
+	ClientConfig *client.Config `yaml:"client,omitempty"`
+}
+
+func (cfg *Config) Validate() error {
+	if len(cfg.URLs) == 0 {
+		return ErrURLsNotSet
+	}
+	if len(cfg.DefaultSeverity) == 0 {
+		cfg.DefaultSeverity = "critical"
+	}
+	return nil
+}
+
+func (cfg *Config) Merge(override *Config) {
+	if override.ClientConfig != nil {
+		cfg.ClientConfig = override.ClientConfig
+	}
+	if len(override.URLs) > 0 {
+		cfg.URLs = override.URLs
+	}
+	if len(override.DefaultSeverity) > 0 {
+		cfg.DefaultSeverity = override.DefaultSeverity
+	}
+	if len(override.ExtraLabels) > 0 {
+		if cfg.ExtraLabels == nil {
+			cfg.ExtraLabels = make(map[string]string)
+		}
+		for k, v := range override.ExtraLabels {
+			cfg.ExtraLabels[k] = v
+		}
+	}
+	if len(override.ExtraAnnotations) > 0 {
+		if cfg.ExtraAnnotations == nil {
+			cfg.ExtraAnnotations = make(map[string]string)
+		}
+		for k, v := range override.ExtraAnnotations {
+			cfg.ExtraAnnotations[k] = v
+		}
+	}
+}
+
+// AlertProvider is the configuration necessary for sending alerts to Alertmanager
+type AlertProvider struct {
+	DefaultConfig Config `yaml:",inline"`
+
+	// DefaultAlert is the default alert configuration to use for endpoints with an alert of the appropriate type
+	DefaultAlert *alert.Alert `yaml:"default-alert,omitempty"`
+
+	// Overrides is a list of Override that may be prioritized over the default configuration
+	Overrides []Override `yaml:"overrides,omitempty"`
+}
+
+// Override is a case under which the default integration is overridden
+type Override struct {
+	Group  string `yaml:"group"`
+	Config `yaml:",inline"`
+}
+
+// AlertmanagerAlert represents an alert in Alertmanager API v2 format
+type AlertmanagerAlert struct {
+	Labels      map[string]string `json:"labels"`
+	Annotations map[string]string `json:"annotations"`
+	StartsAt    time.Time         `json:"startsAt,omitempty"`
+	EndsAt      time.Time         `json:"endsAt,omitempty"`
+}
+
+// Validate the provider's configuration
+func (provider *AlertProvider) Validate() error {
+	registeredGroups := make(map[string]bool)
+	if provider.Overrides != nil {
+		for _, override := range provider.Overrides {
+			if isAlreadyRegistered := registeredGroups[override.Group]; isAlreadyRegistered || override.Group == "" {
+				return ErrDuplicateGroupOverride
+			}
+			registeredGroups[override.Group] = true
+		}
+	}
+	return provider.DefaultConfig.Validate()
+}
+
+// Send sends an alert to all configured Alertmanager instances
+func (provider *AlertProvider) Send(ep *endpoint.Endpoint, alert *alert.Alert, result *endpoint.Result, resolved bool) error {
+	cfg, err := provider.GetConfig(ep.Group, alert)
+	if err != nil {
+		return err
+	}
+	alertPayload := provider.buildAlert(cfg, ep, alert, result, resolved)
+	return provider.sendToAlertmanagers(cfg, []AlertmanagerAlert{alertPayload})
+}
+
+// buildAlert constructs an Alertmanager alert payload
+func (provider *AlertProvider) buildAlert(cfg *Config, ep *endpoint.Endpoint, alert *alert.Alert, result *endpoint.Result, resolved bool) AlertmanagerAlert {
+	now := time.Now()
+	alertPayload := AlertmanagerAlert{
+		Labels:      make(map[string]string),
+		Annotations: make(map[string]string),
+		StartsAt:    now,
+	}
+
+	// Set core Prometheus labels following conventions
+	alertPayload.Labels["alertname"] = "GatusEndpointDown"
+	alertPayload.Labels["instance"] = ep.URL
+	alertPayload.Labels["job"] = "gatus"
+	alertPayload.Labels["severity"] = cfg.DefaultSeverity
+
+	// Add Gatus-specific labels
+	alertPayload.Labels["endpoint"] = ep.Name
+	if ep.Group != "" {
+		alertPayload.Labels["group"] = ep.Group
+	}
+
+	// Add extra labels from config
+	for k, v := range cfg.ExtraLabels {
+		alertPayload.Labels[k] = v
+	}
+
+	// Set core annotations
+	var message, formattedConditionResults string
+	if resolved {
+		alertPayload.Annotations["summary"] = fmt.Sprintf("Gatus: %s", ep.Name)
+		message = "An alert has been resolved after passing successfully " + strconv.Itoa(alert.SuccessThreshold) + " time(s) in a row."
+		alertPayload.EndsAt = now
+	} else {
+		alertPayload.Annotations["summary"] = fmt.Sprintf("Gatus: %s", ep.Name)
+		message = "An alert has been triggered due to having failed " + strconv.Itoa(alert.FailureThreshold) + " time(s) in a row."
+	}
+
+	// Format condition results
+	for _, conditionResult := range result.ConditionResults {
+		var prefix string
+		if conditionResult.Success {
+			prefix = "🟢"
+		} else {
+			prefix = "🔴"
+		}
+		formattedConditionResults += fmt.Sprintf("\n%s %s", prefix, conditionResult.Condition)
+	}
+
+	// Add alert description if provided
+	if len(alert.GetDescription()) > 0 {
+		message += fmt.Sprintf(" %s.", alert.GetDescription())
+	}
+
+	// Append condition results
+	message += formattedConditionResults
+
+	// Set the final description
+	alertPayload.Annotations["description"] = message
+
+	// Add extra annotations from config
+	for k, v := range cfg.ExtraAnnotations {
+		alertPayload.Annotations[k] = v
+	}
+
+	return alertPayload
+}
+
+// sendToAlertmanagers sends alerts to all configured Alertmanager instances.
+// It attempts to send to all instances and only returns an error if all fail.
+func (provider *AlertProvider) sendToAlertmanagers(cfg *Config, alerts []AlertmanagerAlert) error {
+	jsonPayload, err := json.Marshal(alerts)
+	if err != nil {
+		return fmt.Errorf("failed to marshal alerts: %w", err)
+	}
+
+	var errs []error
+	for _, baseURL := range cfg.URLs {
+		if err := provider.sendToURL(cfg, baseURL, jsonPayload); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	// Only fail if all instances failed
+	if len(errs) == len(cfg.URLs) {
+		return fmt.Errorf("failed to send alert to all Alertmanager instances: %v", errs)
+	}
+	return nil
+}
+
+// sendToURL sends the alert payload to a single Alertmanager URL
+func (provider *AlertProvider) sendToURL(cfg *Config, baseURL string, jsonPayload []byte) error {
+	url := strings.TrimSuffix(baseURL, "/")
+	if !strings.HasSuffix(url, "/api/v2/alerts") {
+		url += "/api/v2/alerts"
+	}
+
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(jsonPayload))
+	if err != nil {
+		return fmt.Errorf("failed to create request for %s: %w", url, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	httpClient := client.GetHTTPClient(cfg.ClientConfig)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request to %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("Alertmanager %s returned status %d: %s", url, resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// GetDefaultAlert returns the provider's default alert configuration
+func (provider *AlertProvider) GetDefaultAlert() *alert.Alert {
+	return provider.DefaultAlert
+}
+
+// GetConfig returns the configuration for the provider with the overrides applied
+func (provider *AlertProvider) GetConfig(group string, alert *alert.Alert) (*Config, error) {
+	cfg := provider.DefaultConfig
+
+	// Create deep copies of maps and slices to prevent shared state across alerts
+	if cfg.URLs != nil {
+		urls := make([]string, len(cfg.URLs))
+		copy(urls, cfg.URLs)
+		cfg.URLs = urls
+	}
+	if cfg.ExtraLabels != nil {
+		extraLabels := make(map[string]string)
+		for k, v := range cfg.ExtraLabels {
+			extraLabels[k] = v
+		}
+		cfg.ExtraLabels = extraLabels
+	}
+	if cfg.ExtraAnnotations != nil {
+		extraAnnotations := make(map[string]string)
+		for k, v := range cfg.ExtraAnnotations {
+			extraAnnotations[k] = v
+		}
+		cfg.ExtraAnnotations = extraAnnotations
+	}
+
+	// Handle group overrides
+	if provider.Overrides != nil {
+		for _, override := range provider.Overrides {
+			if group == override.Group {
+				cfg.Merge(&override.Config)
+				break
+			}
+		}
+	}
+
+	// Handle alert overrides
+	if len(alert.ProviderOverride) != 0 {
+		overrideConfig := Config{}
+		if err := yaml.Unmarshal(alert.ProviderOverrideAsBytes(), &overrideConfig); err != nil {
+			return nil, err
+		}
+		cfg.Merge(&overrideConfig)
+	}
+
+	// Validate the configuration
+	err := cfg.Validate()
+	return &cfg, err
+}
+
+// ValidateOverrides validates the alert's provider override and, if present, the group override
+func (provider *AlertProvider) ValidateOverrides(group string, alert *alert.Alert) error {
+	_, err := provider.GetConfig(group, alert)
+	return err
+}

--- a/alerting/provider/alertmanager/alertmanager_test.go
+++ b/alerting/provider/alertmanager/alertmanager_test.go
@@ -1,0 +1,434 @@
+package alertmanager
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/TwiN/gatus/v5/alerting/alert"
+	"github.com/TwiN/gatus/v5/config/endpoint"
+)
+
+func TestAlertProvider_Validate(t *testing.T) {
+	tests := []struct {
+		name          string
+		provider      AlertProvider
+		expectedError bool
+	}{
+		{
+			name: "valid configuration with single URL",
+			provider: AlertProvider{
+				DefaultConfig: Config{
+					URLs: []string{"http://alertmanager:9093"},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "valid configuration with multiple URLs",
+			provider: AlertProvider{
+				DefaultConfig: Config{
+					URLs: []string{"http://alertmanager1:9093", "http://alertmanager2:9093"},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "missing URLs",
+			provider: AlertProvider{
+				DefaultConfig: Config{},
+			},
+			expectedError: true,
+		},
+		{
+			name: "empty URLs slice",
+			provider: AlertProvider{
+				DefaultConfig: Config{
+					URLs: []string{},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "valid configuration with overrides",
+			provider: AlertProvider{
+				DefaultConfig: Config{
+					URLs: []string{"http://alertmanager:9093"},
+				},
+				Overrides: []Override{
+					{Group: "group1", Config: Config{URLs: []string{"http://alertmanager1:9093"}}},
+					{Group: "group2", Config: Config{URLs: []string{"http://alertmanager2:9093"}}},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "duplicate group override",
+			provider: AlertProvider{
+				DefaultConfig: Config{
+					URLs: []string{"http://alertmanager:9093"},
+				},
+				Overrides: []Override{
+					{Group: "group1", Config: Config{URLs: []string{"http://alertmanager1:9093"}}},
+					{Group: "group1", Config: Config{URLs: []string{"http://alertmanager2:9093"}}},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "empty group override",
+			provider: AlertProvider{
+				DefaultConfig: Config{
+					URLs: []string{"http://alertmanager:9093"},
+				},
+				Overrides: []Override{
+					{Group: "", Config: Config{URLs: []string{"http://alertmanager1:9093"}}},
+				},
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.provider.Validate()
+			if test.expectedError && err == nil {
+				t.Error("expected an error, but got none")
+			}
+			if !test.expectedError && err != nil {
+				t.Errorf("expected no error, but got %v", err)
+			}
+		})
+	}
+}
+
+func TestAlertProvider_buildAlert(t *testing.T) {
+	provider := AlertProvider{
+		DefaultConfig: Config{
+			URLs:            []string{"http://alertmanager:9093"},
+			DefaultSeverity: "warning",
+			ExtraLabels: map[string]string{
+				"environment": "test",
+			},
+			ExtraAnnotations: map[string]string{
+				"runbook": "https://wiki.example.com/runbook",
+			},
+		},
+	}
+
+	ep := &endpoint.Endpoint{
+		Name:  "Test API",
+		URL:   "https://api.example.com/health",
+		Group: "production",
+	}
+
+	testAlert := &alert.Alert{
+		Description:      stringPtr("API health check failed"),
+		FailureThreshold: 3,
+		SuccessThreshold: 2,
+	}
+
+	result := &endpoint.Result{
+		ConditionResults: []*endpoint.ConditionResult{
+			{Condition: "[STATUS] == 200", Success: false},
+			{Condition: "[CONNECTED] == true", Success: true},
+		},
+	}
+
+	// Test firing alert
+	firingAlert := provider.buildAlert(&provider.DefaultConfig, ep, testAlert, result, false)
+
+	if firingAlert.Labels["alertname"] != "GatusEndpointDown" {
+		t.Errorf("expected alertname to be 'GatusEndpointDown', got %s", firingAlert.Labels["alertname"])
+	}
+
+	if firingAlert.Labels["instance"] != ep.URL {
+		t.Errorf("expected instance to be %s, got %s", ep.URL, firingAlert.Labels["instance"])
+	}
+
+	if firingAlert.Labels["endpoint"] != ep.Name {
+		t.Errorf("expected endpoint to be %s, got %s", ep.Name, firingAlert.Labels["endpoint"])
+	}
+
+	if firingAlert.Labels["group"] != ep.Group {
+		t.Errorf("expected group to be %s, got %s", ep.Group, firingAlert.Labels["group"])
+	}
+
+	if firingAlert.Labels["severity"] != "warning" {
+		t.Errorf("expected severity to be 'warning', got %s", firingAlert.Labels["severity"])
+	}
+
+	if firingAlert.Labels["environment"] != "test" {
+		t.Errorf("expected environment to be 'test', got %s", firingAlert.Labels["environment"])
+	}
+
+	if firingAlert.Annotations["runbook"] != "https://wiki.example.com/runbook" {
+		t.Errorf("expected runbook annotation, got %s", firingAlert.Annotations["runbook"])
+	}
+
+	if firingAlert.EndsAt != (time.Time{}) {
+		t.Error("expected EndsAt to be zero for firing alert")
+	}
+
+	expectedSummary := "Gatus: Test API"
+	if firingAlert.Annotations["summary"] != expectedSummary {
+		t.Errorf("expected summary to be '%s', got %s", expectedSummary, firingAlert.Annotations["summary"])
+	}
+
+	// Test resolved alert
+	resolvedAlert := provider.buildAlert(&provider.DefaultConfig, ep, testAlert, result, true)
+
+	if !resolvedAlert.EndsAt.After(time.Now().Add(-time.Minute)) {
+		t.Error("expected EndsAt to be set for resolved alert")
+	}
+
+	if resolvedAlert.Annotations["summary"] != expectedSummary {
+		t.Errorf("expected resolved summary to be '%s', got %s", expectedSummary, resolvedAlert.Annotations["summary"])
+	}
+}
+
+func TestAlertProvider_Send(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST request, got %s", r.Method)
+		}
+
+		if r.URL.Path != "/api/v2/alerts" {
+			t.Errorf("expected path /api/v2/alerts, got %s", r.URL.Path)
+		}
+
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("expected Content-Type application/json, got %s", r.Header.Get("Content-Type"))
+		}
+
+		var alerts []AlertmanagerAlert
+		if err := json.NewDecoder(r.Body).Decode(&alerts); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+			http.Error(w, "Bad Request", http.StatusBadRequest)
+			return
+		}
+
+		if len(alerts) != 1 {
+			t.Errorf("expected 1 alert, got %d", len(alerts))
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	provider := AlertProvider{
+		DefaultConfig: Config{
+			URLs: []string{server.URL},
+		},
+	}
+
+	ep := &endpoint.Endpoint{
+		Name: "Test API",
+		URL:  "https://api.example.com/health",
+	}
+
+	testAlert := &alert.Alert{
+		Description:      stringPtr("Test alert"),
+		FailureThreshold: 3,
+		SuccessThreshold: 2,
+	}
+
+	result := &endpoint.Result{
+		Success: false,
+		Errors:  []string{"test error"},
+	}
+
+	err := provider.Send(ep, testAlert, result, false)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestAlertProvider_SendMultipleURLs(t *testing.T) {
+	var server1Calls, server2Calls int32
+
+	server1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&server1Calls, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server1.Close()
+
+	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&server2Calls, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server2.Close()
+
+	provider := AlertProvider{
+		DefaultConfig: Config{
+			URLs: []string{server1.URL, server2.URL},
+		},
+	}
+
+	ep := &endpoint.Endpoint{
+		Name: "Test API",
+		URL:  "https://api.example.com/health",
+	}
+
+	testAlert := &alert.Alert{
+		Description:      stringPtr("Test alert"),
+		FailureThreshold: 3,
+		SuccessThreshold: 2,
+	}
+
+	result := &endpoint.Result{
+		Success: false,
+	}
+
+	err := provider.Send(ep, testAlert, result, false)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if atomic.LoadInt32(&server1Calls) != 1 {
+		t.Errorf("expected server1 to be called once, got %d", server1Calls)
+	}
+
+	if atomic.LoadInt32(&server2Calls) != 1 {
+		t.Errorf("expected server2 to be called once, got %d", server2Calls)
+	}
+}
+
+func TestAlertProvider_SendPartialFailure(t *testing.T) {
+	var successCalls int32
+
+	failServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}))
+	defer failServer.Close()
+
+	successServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&successCalls, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer successServer.Close()
+
+	provider := AlertProvider{
+		DefaultConfig: Config{
+			URLs: []string{failServer.URL, successServer.URL},
+		},
+	}
+
+	ep := &endpoint.Endpoint{
+		Name: "Test API",
+		URL:  "https://api.example.com/health",
+	}
+
+	testAlert := &alert.Alert{
+		Description:      stringPtr("Test alert"),
+		FailureThreshold: 3,
+		SuccessThreshold: 2,
+	}
+
+	result := &endpoint.Result{
+		Success: false,
+	}
+
+	// Should succeed because at least one Alertmanager succeeded
+	err := provider.Send(ep, testAlert, result, false)
+	if err != nil {
+		t.Errorf("expected no error when at least one Alertmanager succeeds, got: %v", err)
+	}
+
+	if atomic.LoadInt32(&successCalls) != 1 {
+		t.Errorf("expected success server to be called once, got %d", successCalls)
+	}
+}
+
+func TestAlertProvider_SendAllFail(t *testing.T) {
+	failServer1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}))
+	defer failServer1.Close()
+
+	failServer2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+	}))
+	defer failServer2.Close()
+
+	provider := AlertProvider{
+		DefaultConfig: Config{
+			URLs: []string{failServer1.URL, failServer2.URL},
+		},
+	}
+
+	ep := &endpoint.Endpoint{
+		Name: "Test API",
+		URL:  "https://api.example.com/health",
+	}
+
+	testAlert := &alert.Alert{
+		Description:      stringPtr("Test alert"),
+		FailureThreshold: 3,
+		SuccessThreshold: 2,
+	}
+
+	result := &endpoint.Result{
+		Success: false,
+	}
+
+	// Should fail because all Alertmanagers failed
+	err := provider.Send(ep, testAlert, result, false)
+	if err == nil {
+		t.Error("expected error when all Alertmanagers fail, got none")
+	}
+}
+
+func TestConfig_Merge(t *testing.T) {
+	base := Config{
+		URLs:            []string{"http://base:9093"},
+		DefaultSeverity: "critical",
+		ExtraLabels: map[string]string{
+			"team": "platform",
+		},
+	}
+
+	override := Config{
+		URLs:            []string{"http://override1:9093", "http://override2:9093"},
+		DefaultSeverity: "warning",
+		ExtraLabels: map[string]string{
+			"environment": "test",
+		},
+		ExtraAnnotations: map[string]string{
+			"runbook": "https://wiki.example.com",
+		},
+	}
+
+	base.Merge(&override)
+
+	// URLs should be completely replaced by override
+	if len(base.URLs) != 2 {
+		t.Errorf("expected URLs to be replaced with 2 items, got %d", len(base.URLs))
+	}
+	if base.URLs[0] != "http://override1:9093" || base.URLs[1] != "http://override2:9093" {
+		t.Errorf("expected URLs to be overridden, got %v", base.URLs)
+	}
+
+	if base.DefaultSeverity != "warning" {
+		t.Errorf("expected severity to be overridden to 'warning', got %s", base.DefaultSeverity)
+	}
+
+	if base.ExtraLabels["team"] != "platform" {
+		t.Error("expected original label to be preserved")
+	}
+
+	if base.ExtraLabels["environment"] != "test" {
+		t.Error("expected override label to be added")
+	}
+
+	if base.ExtraAnnotations["runbook"] != "https://wiki.example.com" {
+		t.Error("expected override annotation to be added")
+	}
+}
+
+func stringPtr(s string) *string {
+	return &s
+}

--- a/alerting/provider/provider.go
+++ b/alerting/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"github.com/TwiN/gatus/v5/alerting/alert"
+	"github.com/TwiN/gatus/v5/alerting/provider/alertmanager"
 	"github.com/TwiN/gatus/v5/alerting/provider/awsses"
 	"github.com/TwiN/gatus/v5/alerting/provider/clickup"
 	"github.com/TwiN/gatus/v5/alerting/provider/custom"
@@ -92,6 +93,7 @@ func MergeProviderDefaultAlertIntoEndpointAlert(providerDefaultAlert, endpointAl
 
 var (
 	// Validate provider interface implementation on compile
+	_ AlertProvider = (*alertmanager.AlertProvider)(nil)
 	_ AlertProvider = (*awsses.AlertProvider)(nil)
 	_ AlertProvider = (*clickup.AlertProvider)(nil)
 	_ AlertProvider = (*custom.AlertProvider)(nil)
@@ -134,6 +136,7 @@ var (
 	_ AlertProvider = (*zulip.AlertProvider)(nil)
 
 	// Validate config interface implementation on compile
+	_ Config[alertmanager.Config]   = (*alertmanager.Config)(nil)
 	_ Config[awsses.Config]         = (*awsses.Config)(nil)
 	_ Config[clickup.Config]        = (*clickup.Config)(nil)
 	_ Config[custom.Config]         = (*custom.Config)(nil)

--- a/config/config.go
+++ b/config/config.go
@@ -594,6 +594,7 @@ func ValidateAlertingConfig(alertingConfig *alerting.Config, endpoints []*endpoi
 		return
 	}
 	alertTypes := []alert.Type{
+		alert.TypeAlertmanager,
 		alert.TypeAWSSES,
 		alert.TypeClickUp,
 		alert.TypeCustom,


### PR DESCRIPTION
## Summary

Adds Alertmanager as an alerting provider, allowing Gatus to post alerts via the Alertmanager API v2.

Rather than reimplementing features like silencing, inhibition rules, grouping, and routing directly in Gatus, this lets users route alerts through Alertmanager and use its full feature set. Alertmanager can then forward to any of its supported receivers (Slack, PagerDuty, email, webhooks, etc.), giving users a single place to manage alert routing and suppression — especially useful alongside an existing Prometheus stack.

- Prometheus-compatible labels (alertname, instance, job, severity)
- Multiple URLs for HA deployments; Alertmanager handles deduplication
- Configurable extra-labels and extra-annotations
- Group-based and per-alert provider overrides
- Lowers minimum-reminder-interval from 5m to 1m to support  Alertmanager's default 5m resolve_timeout (warns if < 5m for other providers)

## Checklist

- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable.