### PR TITLE
feat(client): ipv6 support for tcp/udp

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -99,7 +99,16 @@ func CanCreateNetworkConnection(netType string, address string, body string, con
 	const (
 		MaximumMessageSize = 1024 // in bytes
 	)
-	connection, err := net.DialTimeout(netType, address, config.Timeout)
+	resolvedNetType := netType
+	if config != nil {
+		switch config.Network {
+		case "ip4":
+			resolvedNetType = netType + "4" // "ip4" -> "tcp4"/"udp4"
+		case "ip6":
+			resolvedNetType = netType + "6" // "ip6" -> "tcp6"/"udp6"
+		}
+	}
+	connection, err := net.DialTimeout(resolvedNetType, address, config.Timeout)
 	if err != nil {
 		return false, nil
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -304,13 +304,78 @@ func TestCanPerformTLS(t *testing.T) {
 
 func TestCanCreateConnection(t *testing.T) {
 	t.Parallel()
-	connected, _ := CanCreateNetworkConnection("tcp", "127.0.0.1", "", &Config{Timeout: 5 * time.Second})
-	if connected {
-		t.Error("should've failed, because there's no port in the address")
+	scenarios := []struct {
+		name      string
+		netType   string
+		address   string
+		network   string
+		wantConn  bool
+	}{
+		{
+			name:     "tcp-no-port-fails",
+			netType:  "tcp",
+			address:  "127.0.0.1",
+			network:  "ip",
+			wantConn: false,
+		},
+		{
+			name:     "tcp-valid-address-succeeds",
+			netType:  "tcp",
+			address:  "1.1.1.1:53",
+			network:  "ip",
+			wantConn: true,
+		},
+		{
+			name:     "tcp-ipv4-address-with-ip4-network-succeeds",
+			netType:  "tcp",
+			address:  "1.1.1.1:53",
+			network:  "ip4",
+			wantConn: true,
+		},
+		{
+			name:     "tcp-ipv4-address-with-ip6-network-fails",
+			netType:  "tcp",
+			address:  "1.1.1.1:53",
+			network:  "ip6",
+			wantConn: false,
+		},
+		{
+			name:     "tcp-ipv6-no-port-fails",
+			netType:  "tcp",
+			address:  "2606:4700:4700::1111",
+			network:  "ip",
+			wantConn: false,
+		},
+		{
+			name:     "tcp-ipv6-valid-address-succeeds",
+			netType:  "tcp",
+			address:  "[2606:4700:4700::1111]:53",
+			network:  "ip",
+			wantConn: true,
+		},
+		{
+			name:     "tcp-ipv6-address-with-ip6-network-succeeds",
+			netType:  "tcp",
+			address:  "[2606:4700:4700::1111]:53",
+			network:  "ip6",
+			wantConn: true,
+		},
+		{
+			name:     "tcp-ipv6-address-with-ip4-network-fails",
+			netType:  "tcp",
+			address:  "[2606:4700:4700::1111]:53",
+			network:  "ip4",
+			wantConn: false,
+		},
 	}
-	connected, _ = CanCreateNetworkConnection("tcp", "1.1.1.1:53", "", &Config{Timeout: 5 * time.Second})
-	if !connected {
-		t.Error("should've succeeded, because that IP should always™ be up")
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			t.Parallel()
+			connected, _ := CanCreateNetworkConnection(scenario.netType, scenario.address, "", &Config{Timeout: 5 * time.Second, Network: scenario.network})
+			if connected != scenario.wantConn {
+				t.Errorf("expected connected=%v, got connected=%v", scenario.wantConn, connected)
+			}
+		})
 	}
 }
 

--- a/client/config.go
+++ b/client/config.go
@@ -70,7 +70,7 @@ type Config struct {
 	// IAPConfig is the Google Cloud Identity-Aware-Proxy configuration used for the client. (e.g. audience)
 	IAPConfig *IAPConfig `yaml:"identity-aware-proxy,omitempty"`
 
-	// Network (ip, ip4 or ip6) for the ICMP client
+	// Network (ip, ip4 or ip6) for the ICMP, TCP, and UDP clients
 	Network string `yaml:"network"`
 
 	// TLS configuration (optional)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary

Fixes https://github.com/TwiN/gatus/issues/1245

Improves the `network` config field (`ip`, `ip4`, `ip6`), previously only respected by the ICMP client, to also apply to TCP and UDP connections. This allows endpoints using the `tcp` or `udp` condition type to be forced over IPv4 or IPv6.

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
