### PR TITLE
feat(alerting): Add configurable api-url for OpsGenie provider

### DIFF
--- a/alerting/provider/opsgenie/opsgenie.go
+++ b/alerting/provider/opsgenie/opsgenie.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	restAPI = "https://api.opsgenie.com/v2/alerts"
+	defaultAPIURL = "https://api.opsgenie.com/v2/alerts"
 )
 
 var (
@@ -25,6 +25,11 @@ var (
 )
 
 type Config struct {
+	// APIURL to use for the OpsGenie API
+	//
+	// default: https://api.opsgenie.com/v2/alerts
+	APIURL string `yaml:"api-url"`
+
 	// APIKey to use for
 	APIKey string `yaml:"api-key"`
 
@@ -58,6 +63,9 @@ func (cfg *Config) Validate() error {
 	if len(cfg.APIKey) == 0 {
 		return ErrAPIKeyNotSet
 	}
+	if len(cfg.APIURL) == 0 {
+		cfg.APIURL = defaultAPIURL
+	}
 	if len(cfg.Source) == 0 {
 		cfg.Source = "gatus"
 	}
@@ -74,6 +82,9 @@ func (cfg *Config) Validate() error {
 }
 
 func (cfg *Config) Merge(override *Config) {
+	if len(override.APIURL) > 0 {
+		cfg.APIURL = override.APIURL
+	}
 	if len(override.APIKey) > 0 {
 		cfg.APIKey = override.APIKey
 	}
@@ -137,12 +148,12 @@ func (provider *AlertProvider) Send(ep *endpoint.Endpoint, alert *alert.Alert, r
 
 func (provider *AlertProvider) sendAlertRequest(cfg *Config, ep *endpoint.Endpoint, alert *alert.Alert, result *endpoint.Result, resolved bool) error {
 	payload := provider.buildCreateRequestBody(cfg, ep, alert, result, resolved)
-	return provider.sendRequest(cfg, restAPI, http.MethodPost, payload)
+	return provider.sendRequest(cfg, cfg.APIURL, http.MethodPost, payload)
 }
 
 func (provider *AlertProvider) closeAlert(cfg *Config, ep *endpoint.Endpoint, alert *alert.Alert) error {
 	payload := provider.buildCloseRequestBody(ep, alert)
-	url := restAPI + "/" + cfg.AliasPrefix + buildKey(ep) + "/close?identifierType=alias"
+	url := cfg.APIURL + "/" + cfg.AliasPrefix + buildKey(ep) + "/close?identifierType=alias"
 	return provider.sendRequest(cfg, url, http.MethodPost, payload)
 }
 

--- a/alerting/provider/opsgenie/opsgenie_test.go
+++ b/alerting/provider/opsgenie/opsgenie_test.go
@@ -20,6 +20,16 @@ func TestAlertProvider_Validate(t *testing.T) {
 	if err := validProvider.Validate(); err != nil {
 		t.Error("provider should've been valid")
 	}
+	if validProvider.DefaultConfig.APIURL != defaultAPIURL {
+		t.Errorf("expected APIURL to be %s, got %s", defaultAPIURL, validProvider.DefaultConfig.APIURL)
+	}
+	customURLProvider := AlertProvider{DefaultConfig: Config{APIKey: "00000000-0000-0000-0000-000000000000", APIURL: "https://api.atlassian.com/jsm/ops/integration/v2/alerts"}}
+	if err := customURLProvider.Validate(); err != nil {
+		t.Error("provider with custom api-url should've been valid")
+	}
+	if customURLProvider.DefaultConfig.APIURL != "https://api.atlassian.com/jsm/ops/integration/v2/alerts" {
+		t.Errorf("expected APIURL to be preserved, got %s", customURLProvider.DefaultConfig.APIURL)
+	}
 }
 
 func TestAlertProvider_Send(t *testing.T) {
@@ -40,6 +50,19 @@ func TestAlertProvider_Send(t *testing.T) {
 			Resolved:      false,
 			ExpectedError: false,
 			MockRoundTripper: test.MockRoundTripper(func(r *http.Request) *http.Response {
+				return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}
+			}),
+		},
+		{
+			Name:          "triggered-custom-api-url",
+			Provider:      AlertProvider{DefaultConfig: Config{APIKey: "00000000-0000-0000-0000-000000000000", APIURL: "https://api.atlassian.com/jsm/ops/integration/v2/alerts"}},
+			Alert:         alert.Alert{Description: &description, SuccessThreshold: 1, FailureThreshold: 1},
+			Resolved:      false,
+			ExpectedError: false,
+			MockRoundTripper: test.MockRoundTripper(func(r *http.Request) *http.Response {
+				if r.URL.String() != "https://api.atlassian.com/jsm/ops/integration/v2/alerts" {
+					return &http.Response{StatusCode: http.StatusInternalServerError, Body: http.NoBody}
+				}
 				return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}
 			}),
 		},
@@ -342,6 +365,14 @@ func TestAlertProvider_GetConfig(t *testing.T) {
 			InputAlert:     alert.Alert{ProviderOverride: map[string]any{"api-key": "00000000-0000-0000-0000-000000000001"}},
 			ExpectedOutput: Config{APIKey: "00000000-0000-0000-0000-000000000001"},
 		},
+		{
+			Name: "provider-with-custom-api-url",
+			Provider: AlertProvider{
+				DefaultConfig: Config{APIKey: "00000000-0000-0000-0000-000000000000", APIURL: "https://api.atlassian.com/jsm/ops/integration/v2/alerts"},
+			},
+			InputAlert:     alert.Alert{},
+			ExpectedOutput: Config{APIKey: "00000000-0000-0000-0000-000000000000", APIURL: "https://api.atlassian.com/jsm/ops/integration/v2/alerts"},
+		},
 	}
 	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
@@ -351,6 +382,9 @@ func TestAlertProvider_GetConfig(t *testing.T) {
 			}
 			if got.APIKey != scenario.ExpectedOutput.APIKey {
 				t.Errorf("expected APIKey to be %s, got %s", scenario.ExpectedOutput.APIKey, got.APIKey)
+			}
+			if scenario.ExpectedOutput.APIURL != "" && got.APIURL != scenario.ExpectedOutput.APIURL {
+				t.Errorf("expected APIURL to be %s, got %s", scenario.ExpectedOutput.APIURL, got.APIURL)
 			}
 			// Test ValidateOverrides as well, since it really just calls GetConfig
 			if err = scenario.Provider.ValidateOverrides("", &scenario.InputAlert); err != nil {


### PR DESCRIPTION
## Summary

The OpsGenie API URL is currently hardcoded to `https://api.opsgenie.com/v2/alerts`. This makes it impossible to use alternative API-compatible endpoints such as:

- **Atlassian JSM Operations API**: `https://api.atlassian.com/jsm/ops/integration/v2/alerts`
- **EU OpsGenie API**: `https://api.eu.opsgenie.com/v2/alerts`

Atlassian is [retiring standalone OpsGenie](https://www.itmethods.com/opsgenie-is-being-deprecated-how-to-prepare-for-migration/) (shutdown April 5, 2027) and migrating users to JSM Operations, which exposes the same alert API at a different base URL.

## Changes

Adds an optional `api-url` field to the OpsGenie `Config` struct, defaulting to the current URL for backwards compatibility:

```yaml
alerting:
  opsgenie:
    api-url: "https://api.atlassian.com/jsm/ops/integration/v2/alerts"
    api-key: "..."
```

## Prior art

Prometheus Alertmanager already supports this via a configurable `api_url` field, which enabled seamless JSM migration without code changes:

- [prometheus/alertmanager#4244](https://github.com/prometheus/alertmanager/issues/4244) — confirmed existing OpsGenie receiver works with JSM by changing the URL
- [prometheus/alertmanager#3949](https://github.com/prometheus/alertmanager/pull/3949) — confirmed API compatibility between OpsGenie and JSM