### PR TITLE
fix: prevent zstd Accept-Encoding panic in API middleware

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -62,7 +62,7 @@ func (a *API) createRouter(cfg *config.Config) *fiber.App {
 	}
 	// Middlewares
 	app.Use(recover.New())
-	app.Use(compress.New())
+	app.Use(compress.New(compress.Config{Level: compress.LevelBestSpeed}))
 	// Define metrics handler, if necessary
 	if cfg.Metrics {
 		metricsHandler := promhttp.InstrumentMetricHandler(prometheus.DefaultRegisterer, promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -17,6 +17,7 @@ func TestNew(t *testing.T) {
 		Path         string
 		ExpectedCode int
 		Gzip         bool
+		Zstd         bool
 		WithSecurity bool
 	}
 	scenarios := []Scenario{
@@ -56,6 +57,12 @@ func TestNew(t *testing.T) {
 			Path:         "/js/app.js",
 			ExpectedCode: fiber.StatusOK,
 			Gzip:         true,
+		},
+		{
+			Name:         "app.js-zstd",
+			Path:         "/js/app.js",
+			ExpectedCode: fiber.StatusOK,
+			Zstd:         true,
 		},
 		{
 			Name:         "chunk-vendors.js",
@@ -119,6 +126,9 @@ func TestNew(t *testing.T) {
 			request := httptest.NewRequest("GET", scenario.Path, http.NoBody)
 			if scenario.Gzip {
 				request.Header.Set("Accept-Encoding", "gzip")
+			}
+			if scenario.Zstd {
+				request.Header.Set("Accept-Encoding", "zstd")
 			}
 			response, err := router.Test(request)
 			if err != nil {


### PR DESCRIPTION
## Bug
Fixes #1546 — requests with `Accept-Encoding: zstd` could panic the server with `unknown encoder level` when using default compression middleware settings.

## Fix
- Configure Fiber compression middleware with an explicit `LevelBestSpeed`
- Add a regression API test that requests `/js/app.js` with `Accept-Encoding: zstd` and asserts a successful response

This avoids passing an invalid zstd encoder level through the stack while keeping compression enabled.

## Testing
- `go test ./api`

Happy to address any feedback.

Greetings, saschabuehrle