### PR TITLE
feat(client): add IMAP STARTTLS support

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/tls"
@@ -186,6 +187,11 @@ func CanPerformStartTLS(address string, config *Config) (connected bool, certifi
 		}
 	}
 
+	// Detect protocol from port: 143 = IMAP, others = SMTP
+	if hostAndPort[1] == "143" {
+		return canPerformIMAPSTARTTLS(connection, hostAndPort[0], config)
+	}
+
 	smtpClient, err := smtp.NewClient(connection, hostAndPort[0])
 	if err != nil {
 		return
@@ -202,6 +208,46 @@ func CanPerformStartTLS(address string, config *Config) (connected bool, certifi
 	} else {
 		return false, nil, errors.New("could not get TLS connection state")
 	}
+	return true, certificate, nil
+}
+
+// canPerformIMAPSTARTTLS performs STARTTLS negotiation on an IMAP connection.
+func canPerformIMAPSTARTTLS(conn net.Conn, host string, config *Config) (connected bool, certificate *x509.Certificate, err error) {
+	// Read IMAP greeting
+	reader := bufio.NewReader(conn)
+	greeting, err := reader.ReadString('\n')
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to read IMAP greeting: %w", err)
+	}
+	if !strings.HasPrefix(greeting, "* OK") {
+		return false, nil, fmt.Errorf("unexpected IMAP greeting: %s", strings.TrimSpace(greeting))
+	}
+
+	// Send STARTTLS command
+	_, err = conn.Write([]byte("a001 STARTTLS\r\n"))
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to send IMAP STARTTLS command: %w", err)
+	}
+
+	// Read response
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to read IMAP STARTTLS response: %w", err)
+	}
+	if !strings.HasPrefix(response, "a001 OK") {
+		return false, nil, fmt.Errorf("IMAP STARTTLS failed: %s", strings.TrimSpace(response))
+	}
+
+	// Upgrade to TLS
+	tlsConn := tls.Client(conn, &tls.Config{
+		InsecureSkipVerify: config.Insecure,
+		ServerName:         host,
+	})
+	err = tlsConn.Handshake()
+	if err != nil {
+		return false, nil, fmt.Errorf("IMAP TLS handshake failed: %w", err)
+	}
+	certificate = tlsConn.ConnectionState().PeerCertificates[0]
 	return true, certificate, nil
 }
 


### PR DESCRIPTION
## Summary
Fixes #689 - Adds IMAP STARTTLS support to `CanPerformStartTLS`, which previously only worked with SMTP.

When connecting to IMAP servers on port 143, the function now performs the IMAP-specific STARTTLS negotiation instead of failing with a "short response" error from the SMTP client.

## Changes
- `client/client.go`: Added IMAP protocol detection by port (143), with a new `canPerformIMAPSTARTTLS` helper implementing the IMAP STARTTLS flow

## How it works
1. Connect to server
2. Read IMAP greeting (`* OK [CAPABILITY ... STARTTLS ...]`)
3. Send `a001 STARTTLS` command
4. Read OK response
5. Upgrade to TLS

## Test plan
- [x] `go build ./client/` succeeds