### PR TITLE
fix: return error from rdapQuery when no expiration event found

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -529,7 +529,7 @@ func rdapQuery(hostname string) (*whois.Response, error) {
 		}
 	}
 	if response.ExpirationDate.IsZero() {
-		return nil, errors.New("no expiration event found in RDAP response")
+		return nil, fmt.Errorf("no expiration event found in RDAP response for %s", hostname)
 	}
 	return &response, nil
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -55,6 +55,13 @@ func TestRdapQuery(t *testing.T) {
 	} else if response.ExpirationDate.Unix() <= 0 {
 		t.Error("expected to have a valid expiry date, got", response.ExpirationDate.Unix())
 	}
+	// .net domain: rdapQuery must either return a valid expiration or an error,
+	// but never silently return a zero-value expiration date (the bug in #1570)
+	if response, err := rdapQuery("google.net"); err != nil {
+		t.Logf("rdapQuery returned error for .net domain (fallback to WHOIS expected): %s", err)
+	} else if response.ExpirationDate.IsZero() {
+		t.Error("rdapQuery returned a zero expiration date without an error for .net domain")
+	}
 }
 
 func TestGetDomainExpiration(t *testing.T) {
@@ -82,6 +89,12 @@ func TestGetDomainExpiration(t *testing.T) {
 		t.Errorf("expected error to be nil, but got: `%s`", err)
 	} else if domainExpiration <= 0 {
 		t.Error("expected domain expiration to be higher than 0")
+	}
+	// .net domain: should succeed via RDAP or WHOIS fallback (#1570)
+	if domainExpiration, err := GetDomainExpiration("google.net"); err != nil {
+		t.Errorf("expected error to be nil for .net domain, but got: `%s`", err)
+	} else if domainExpiration <= 0 {
+		t.Error("expected domain expiration to be higher than 0 for .net domain")
 	}
 }
 


### PR DESCRIPTION
Fixes #1570

`rdapQuery()` was silently returning a zero-value `ExpirationDate` when the RDAP
response didn't contain an expiration event. This meant `GetDomainExpiration` never
fell back to WHOIS for domains like .net where RDAP might not include expiration data.

Added a check after the event loop: if `ExpirationDate` is still zero, return an error
so the caller falls back to WHOIS as intended (client.go:73-74).

Also added a test case for a .net domain in `TestRdapQuery`.