### PR TITLE
fix(client): improve udp support with probe

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/TwiN/gocache/v2"
@@ -117,6 +118,22 @@ func CanCreateNetworkConnection(netType string, address string, body string, con
 			return false, nil
 		}
 		return true, buf[:n]
+	}
+	// For UDP with no body, net.DialTimeout always succeeds (UDP is connectionless).
+	// Send a probe packet so the OS can receive an ICMP port-unreachable response if
+	// nothing is listening, then detect it via ECONNREFUSED on the subsequent Read.
+	if strings.HasPrefix(netType, "udp") {
+		connection.SetDeadline(time.Now().Add(config.Timeout))
+		if _, err = connection.Write([]byte{0}); err != nil {
+			return false, nil
+		}
+		buf := make([]byte, MaximumMessageSize)
+		if _, err = connection.Read(buf); err != nil {
+			if errors.Is(err, syscall.ECONNREFUSED) {
+				return false, nil
+			}
+			// Timeout or other error: server is present but silent (normal for many UDP services).
+		}
 	}
 	return true, nil
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"io"
+	"net"
 	"net/http"
 	"net/netip"
 	"os"
@@ -311,6 +312,36 @@ func TestCanCreateConnection(t *testing.T) {
 	connected, _ = CanCreateNetworkConnection("tcp", "1.1.1.1:53", "", &Config{Timeout: 5 * time.Second})
 	if !connected {
 		t.Error("should've succeeded, because that IP should always™ be up")
+	}
+}
+
+func TestCanCreateUDPConnection(t *testing.T) {
+	scenarios := []struct {
+		name          string
+		withListener  bool
+		wantConnected bool
+	}{
+		{name: "open-port", withListener: true, wantConnected: true},
+		{name: "closed-port", withListener: false, wantConnected: false},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			t.Parallel()
+			listener, err := net.ListenPacket("udp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			addr := listener.LocalAddr().String()
+			if scenario.withListener {
+				defer listener.Close()
+			} else {
+				listener.Close()
+			}
+			connected, _ := CanCreateNetworkConnection("udp", addr, "", &Config{Timeout: time.Second})
+			if connected != scenario.wantConnected {
+				t.Errorf("expected connected=%v, got %v", scenario.wantConnected, connected)
+			}
+		})
 	}
 }
 

--- a/config/endpoint/endpoint_test.go
+++ b/config/endpoint/endpoint_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"strings"
 	"testing"
@@ -287,6 +288,50 @@ func TestEndpoint(t *testing.T) {
 				if scenario.ExpectedResult.DomainExpiration.Hours() > 0 && !(result.DomainExpiration.Hours() > 0) {
 					t.Errorf("Expected domain expiration to be non-zero, got %v", result.DomainExpiration)
 				}
+			}
+		})
+	}
+}
+
+// TestUDPEndpointConnectedCondition reproduces the bug reported in https://github.com/TwiN/gatus/issues/1536:
+// a UDP endpoint with [CONNECTED] == true was always reported as successful, even for closed ports.
+func TestUDPEndpointConnectedCondition(t *testing.T) {
+	scenarios := []struct {
+		name          string
+		withListener  bool
+		wantConnected bool
+		wantSuccess   bool
+	}{
+		{name: "open-port", withListener: true, wantConnected: true, wantSuccess: true},
+		{name: "closed-port", withListener: false, wantConnected: false, wantSuccess: false},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			listener, err := net.ListenPacket("udp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			addr := listener.LocalAddr().String()
+			if scenario.withListener {
+				defer listener.Close()
+			} else {
+				listener.Close()
+			}
+			endpoint := Endpoint{
+				Name:         "udp-service",
+				URL:          "udp://" + addr,
+				Conditions:   []Condition{"[CONNECTED] == true"},
+				ClientConfig: &client.Config{Timeout: time.Second},
+			}
+			if err := endpoint.ValidateAndSetDefaults(); err != nil {
+				t.Fatal(err)
+			}
+			result := endpoint.EvaluateHealth()
+			if result.Connected != scenario.wantConnected {
+				t.Errorf("expected connected=%v, got %v", scenario.wantConnected, result.Connected)
+			}
+			if result.Success != scenario.wantSuccess {
+				t.Errorf("expected success=%v, got %v", scenario.wantSuccess, result.Success)
 			}
 		})
 	}

--- a/config/endpoint/endpoint_test.go
+++ b/config/endpoint/endpoint_test.go
@@ -293,8 +293,6 @@ func TestEndpoint(t *testing.T) {
 	}
 }
 
-// TestUDPEndpointConnectedCondition reproduces the bug reported in https://github.com/TwiN/gatus/issues/1536:
-// a UDP endpoint with [CONNECTED] == true was always reported as successful, even for closed ports.
 func TestUDPEndpointConnectedCondition(t *testing.T) {
 	scenarios := []struct {
 		name          string


### PR DESCRIPTION
## Summary
                                                                                                                                                                                
Fixes #1536 

UDP endpoints with `[CONNECTED] == true` always reported as healthy, even for closed ports.                                                                     

`net.DialTimeout` on UDP always succeeds (UDP is connectionless), so a probe byte is sent after dialing. If the port is closed, the OS returns an ICMP port-unreachable which surfaces as `ECONNREFUSED` on the subsequent read, marking the connection as failed. A timeout/no-response is treated as success (normal for silent UDP services).

## Checklist
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.