### PR TITLE
feat(email): add batched email alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1067,6 +1067,9 @@ endpoints:
 | `alerting.email.port`              | Port the mail server is listening to (e.g. `587`)                                             | Required `0`  |
 | `alerting.email.to`                | Email(s) to send the alerts to                                                                | Required `""` |
 | `alerting.email.default-alert`     | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert)    | N/A           |
+| `alerting.email.batch.enabled`     | Whether to batch email alerts into a single summary email                                     | `false`       |
+| `alerting.email.batch.window`      | How long to wait for additional alerts before sending the summary                             | `2m`          |
+| `alerting.email.batch.max-alerts`  | Maximum number of alerts to buffer before flushing immediately                                | `50`          |
 | `alerting.email.client.insecure`   | Whether to skip TLS verification                                                              | `false`       |
 | `alerting.email.overrides`         | List of overrides that may be prioritized over the default configuration                      | `[]`          |
 | `alerting.email.overrides[].group` | Endpoint group for which the configuration will be overridden by this configuration           | `""`          |
@@ -1081,6 +1084,10 @@ alerting:
     host: "mail.example.com"
     port: 587
     to: "recipient1@example.com,recipient2@example.com"
+    batch:
+      enabled: true
+      window: 2m
+      max-alerts: 50
     client:
       insecure: false
     # You can also add group-specific to keys, which will
