### PR TITLE
fix(config): walk the resolved config path, not the raw argument

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -218,7 +218,11 @@ func LoadConfiguration(configPath string) (*Config, error) {
 	}
 	var config *Config
 	if fileInfo.IsDir() {
-		err := walkConfigDir(configPath, func(path string, d fs.DirEntry, err error) error {
+		// Walk the directory we actually resolved, not the raw argument: when
+		// configPath is empty and the directory came from one of the default
+		// paths, walking configPath would descend from the current working
+		// directory and silently skip every file. See #456.
+		err := walkConfigDir(usedConfigPath, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return fmt.Errorf("error walking path %s: %w", path, err)
 			}


### PR DESCRIPTION
### Problem

`LoadConfiguration` chooses `usedConfigPath` by walking the raw
argument and then the two default paths (`DefaultConfigurationFilePath`,
`DefaultFallbackConfigurationFilePath`), keeping the first one that
stats cleanly.

When the resolved path turns out to be a directory it walks it, but the
call uses the function argument `configPath`, not the resolved
`usedConfigPath`:

```go
if fileInfo.IsDir() {
    err := walkConfigDir(configPath, func(path string, d fs.DirEntry, err error) error {
        ...
```

If `configPath` is empty (the common case, e.g. `GATUS_CONFIG_PATH`
unset) and one of the default paths happens to resolve to a directory,
`walkConfigDir` is handed `""`, descends from the current working
directory, and silently skips every config file. Gatus fails to load
anything, even though `os.Stat` on the default path succeeded. #456.

### Fix

Walk the path we already proved exists:

```diff
- err := walkConfigDir(configPath, func(path string, d fs.DirEntry, err error) error {
+ err := walkConfigDir(usedConfigPath, func(path string, d fs.DirEntry, err error) error {
```

No behaviour change when the caller explicitly passes a directory:
`configPath == usedConfigPath` in that case. Only the
"argument is empty, default resolves to a directory" path changes, and
that path is currently broken.

Fixes #456