@@ -1116,6 +1123,8 @@ endpoints:
 ```
 
 > ⚠ Some mail servers are painfully slow.
+>
+> When batching is enabled, Gatus groups email alerts that share the same SMTP configuration and recipient list into one summary email. Triggered and resolved alerts are rendered in separate sections, and pending summaries are flushed on shutdown.
 
 
 #### Configuring Gitea alerts

--- a/alerting/provider/email/batch.go
+++ b/alerting/provider/email/batch.go
@@ -9,16 +9,26 @@ import (
 
 	"github.com/TwiN/gatus/v5/alerting/alert"
 	"github.com/TwiN/gatus/v5/config/endpoint"
+	"github.com/TwiN/logr"
+)
+
+const (
+	DefaultBatchWindow = 2 * time.Minute
+	DefaultBatchMax    = 50
 )
 
 type BatchConfig struct {
-	Enabled bool          `yaml:"batch-enabled,omitempty"`
-	Window  time.Duration `yaml:"batch-window,omitempty"`
+	Enabled bool          `yaml:"enabled,omitempty"`
+	Window  time.Duration `yaml:"window,omitempty"`
+	Max     int           `yaml:"max-alerts,omitempty"`
 }
 
 func (cfg *BatchConfig) setDefaults() {
 	if cfg.Window <= 0 {
-		cfg.Window = 30 * time.Second
+		cfg.Window = DefaultBatchWindow
+	}
+	if cfg.Max <= 0 {
+		cfg.Max = DefaultBatchMax
 	}
 }
 
@@ -30,11 +40,15 @@ type batchMessage struct {
 }
 
 type batchKey struct {
-	from     string
-	host     string
-	port     int
-	to       string
-	resolved bool
+	from string
+	to   string
+	host string
+	port int
+}
+
+type batchManager struct {
+	mu      sync.Mutex
+	entries map[batchKey]*batchEntry
 }
 
 type batchEntry struct {
@@ -43,72 +57,153 @@ type batchEntry struct {
 	timer    *time.Timer
 }
 
-var emailBatchState = struct {
-	sync.Mutex
-	entries map[batchKey]*batchEntry
-}{entries: make(map[batchKey]*batchEntry)}
+var emailBatchManager = &batchManager{entries: make(map[batchKey]*batchEntry)}
 
 func (provider *AlertProvider) queueOrSend(ep *endpoint.Endpoint, al *alert.Alert, result *endpoint.Result, resolved bool, cfg *Config) error {
 	if provider == nil || provider.Batch == nil || !provider.Batch.Enabled {
-		return provider.sendEmail(cfg, provider.buildMessageSubjectAndBody(ep, al, result, resolved))
+		subject, body := provider.buildMessageSubjectAndBody(ep, al, result, resolved)
+		return provider.sendEmail(cfg, subject, body)
 	}
 	provider.Batch.setDefaults()
 	message := batchMessage{endpoint: ep, alert: al, result: result, resolved: resolved}
-	key := batchKey{from: cfg.From, host: cfg.Host, port: cfg.Port, to: cfg.To, resolved: resolved}
+	key := batchKey{from: cfg.From, to: cfg.To, host: cfg.Host, port: cfg.Port}
+	return emailBatchManager.enqueue(provider, key, cfg, message)
+}
 
-	emailBatchState.Lock()
-	defer emailBatchState.Unlock()
-	entry, exists := emailBatchState.entries[key]
+func (manager *batchManager) enqueue(provider *AlertProvider, key batchKey, cfg *Config, message batchMessage) error {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+
+	entry, exists := manager.entries[key]
 	if !exists {
 		entry = &batchEntry{cfg: cfg}
 		entry.timer = time.AfterFunc(provider.Batch.Window, func() {
-			provider.flushBatch(key)
+			manager.flush(provider, key)
 		})
-		emailBatchState.entries[key] = entry
+		manager.entries[key] = entry
 	}
-	entry.messages = append(entry.messages, message)
+	entry.messages = appendOrReplace(entry.messages, message)
+	if len(entry.messages) >= provider.Batch.Max {
+		go manager.flush(provider, key)
+	}
 	return nil
 }
 
-func (provider *AlertProvider) flushBatch(key batchKey) {
-	emailBatchState.Lock()
-	entry, exists := emailBatchState.entries[key]
-	if !exists {
-		emailBatchState.Unlock()
-		return
+func appendOrReplace(messages []batchMessage, message batchMessage) []batchMessage {
+	for index, existing := range messages {
+		if existing.endpoint.Key() == message.endpoint.Key() && existing.resolved == message.resolved {
+			messages[index] = message
+			return messages
+		}
 	}
-	delete(emailBatchState.entries, key)
-	emailBatchState.Unlock()
-
-	subject, body := provider.buildBatchedMessageSubjectAndBody(entry.messages, key.resolved)
-	_ = provider.sendEmail(entry.cfg, subject, body)
+	return append(messages, message)
 }
 
-func (provider *AlertProvider) buildBatchedMessageSubjectAndBody(messages []batchMessage, resolved bool) (string, string) {
+func (manager *batchManager) flush(provider *AlertProvider, key batchKey) {
+	entry := manager.take(key)
+	if entry == nil || len(entry.messages) == 0 {
+		return
+	}
+	subject, body := provider.buildBatchedMessageSubjectAndBody(entry.messages)
+	if err := provider.sendEmail(entry.cfg, subject, body); err != nil {
+		logr.Errorf("[email.batch.flush] Failed to send batched email alert: %s", err.Error())
+	}
+}
+
+func (manager *batchManager) take(key batchKey) *batchEntry {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	entry, exists := manager.entries[key]
+	if !exists {
+		return nil
+	}
+	delete(manager.entries, key)
+	if entry.timer != nil {
+		entry.timer.Stop()
+	}
+	return entry
+}
+
+func (manager *batchManager) flushAll(provider *AlertProvider) {
+	manager.mu.Lock()
+	keys := make([]batchKey, 0, len(manager.entries))
+	for key := range manager.entries {
+		keys = append(keys, key)
+	}
+	manager.mu.Unlock()
+	for _, key := range keys {
+		manager.flush(provider, key)
+	}
+}
+
+func (provider *AlertProvider) buildBatchedMessageSubjectAndBody(messages []batchMessage) (string, string) {
 	if len(messages) == 1 {
 		msg := messages[0]
-		return provider.buildMessageSubjectAndBody(msg.endpoint, msg.alert, msg.result, resolved)
+		return provider.buildMessageSubjectAndBody(msg.endpoint, msg.alert, msg.result, msg.resolved)
 	}
-	serviceNames := make([]string, 0, len(messages))
+	triggered := make([]batchMessage, 0)
+	resolved := make([]batchMessage, 0)
 	for _, message := range messages {
-		serviceNames = append(serviceNames, message.endpoint.DisplayName())
-	}
-	sort.Strings(serviceNames)
-	statusWord := "triggered"
-	intro := "The following alerts were triggered"
-	if resolved {
-		statusWord = "resolved"
-		intro = "The following alerts were resolved"
-	}
-	subject := fmt.Sprintf("%d alerts %s", len(messages), statusWord)
-	lines := []string{intro + ":", ""}
-	for _, message := range messages {
-		line := fmt.Sprintf("- %s", message.endpoint.DisplayName())
-		if description := message.alert.GetDescription(); description != "" {
-			line += fmt.Sprintf(" (%s)", description)
+		if message.resolved {
+			resolved = append(resolved, message)
+		} else {
+			triggered = append(triggered, message)
 		}
-		lines = append(lines, line)
 	}
-	lines = append(lines, "", "Services: "+strings.Join(serviceNames, ", "))
-	return subject, strings.Join(lines, "\n")
+	subjectParts := make([]string, 0, 2)
+	if len(triggered) > 0 {
+		subjectParts = append(subjectParts, fmt.Sprintf("%d service(s) DOWN", len(triggered)))
+	}
+	if len(resolved) > 0 {
+		subjectParts = append(subjectParts, fmt.Sprintf("%d service(s) recovered", len(resolved)))
+	}
+	if len(subjectParts) == 0 {
+		subjectParts = append(subjectParts, fmt.Sprintf("%d alert(s)", len(messages)))
+	}
+	lines := []string{
+		fmt.Sprintf("Gatus Alert Summary, %s", time.Now().UTC().Format("2006-01-02 15:04 UTC")),
+		strings.Repeat("=", 60),
+	}
+	if len(triggered) > 0 {
+		lines = append(lines, "", fmt.Sprintf("TRIGGERED (%d)", len(triggered)), strings.Repeat("-", 40))
+		lines = append(lines, formatBatchLines(triggered, false)...)
+	}
+	if len(resolved) > 0 {
+		lines = append(lines, "", fmt.Sprintf("RESOLVED (%d)", len(resolved)), strings.Repeat("-", 40))
+		lines = append(lines, formatBatchLines(resolved, true)...)
+	}
+	lines = append(lines, "", "—", "Gatus")
+	return fmt.Sprintf("[Gatus] %s", strings.Join(subjectParts, " / ")), strings.Join(lines, "\n")
+}
+
+func formatBatchLines(messages []batchMessage, resolved bool) []string {
+	sort.Slice(messages, func(i, j int) bool {
+		return messages[i].endpoint.DisplayName() < messages[j].endpoint.DisplayName()
+	})
+	lines := make([]string, 0)
+	for _, message := range messages {
+		ep := message.endpoint
+		lines = append(lines, fmt.Sprintf("- %s", ep.DisplayName()))
+		if ep.Group != "" {
+			lines = append(lines, fmt.Sprintf("  Group: %s", ep.Group))
+		}
+		if ep.URL != "" && !resolved {
+			lines = append(lines, fmt.Sprintf("  URL: %s", ep.URL))
+		}
+		if description := message.alert.GetDescription(); description != "" {
+			lines = append(lines, fmt.Sprintf("  Note: %s", description))
+		}
+		if !resolved && len(message.result.ConditionResults) > 0 {
+			lines = append(lines, "  Conditions:")
+			for _, conditionResult := range message.result.ConditionResults {
+				prefix := "❌"
+				if conditionResult.Success {
+					prefix = "✅"
+				}
+				lines = append(lines, fmt.Sprintf("    %s %s", prefix, conditionResult.Condition))
+			}
+		}
+		lines = append(lines, "")
+	}
+	return lines
 }

--- a/alerting/provider/email/batch.go
+++ b/alerting/provider/email/batch.go
@@ -1,0 +1,114 @@
+package email
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/TwiN/gatus/v5/alerting/alert"
+	"github.com/TwiN/gatus/v5/config/endpoint"
+)
+
+type BatchConfig struct {
+	Enabled bool          `yaml:"batch-enabled,omitempty"`
+	Window  time.Duration `yaml:"batch-window,omitempty"`
+}
+
+func (cfg *BatchConfig) setDefaults() {
+	if cfg.Window <= 0 {
+		cfg.Window = 30 * time.Second
+	}
+}
+
+type batchMessage struct {
+	endpoint *endpoint.Endpoint
+	alert    *alert.Alert
+	result   *endpoint.Result
+	resolved bool
+}
+
+type batchKey struct {
+	from     string
+	host     string
+	port     int
+	to       string
+	resolved bool
+}
+
+type batchEntry struct {
+	cfg      *Config
+	messages []batchMessage
+	timer    *time.Timer
+}
+
+var emailBatchState = struct {
+	sync.Mutex
+	entries map[batchKey]*batchEntry
+}{entries: make(map[batchKey]*batchEntry)}
+
+func (provider *AlertProvider) queueOrSend(ep *endpoint.Endpoint, al *alert.Alert, result *endpoint.Result, resolved bool, cfg *Config) error {
+	if provider == nil || provider.Batch == nil || !provider.Batch.Enabled {
+		return provider.sendEmail(cfg, provider.buildMessageSubjectAndBody(ep, al, result, resolved))
+	}
+	provider.Batch.setDefaults()
+	message := batchMessage{endpoint: ep, alert: al, result: result, resolved: resolved}
+	key := batchKey{from: cfg.From, host: cfg.Host, port: cfg.Port, to: cfg.To, resolved: resolved}
+
+	emailBatchState.Lock()
+	defer emailBatchState.Unlock()
+	entry, exists := emailBatchState.entries[key]
+	if !exists {
+		entry = &batchEntry{cfg: cfg}
+		entry.timer = time.AfterFunc(provider.Batch.Window, func() {
+			provider.flushBatch(key)
+		})
+		emailBatchState.entries[key] = entry
+	}
+	entry.messages = append(entry.messages, message)
+	return nil
+}
+
+func (provider *AlertProvider) flushBatch(key batchKey) {
+	emailBatchState.Lock()
+	entry, exists := emailBatchState.entries[key]
+	if !exists {
+		emailBatchState.Unlock()
+		return
+	}
+	delete(emailBatchState.entries, key)
+	emailBatchState.Unlock()
+
+	subject, body := provider.buildBatchedMessageSubjectAndBody(entry.messages, key.resolved)
+	_ = provider.sendEmail(entry.cfg, subject, body)
+}
+
+func (provider *AlertProvider) buildBatchedMessageSubjectAndBody(messages []batchMessage, resolved bool) (string, string) {
+	if len(messages) == 1 {
+		msg := messages[0]
+		return provider.buildMessageSubjectAndBody(msg.endpoint, msg.alert, msg.result, resolved)
+	}
+	serviceNames := make([]string, 0, len(messages))
+	for _, message := range messages {
+		serviceNames = append(serviceNames, message.endpoint.DisplayName())
+	}
+	sort.Strings(serviceNames)
+	statusWord := "triggered"
+	intro := "The following alerts were triggered"
+	if resolved {
+		statusWord = "resolved"
+		intro = "The following alerts were resolved"
+	}
+	subject := fmt.Sprintf("%d alerts %s", len(messages), statusWord)
+	lines := []string{intro + ":", ""}
+	for _, message := range messages {
+		line := fmt.Sprintf("- %s", message.endpoint.DisplayName())
+		if description := message.alert.GetDescription(); description != "" {
+			line += fmt.Sprintf(" (%s)", description)
+		}
+		lines = append(lines, line)
+	}
+	lines = append(lines, "", "Services: "+strings.Join(serviceNames, ", "))
+	return subject, strings.Join(lines, "\n")
+}

--- a/alerting/provider/email/batch.go
+++ b/alerting/provider/email/batch.go
@@ -125,6 +125,9 @@ func (manager *batchManager) take(key batchKey) *batchEntry {
 }
 
 func (manager *batchManager) flushAll(provider *AlertProvider) {
+	if provider == nil {
+		return
+	}
 	manager.mu.Lock()
 	keys := make([]batchKey, 0, len(manager.entries))
 	for key := range manager.entries {

--- a/alerting/provider/email/email.go
+++ b/alerting/provider/email/email.go
@@ -117,6 +117,10 @@ func (provider *AlertProvider) Send(ep *endpoint.Endpoint, alert *alert.Alert, r
 	return provider.queueOrSend(ep, alert, result, resolved, cfg)
 }
 
+func (provider *AlertProvider) Flush() {
+	emailBatchManager.flushAll(provider)
+}
+
 func (provider *AlertProvider) sendEmail(cfg *Config, subject, body string) error {
 	var username string
 	if len(cfg.Username) > 0 {

--- a/alerting/provider/email/email.go
+++ b/alerting/provider/email/email.go
@@ -77,6 +77,10 @@ type AlertProvider struct {
 	// DefaultAlert is the default alert configuration to use for endpoints with an alert of the appropriate type
 	DefaultAlert *alert.Alert `yaml:"default-alert,omitempty"`
 
+	// Batch controls whether multiple email alerts are grouped into one message over a short time window.
+	// Disabled by default to preserve existing behavior.
+	Batch *BatchConfig `yaml:"batch,omitempty"`
+
 	// Overrides is a list of Override that may be prioritized over the default configuration
 	Overrides []Override `yaml:"overrides,omitempty"`
 }
@@ -89,6 +93,9 @@ type Override struct {
 
 // Validate the provider's configuration
 func (provider *AlertProvider) Validate() error {
+	if provider.Batch != nil {
+		provider.Batch.setDefaults()
+	}
 	registeredGroups := make(map[string]bool)
 	if provider.Overrides != nil {
 		for _, override := range provider.Overrides {
@@ -107,13 +114,16 @@ func (provider *AlertProvider) Send(ep *endpoint.Endpoint, alert *alert.Alert, r
 	if err != nil {
 		return err
 	}
+	return provider.queueOrSend(ep, alert, result, resolved, cfg)
+}
+
+func (provider *AlertProvider) sendEmail(cfg *Config, subject, body string) error {
 	var username string
 	if len(cfg.Username) > 0 {
 		username = cfg.Username
 	} else {
 		username = cfg.From
 	}
-	subject, body := provider.buildMessageSubjectAndBody(ep, alert, result, resolved)
 	m := gomail.NewMessage()
 	m.SetHeader("From", cfg.From)
 	m.SetHeader("To", strings.Split(cfg.To, ",")...)
@@ -121,16 +131,13 @@ func (provider *AlertProvider) Send(ep *endpoint.Endpoint, alert *alert.Alert, r
 	m.SetBody("text/plain", body)
 	var d *gomail.Dialer
 	if len(cfg.Password) == 0 {
-		// Get the domain in the From address
 		localName := "localhost"
 		fromParts := strings.Split(cfg.From, `@`)
 		if len(fromParts) == 2 {
 			localName = fromParts[1]
 		}
-		// Create a dialer with no authentication
 		d = &gomail.Dialer{Host: cfg.Host, Port: cfg.Port, LocalName: localName}
 	} else {
-		// Create an authenticated dialer
 		d = gomail.NewDialer(cfg.Host, cfg.Port, username, cfg.Password)
 	}
 	if cfg.ClientConfig != nil && cfg.ClientConfig.Insecure {

--- a/alerting/provider/email/email_test.go
+++ b/alerting/provider/email/email_test.go
@@ -163,10 +163,10 @@ func TestAlertProvider_buildBatchedMessageSubjectAndBody(t *testing.T) {
 	if !contains(body, "TRIGGERED (1)") || !contains(body, "RESOLVED (1)") {
 		t.Fatalf("expected body to contain both sections, got %q", body)
 	}
-	if !contains(body, "- service-a") || !contains(body, "URL: https://a.example.com") || !contains(body, "❌ [STATUS] == 200") {
+	if !contains(body, "- core/service-a") || !contains(body, "URL: https://a.example.com") || !contains(body, "❌ [STATUS] == 200") {
 		t.Fatalf("expected triggered details in body, got %q", body)
 	}
-	if !contains(body, "- service-b") {
+	if !contains(body, "- core/service-b") {
 		t.Fatalf("expected resolved service in body, got %q", body)
 	}
 }

--- a/alerting/provider/email/email_test.go
+++ b/alerting/provider/email/email_test.go
@@ -149,6 +149,21 @@ func TestAlertProvider_buildRequestBody(t *testing.T) {
 	}
 }
 
+func TestAlertProvider_buildBatchedMessageSubjectAndBody(t *testing.T) {
+	description := "api down"
+	provider := AlertProvider{}
+	subject, body := provider.buildBatchedMessageSubjectAndBody([]batchMessage{
+		{endpoint: &endpoint.Endpoint{Name: "service-a"}, alert: &alert.Alert{Description: &description}},
+		{endpoint: &endpoint.Endpoint{Name: "service-b"}, alert: &alert.Alert{}},
+	}, false)
+	if subject != "2 alerts triggered" {
+		t.Fatalf("expected batched subject, got %q", subject)
+	}
+	if body != "The following alerts were triggered:\n\n- service-a (api down)\n- service-b\n\nServices: service-a, service-b" {
+		t.Fatalf("unexpected batched body: %q", body)
+	}
+}
+
 func TestAlertProvider_GetDefaultAlert(t *testing.T) {
 	if (&AlertProvider{DefaultAlert: &alert.Alert{}}).GetDefaultAlert() == nil {
 		t.Error("expected default alert to be not nil")

--- a/alerting/provider/email/email_test.go
+++ b/alerting/provider/email/email_test.go
@@ -1,6 +1,7 @@
 package email
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/TwiN/gatus/v5/alerting/alert"
@@ -153,15 +154,25 @@ func TestAlertProvider_buildBatchedMessageSubjectAndBody(t *testing.T) {
 	description := "api down"
 	provider := AlertProvider{}
 	subject, body := provider.buildBatchedMessageSubjectAndBody([]batchMessage{
-		{endpoint: &endpoint.Endpoint{Name: "service-a"}, alert: &alert.Alert{Description: &description}},
-		{endpoint: &endpoint.Endpoint{Name: "service-b"}, alert: &alert.Alert{}},
-	}, false)
-	if subject != "2 alerts triggered" {
+		{endpoint: &endpoint.Endpoint{Name: "service-a", Group: "core", URL: "https://a.example.com"}, alert: &alert.Alert{Description: &description}, result: &endpoint.Result{ConditionResults: []*endpoint.ConditionResult{{Condition: "[STATUS] == 200", Success: false}}}, resolved: false},
+		{endpoint: &endpoint.Endpoint{Name: "service-b", Group: "core"}, alert: &alert.Alert{}, resolved: true},
+	})
+	if subject != "[Gatus] 1 service(s) DOWN / 1 service(s) recovered" {
 		t.Fatalf("expected batched subject, got %q", subject)
 	}
-	if body != "The following alerts were triggered:\n\n- service-a (api down)\n- service-b\n\nServices: service-a, service-b" {
-		t.Fatalf("unexpected batched body: %q", body)
+	if !contains(body, "TRIGGERED (1)") || !contains(body, "RESOLVED (1)") {
+		t.Fatalf("expected body to contain both sections, got %q", body)
 	}
+	if !contains(body, "- service-a") || !contains(body, "URL: https://a.example.com") || !contains(body, "❌ [STATUS] == 200") {
+		t.Fatalf("expected triggered details in body, got %q", body)
+	}
+	if !contains(body, "- service-b") {
+		t.Fatalf("expected resolved service in body, got %q", body)
+	}
+}
+
+func contains(s, needle string) bool {
+	return strings.Contains(s, needle)
 }
 
 func TestAlertProvider_GetDefaultAlert(t *testing.T) {

--- a/alerting/provider/email/email_test.go
+++ b/alerting/provider/email/email_test.go
@@ -3,6 +3,7 @@ package email
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/TwiN/gatus/v5/alerting/alert"
 	"github.com/TwiN/gatus/v5/config/endpoint"
@@ -168,6 +169,67 @@ func TestAlertProvider_buildBatchedMessageSubjectAndBody(t *testing.T) {
 	}
 	if !contains(body, "- core/service-b") {
 		t.Fatalf("expected resolved service in body, got %q", body)
+	}
+}
+
+func TestAppendOrReplace_DedupesSameEndpointAndState(t *testing.T) {
+	messages := []batchMessage{{
+		endpoint: &endpoint.Endpoint{Name: "service-a", Group: "core"},
+		alert:    &alert.Alert{},
+		result:   &endpoint.Result{},
+		resolved: false,
+	}}
+	replaced := appendOrReplace(messages, batchMessage{
+		endpoint: &endpoint.Endpoint{Name: "service-a", Group: "core"},
+		alert:    &alert.Alert{},
+		result:   &endpoint.Result{ConditionResults: []*endpoint.ConditionResult{{Condition: "[STATUS] == 200", Success: false}}},
+		resolved: false,
+	})
+	if len(replaced) != 1 {
+		t.Fatalf("expected one deduped message, got %d", len(replaced))
+	}
+	if len(replaced[0].result.ConditionResults) != 1 {
+		t.Fatalf("expected replacement payload to be kept")
+	}
+}
+
+func TestAppendOrReplace_KeepsTriggeredAndResolvedSeparate(t *testing.T) {
+	messages := []batchMessage{{
+		endpoint: &endpoint.Endpoint{Name: "service-a", Group: "core"},
+		alert:    &alert.Alert{},
+		result:   &endpoint.Result{},
+		resolved: false,
+	}}
+	result := appendOrReplace(messages, batchMessage{
+		endpoint: &endpoint.Endpoint{Name: "service-a", Group: "core"},
+		alert:    &alert.Alert{},
+		result:   &endpoint.Result{},
+		resolved: true,
+	})
+	if len(result) != 2 {
+		t.Fatalf("expected triggered and resolved entries to both remain, got %d", len(result))
+	}
+}
+
+func TestBatchManager_TakeRemovesPendingEntry(t *testing.T) {
+	manager := &batchManager{entries: make(map[batchKey]*batchEntry)}
+	key := batchKey{from: "from@example.com", to: "to@example.com", host: "smtp.example.com", port: 587}
+	manager.entries[key] = &batchEntry{
+		cfg: &Config{From: "from@example.com", To: "to@example.com", Host: "smtp.example.com", Port: 587, Password: "password"},
+		messages: []batchMessage{{
+			endpoint: &endpoint.Endpoint{Name: "service-a"},
+			alert:    &alert.Alert{},
+			result:   &endpoint.Result{},
+			resolved: false,
+		}},
+		timer: time.NewTimer(time.Hour),
+	}
+	entry := manager.take(key)
+	if entry == nil {
+		t.Fatal("expected take to return the pending batch entry")
+	}
+	if len(manager.entries) != 0 {
+		t.Fatalf("expected take to remove pending entry, got %d", len(manager.entries))
 	}
 }
 

--- a/alerting/provider/provider.go
+++ b/alerting/provider/provider.go
@@ -60,6 +60,10 @@ type AlertProvider interface {
 	ValidateOverrides(group string, alert *alert.Alert) error
 }
 
+type Flushable interface {
+	Flush()
+}
+
 type Config[T any] interface {
 	Validate() error
 	Merge(override *T)

--- a/alerting/provider/provider.go
+++ b/alerting/provider/provider.go
@@ -60,6 +60,7 @@ type AlertProvider interface {
 	ValidateOverrides(group string, alert *alert.Alert) error
 }
 
+// Flushable is implemented by providers that buffer alerts and need to flush pending messages on shutdown.
 type Flushable interface {
 	Flush()
 }

--- a/watchdog/watchdog.go
+++ b/watchdog/watchdog.go
@@ -78,12 +78,11 @@ func flushAlertProviders(cfg *config.Config) {
 	if cfg == nil || cfg.Alerting == nil {
 		return
 	}
-	providers := []provider.AlertProvider{
-		cfg.Alerting.Email,
-	}
-	for _, alertProvider := range providers {
-		if flushable, ok := alertProvider.(provider.Flushable); ok && flushable != nil {
-			flushable.Flush()
-		}
+	flushProvider(cfg.Alerting.Email)
+}
+
+func flushProvider(alertProvider provider.AlertProvider) {
+	if flushable, ok := alertProvider.(provider.Flushable); ok && flushable != nil {
+		flushable.Flush()
 	}
 }

--- a/watchdog/watchdog.go
+++ b/watchdog/watchdog.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/TwiN/gatus/v5/alerting/provider"
 	"github.com/TwiN/gatus/v5/config"
 	"golang.org/x/sync/semaphore"
 )
@@ -69,5 +70,20 @@ func Shutdown(cfg *config.Config) {
 			ep.Close()
 		}
 	}
+	flushAlertProviders(cfg)
 	cancelFunc()
+}
+
+func flushAlertProviders(cfg *config.Config) {
+	if cfg == nil || cfg.Alerting == nil {
+		return
+	}
+	providers := []provider.AlertProvider{
+		cfg.Alerting.Email,
+	}
+	for _, alertProvider := range providers {
+		if flushable, ok := alertProvider.(provider.Flushable); ok && flushable != nil {
+			flushable.Flush()
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- add optional batching support for SMTP email alerts
- group triggered and resolved alert events into summary emails over a short time window
- flush pending email batches on shutdown and add focused test coverage

## Why
This helps reduce email spam during broader incidents, for example when:
- multiple services on the same server fail together
- an automatic update breaks several services
- several endpoints depend on one shared service like DNS, auth, proxying, or a database

## Configuration
```yaml
alerting:
  email:
    from: alerts@example.com
    to: you@example.com
    host: smtp.example.com
    port: 587
    username: alerts@example.com
    password: secret
    batch:
      enabled: true
      window: 30s
      max-alerts: 50
```

Closes #1622
