### PR TITLE
feat(alerting): Add new jsm integration based on opsgenie

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,49 +834,50 @@ endpoints:
 > 📝 If an alerting provider is not properly configured, all alerts configured with the provider's type will be
 > ignored.
 
-| Parameter                  | Description                                                                                                                             | Default |
-|:---------------------------|:----------------------------------------------------------------------------------------------------------------------------------------|:--------|
-| `alerting.awsses`          | Configuration for alerts of type `awsses`. <br />See [Configuring AWS SES alerts](#configuring-aws-ses-alerts).                         | `{}`    |
-| `alerting.clickup`         | Configuration for alerts of type `clickup`. <br />See [Configuring ClickUp alerts](#configuring-clickup-alerts).                        | `{}`    |
-| `alerting.custom`          | Configuration for custom actions on failure or alerts. <br />See [Configuring Custom alerts](#configuring-custom-alerts).               | `{}`    |
-| `alerting.datadog`         | Configuration for alerts of type `datadog`. <br />See [Configuring Datadog alerts](#configuring-datadog-alerts).                        | `{}`    |
-| `alerting.discord`         | Configuration for alerts of type `discord`. <br />See [Configuring Discord alerts](#configuring-discord-alerts).                        | `{}`    |
-| `alerting.email`           | Configuration for alerts of type `email`. <br />See [Configuring Email alerts](#configuring-email-alerts).                              | `{}`    |
-| `alerting.gitea`           | Configuration for alerts of type `gitea`. <br />See [Configuring Gitea alerts](#configuring-gitea-alerts).                              | `{}`    |
-| `alerting.github`          | Configuration for alerts of type `github`. <br />See [Configuring GitHub alerts](#configuring-github-alerts).                           | `{}`    |
-| `alerting.gitlab`          | Configuration for alerts of type `gitlab`. <br />See [Configuring GitLab alerts](#configuring-gitlab-alerts).                           | `{}`    |
-| `alerting.googlechat`      | Configuration for alerts of type `googlechat`. <br />See [Configuring Google Chat alerts](#configuring-google-chat-alerts).             | `{}`    |
-| `alerting.gotify`          | Configuration for alerts of type `gotify`. <br />See [Configuring Gotify alerts](#configuring-gotify-alerts).                           | `{}`    |
-| `alerting.homeassistant`   | Configuration for alerts of type `homeassistant`. <br />See [Configuring HomeAssistant alerts](#configuring-homeassistant-alerts).      | `{}`    |
-| `alerting.ifttt`           | Configuration for alerts of type `ifttt`. <br />See [Configuring IFTTT alerts](#configuring-ifttt-alerts).                              | `{}`    |
-| `alerting.ilert`           | Configuration for alerts of type `ilert`. <br />See [Configuring ilert alerts](#configuring-ilert-alerts).                              | `{}`    |
-| `alerting.incident-io`     | Configuration for alerts of type `incident-io`. <br />See [Configuring Incident.io alerts](#configuring-incidentio-alerts).             | `{}`    |
-| `alerting.line`            | Configuration for alerts of type `line`. <br />See [Configuring Line alerts](#configuring-line-alerts).                                 | `{}`    |
-| `alerting.matrix`          | Configuration for alerts of type `matrix`. <br />See [Configuring Matrix alerts](#configuring-matrix-alerts).                           | `{}`    |
-| `alerting.mattermost`      | Configuration for alerts of type `mattermost`. <br />See [Configuring Mattermost alerts](#configuring-mattermost-alerts).               | `{}`    |
-| `alerting.messagebird`     | Configuration for alerts of type `messagebird`. <br />See [Configuring Messagebird alerts](#configuring-messagebird-alerts).            | `{}`    |
-| `alerting.n8n`             | Configuration for alerts of type `n8n`. <br />See [Configuring n8n alerts](#configuring-n8n-alerts).                                    | `{}`    |
-| `alerting.newrelic`        | Configuration for alerts of type `newrelic`. <br />See [Configuring New Relic alerts](#configuring-new-relic-alerts).                   | `{}`    |
-| `alerting.ntfy`            | Configuration for alerts of type `ntfy`. <br />See [Configuring Ntfy alerts](#configuring-ntfy-alerts).                                 | `{}`    |
-| `alerting.opsgenie`        | Configuration for alerts of type `opsgenie`. <br />See [Configuring Opsgenie alerts](#configuring-opsgenie-alerts).                     | `{}`    |
-| `alerting.pagerduty`       | Configuration for alerts of type `pagerduty`. <br />See [Configuring PagerDuty alerts](#configuring-pagerduty-alerts).                  | `{}`    |
-| `alerting.plivo`           | Configuration for alerts of type `plivo`. <br />See [Configuring Plivo alerts](#configuring-plivo-alerts).                              | `{}`    |
-| `alerting.pushover`        | Configuration for alerts of type `pushover`. <br />See [Configuring Pushover alerts](#configuring-pushover-alerts).                     | `{}`    |
-| `alerting.rocketchat`      | Configuration for alerts of type `rocketchat`. <br />See [Configuring Rocket.Chat alerts](#configuring-rocketchat-alerts).              | `{}`    |
-| `alerting.sendgrid`        | Configuration for alerts of type `sendgrid`. <br />See [Configuring SendGrid alerts](#configuring-sendgrid-alerts).                     | `{}`    |
-| `alerting.signal`          | Configuration for alerts of type `signal`. <br />See [Configuring Signal alerts](#configuring-signal-alerts).                           | `{}`    |
-| `alerting.signl4`          | Configuration for alerts of type `signl4`. <br />See [Configuring SIGNL4 alerts](#configuring-signl4-alerts).                           | `{}`    |
-| `alerting.slack`           | Configuration for alerts of type `slack`. <br />See [Configuring Slack alerts](#configuring-slack-alerts).                              | `{}`    |
-| `alerting.splunk`          | Configuration for alerts of type `splunk`. <br />See [Configuring Splunk alerts](#configuring-splunk-alerts).                           | `{}`    |
-| `alerting.squadcast`       | Configuration for alerts of type `squadcast`. <br />See [Configuring Squadcast alerts](#configuring-squadcast-alerts).                  | `{}`    |
-| `alerting.teams`           | Configuration for alerts of type `teams`. *(Deprecated)* <br />See [Configuring Teams alerts](#configuring-teams-alerts-deprecated).    | `{}`    |
-| `alerting.teams-workflows` | Configuration for alerts of type `teams-workflows`. <br />See [Configuring Teams Workflow alerts](#configuring-teams-workflow-alerts).  | `{}`    |
-| `alerting.telegram`        | Configuration for alerts of type `telegram`. <br />See [Configuring Telegram alerts](#configuring-telegram-alerts).                     | `{}`    |
-| `alerting.twilio`          | Settings for alerts of type `twilio`. <br />See [Configuring Twilio alerts](#configuring-twilio-alerts).                                | `{}`    |
-| `alerting.vonage`          | Configuration for alerts of type `vonage`. <br />See [Configuring Vonage alerts](#configuring-vonage-alerts).                           | `{}`    |
-| `alerting.webex`           | Configuration for alerts of type `webex`. <br />See [Configuring Webex alerts](#configuring-webex-alerts).                              | `{}`    |
-| `alerting.zapier`          | Configuration for alerts of type `zapier`. <br />See [Configuring Zapier alerts](#configuring-zapier-alerts).                           | `{}`    |
-| `alerting.zulip`           | Configuration for alerts of type `zulip`. <br />See [Configuring Zulip alerts](#configuring-zulip-alerts).                              | `{}`    |
+| Parameter                  | Description                                                                                                                            | Default |
+|:---------------------------|:---------------------------------------------------------------------------------------------------------------------------------------|:--------|
+| `alerting.awsses`          | Configuration for alerts of type `awsses`. <br />See [Configuring AWS SES alerts](#configuring-aws-ses-alerts).                        | `{}`    |
+| `alerting.clickup`         | Configuration for alerts of type `clickup`. <br />See [Configuring ClickUp alerts](#configuring-clickup-alerts).                       | `{}`    |
+| `alerting.custom`          | Configuration for custom actions on failure or alerts. <br />See [Configuring Custom alerts](#configuring-custom-alerts).              | `{}`    |
+| `alerting.datadog`         | Configuration for alerts of type `datadog`. <br />See [Configuring Datadog alerts](#configuring-datadog-alerts).                       | `{}`    |
+| `alerting.discord`         | Configuration for alerts of type `discord`. <br />See [Configuring Discord alerts](#configuring-discord-alerts).                       | `{}`    |
+| `alerting.email`           | Configuration for alerts of type `email`. <br />See [Configuring Email alerts](#configuring-email-alerts).                             | `{}`    |
+| `alerting.gitea`           | Configuration for alerts of type `gitea`. <br />See [Configuring Gitea alerts](#configuring-gitea-alerts).                             | `{}`    |
+| `alerting.github`          | Configuration for alerts of type `github`. <br />See [Configuring GitHub alerts](#configuring-github-alerts).                          | `{}`    |
+| `alerting.gitlab`          | Configuration for alerts of type `gitlab`. <br />See [Configuring GitLab alerts](#configuring-gitlab-alerts).                          | `{}`    |
+| `alerting.googlechat`      | Configuration for alerts of type `googlechat`. <br />See [Configuring Google Chat alerts](#configuring-google-chat-alerts).            | `{}`    |
+| `alerting.gotify`          | Configuration for alerts of type `gotify`. <br />See [Configuring Gotify alerts](#configuring-gotify-alerts).                          | `{}`    |
+| `alerting.homeassistant`   | Configuration for alerts of type `homeassistant`. <br />See [Configuring HomeAssistant alerts](#configuring-homeassistant-alerts).     | `{}`    |
+| `alerting.ifttt`           | Configuration for alerts of type `ifttt`. <br />See [Configuring IFTTT alerts](#configuring-ifttt-alerts).                             | `{}`    |
+| `alerting.ilert`           | Configuration for alerts of type `ilert`. <br />See [Configuring ilert alerts](#configuring-ilert-alerts).                             | `{}`    |
+| `alerting.incident-io`     | Configuration for alerts of type `incident-io`. <br />See [Configuring Incident.io alerts](#configuring-incidentio-alerts).            | `{}`    |
+| `alerting.jsm`               | Configuration for alerts of type `jsm`. <br />See [Configuring JSM alerts](#configuring-jsm-alerts).                                     | `{}`    |
+| `alerting.line`            | Configuration for alerts of type `line`. <br />See [Configuring Line alerts](#configuring-line-alerts).                                | `{}`    |
+| `alerting.matrix`          | Configuration for alerts of type `matrix`. <br />See [Configuring Matrix alerts](#configuring-matrix-alerts).                          | `{}`    |
+| `alerting.mattermost`      | Configuration for alerts of type `mattermost`. <br />See [Configuring Mattermost alerts](#configuring-mattermost-alerts).              | `{}`    |
+| `alerting.messagebird`     | Configuration for alerts of type `messagebird`. <br />See [Configuring Messagebird alerts](#configuring-messagebird-alerts).           | `{}`    |
+| `alerting.n8n`             | Configuration for alerts of type `n8n`. <br />See [Configuring n8n alerts](#configuring-n8n-alerts).                                   | `{}`    |
+| `alerting.newrelic`        | Configuration for alerts of type `newrelic`. <br />See [Configuring New Relic alerts](#configuring-new-relic-alerts).                  | `{}`    |
+| `alerting.ntfy`            | Configuration for alerts of type `ntfy`. <br />See [Configuring Ntfy alerts](#configuring-ntfy-alerts).                                | `{}`    |
+| `alerting.opsgenie`        | Configuration for alerts of type `opsgenie`. <br />See [Configuring Opsgenie alerts](#configuring-opsgenie-alerts).                    | `{}`    |
+| `alerting.pagerduty`       | Configuration for alerts of type `pagerduty`. <br />See [Configuring PagerDuty alerts](#configuring-pagerduty-alerts).                 | `{}`    |
+| `alerting.plivo`           | Configuration for alerts of type `plivo`. <br />See [Configuring Plivo alerts](#configuring-plivo-alerts).                             | `{}`    |
+| `alerting.pushover`        | Configuration for alerts of type `pushover`. <br />See [Configuring Pushover alerts](#configuring-pushover-alerts).                    | `{}`    |
+| `alerting.rocketchat`      | Configuration for alerts of type `rocketchat`. <br />See [Configuring Rocket.Chat alerts](#configuring-rocketchat-alerts).             | `{}`    |
+| `alerting.sendgrid`        | Configuration for alerts of type `sendgrid`. <br />See [Configuring SendGrid alerts](#configuring-sendgrid-alerts).                    | `{}`    |
+| `alerting.signal`          | Configuration for alerts of type `signal`. <br />See [Configuring Signal alerts](#configuring-signal-alerts).                          | `{}`    |
+| `alerting.signl4`          | Configuration for alerts of type `signl4`. <br />See [Configuring SIGNL4 alerts](#configuring-signl4-alerts).                          | `{}`    |
+| `alerting.slack`           | Configuration for alerts of type `slack`. <br />See [Configuring Slack alerts](#configuring-slack-alerts).                             | `{}`    |
+| `alerting.splunk`          | Configuration for alerts of type `splunk`. <br />See [Configuring Splunk alerts](#configuring-splunk-alerts).                          | `{}`    |
+| `alerting.squadcast`       | Configuration for alerts of type `squadcast`. <br />See [Configuring Squadcast alerts](#configuring-squadcast-alerts).                 | `{}`    |
+| `alerting.teams`           | Configuration for alerts of type `teams`. *(Deprecated)* <br />See [Configuring Teams alerts](#configuring-teams-alerts-deprecated).   | `{}`    |
+| `alerting.teams-workflows` | Configuration for alerts of type `teams-workflows`. <br />See [Configuring Teams Workflow alerts](#configuring-teams-workflow-alerts). | `{}`    |
+| `alerting.telegram`        | Configuration for alerts of type `telegram`. <br />See [Configuring Telegram alerts](#configuring-telegram-alerts).                    | `{}`    |
+| `alerting.twilio`          | Settings for alerts of type `twilio`. <br />See [Configuring Twilio alerts](#configuring-twilio-alerts).                               | `{}`    |
+| `alerting.vonage`          | Configuration for alerts of type `vonage`. <br />See [Configuring Vonage alerts](#configuring-vonage-alerts).                          | `{}`    |
+| `alerting.webex`           | Configuration for alerts of type `webex`. <br />See [Configuring Webex alerts](#configuring-webex-alerts).                             | `{}`    |
+| `alerting.zapier`          | Configuration for alerts of type `zapier`. <br />See [Configuring Zapier alerts](#configuring-zapier-alerts).                          | `{}`    |
+| `alerting.zulip`           | Configuration for alerts of type `zulip`. <br />See [Configuring Zulip alerts](#configuring-zulip-alerts).                             | `{}`    |
 
 
 #### Configuring AWS SES alerts
@@ -1490,6 +1491,28 @@ endpoints:
 In order to get the required alert source config id and authentication token, you must configure an HTTP alert source.
 
 > **_NOTE:_**  the source config id is of the form `https://api.incident.io/v2/alert_events/http/$ID` and the token is expected to be passed as a bearer token like so: `Authorization: Bearer $TOKEN`
+
+#### Configuring JSM alerts
+> **_NOTE:_**  This integration is working similarly to the deprecated Opsgenie integration, but uses the newer API of Jira Service Management (JSM).
+
+| Parameter                    | Description                                                                                | Default              |
+|:-----------------------------|:-------------------------------------------------------------------------------------------|:---------------------|
+| `alerting.jsm`               | Configuration for alerts of type `jsm`                                                     | `{}`                 |
+| `alerting.jsm.api-key`       | JSM API Key                                                                                | Required `""`        |
+| `alerting.jsm.priority`      | Priority level of the alert.                                                               | `P1`                 |
+| `alerting.jsm.source`        | Source field of the alert.                                                                 | `gatus`              |
+| `alerting.jsm.entity-prefix` | Entity field prefix.                                                                       | `gatus-`             |
+| `alerting.jsm.alias-prefix`  | Alias field prefix.                                                                        | `gatus-healthcheck-` |
+| `alerting.jsm.tags`          | Tags of alert.                                                                             | `[]`                 |
+| `alerting.jsm.default-alert` | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert) | N/A                  |
+
+JSM (Jira Service Management) provider will automatically open and close alerts.
+
+```yaml
+alerting:
+  jsm:
+    api-key: "00000000-0000-0000-0000-000000000000"
+```
 
 
 #### Configuring Line alerts

--- a/README.md
+++ b/README.md
@@ -1495,16 +1495,19 @@ In order to get the required alert source config id and authentication token, yo
 #### Configuring JSM alerts
 > **_NOTE:_**  This integration is working similarly to the deprecated Opsgenie integration, but uses the newer API of Jira Service Management (JSM).
 
-| Parameter                    | Description                                                                                | Default              |
-|:-----------------------------|:-------------------------------------------------------------------------------------------|:---------------------|
-| `alerting.jsm`               | Configuration for alerts of type `jsm`                                                     | `{}`                 |
-| `alerting.jsm.api-key`       | JSM API Key                                                                                | Required `""`        |
-| `alerting.jsm.priority`      | Priority level of the alert.                                                               | `P1`                 |
-| `alerting.jsm.source`        | Source field of the alert.                                                                 | `gatus`              |
-| `alerting.jsm.entity-prefix` | Entity field prefix.                                                                       | `gatus-`             |
-| `alerting.jsm.alias-prefix`  | Alias field prefix.                                                                        | `gatus-healthcheck-` |
-| `alerting.jsm.tags`          | Tags of alert.                                                                             | `[]`                 |
-| `alerting.jsm.default-alert` | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert) | N/A                  |
+| Parameter                        | Description                                                                                | Default              |
+|:-----------------------------    |:-------------------------------------------------------------------------------------------|:---------------------|
+| `alerting.jsm`                   | Configuration for alerts of type `jsm`                                                     | `{}`                 |
+| `alerting.jsm.api-key`           | JSM API Key                                                                                | Required `""`        |
+| `alerting.jsm.priority`          | Priority level of the alert.                                                               | `P1`                 |
+| `alerting.jsm.source`            | Source field of the alert.                                                                 | `gatus`              |
+| `alerting.jsm.entity-prefix`     | Entity field prefix.                                                                       | `gatus-`             |
+| `alerting.jsm.alias-prefix`      | Alias field prefix.                                                                        | `gatus-healthcheck-` |
+| `alerting.jsm.tags`              | Tags of alert.                                                                             | `[]`                 |
+| `alerting.jsm.default-alert`     | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert) | N/A                  |
+| `alerting.jsm.overrides`         | List of overrides that may be prioritized over the default configuration                   | `[]`                 |
+| `alerting.jsm.overrides[].group` | Endpoint group for which the configuration will be overridden by this configuration        | `""`                 |
+| `alerting.jsm.overrides[].*`     | See `alerting.jsm.*` parameters                                                            | `{}`                 | 
 
 JSM (Jira Service Management) provider will automatically open and close alerts.
 

--- a/alerting/alert/type.go
+++ b/alerting/alert/type.go
@@ -50,6 +50,9 @@ const (
 	// TypeIncidentIO is the Type for the incident-io alerting provider
 	TypeIncidentIO Type = "incident-io"
 
+	// TypeJSM is the Type for the jsm alerting provider
+	TypeJSM Type = "jsm"
+
 	// TypeLine is the Type for the line alerting provider
 	TypeLine Type = "line"
 

--- a/alerting/config.go
+++ b/alerting/config.go
@@ -21,6 +21,7 @@ import (
 	"github.com/TwiN/gatus/v5/alerting/provider/ifttt"
 	"github.com/TwiN/gatus/v5/alerting/provider/ilert"
 	"github.com/TwiN/gatus/v5/alerting/provider/incidentio"
+	"github.com/TwiN/gatus/v5/alerting/provider/jsm"
 	"github.com/TwiN/gatus/v5/alerting/provider/line"
 	"github.com/TwiN/gatus/v5/alerting/provider/matrix"
 	"github.com/TwiN/gatus/v5/alerting/provider/mattermost"
@@ -96,6 +97,9 @@ type Config struct {
 
 	// IncidentIO is the configuration for the incident-io alerting provider
 	IncidentIO *incidentio.AlertProvider `yaml:"incident-io,omitempty"`
+
+	// JSM is the configuration for the jsm alerting provider
+	JSM *jsm.AlertProvider `yaml:"jsm,omitempty"`
 
 	// Line is the configuration for the line alerting provider
 	Line *line.AlertProvider `yaml:"line,omitempty"`

--- a/alerting/provider/jsm/jsm.go
+++ b/alerting/provider/jsm/jsm.go
@@ -1,0 +1,284 @@
+package jsm
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/TwiN/gatus/v5/alerting/alert"
+	"github.com/TwiN/gatus/v5/client"
+	"github.com/TwiN/gatus/v5/config/endpoint"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	restAPI = "https://api.atlassian.com/jsm/ops/integration/v2/alerts"
+)
+
+var (
+	ErrAPIKeyNotSet = errors.New("api-key not set")
+)
+
+type Config struct {
+	// APIKey to use for
+	APIKey string `yaml:"api-key"`
+
+	// Priority to be used in JSM alert payload
+	//
+	// default: P1
+	Priority string `yaml:"priority"`
+
+	// Source define source to be used in JSM alert payload
+	//
+	// default: gatus
+	Source string `yaml:"source"`
+
+	// EntityPrefix is a prefix to be used in entity argument in JSM alert payload
+	//
+	// default: gatus-
+	EntityPrefix string `yaml:"entity-prefix"`
+
+	//AliasPrefix is a prefix to be used in alias argument in JSM alert payload
+	//
+	// default: gatus-healthcheck-
+	AliasPrefix string `yaml:"alias-prefix"`
+
+	// Tags to be used in JSM alert payload
+	//
+	// default: []
+	Tags []string `yaml:"tags"`
+}
+
+func (cfg *Config) Validate() error {
+	if len(cfg.APIKey) == 0 {
+		return ErrAPIKeyNotSet
+	}
+	if len(cfg.Source) == 0 {
+		cfg.Source = "gatus"
+	}
+	if len(cfg.EntityPrefix) == 0 {
+		cfg.EntityPrefix = "gatus-"
+	}
+	if len(cfg.AliasPrefix) == 0 {
+		cfg.AliasPrefix = "gatus-healthcheck-"
+	}
+	if len(cfg.Priority) == 0 {
+		cfg.Priority = "P1"
+	}
+	return nil
+}
+
+func (cfg *Config) Merge(override *Config) {
+	if len(override.APIKey) > 0 {
+		cfg.APIKey = override.APIKey
+	}
+	if len(override.Priority) > 0 {
+		cfg.Priority = override.Priority
+	}
+	if len(override.Source) > 0 {
+		cfg.Source = override.Source
+	}
+	if len(override.EntityPrefix) > 0 {
+		cfg.EntityPrefix = override.EntityPrefix
+	}
+	if len(override.AliasPrefix) > 0 {
+		cfg.AliasPrefix = override.AliasPrefix
+	}
+	if len(override.Tags) > 0 {
+		cfg.Tags = override.Tags
+	}
+}
+
+type AlertProvider struct {
+	DefaultConfig Config `yaml:",inline"`
+
+	// DefaultAlert is the default alert configuration to use for endpoints with an alert of the appropriate type
+	DefaultAlert *alert.Alert `yaml:"default-alert,omitempty"`
+}
+
+// Validate the provider's configuration
+func (provider *AlertProvider) Validate() error {
+	return provider.DefaultConfig.Validate()
+}
+
+// Send an alert using the provider
+//
+// Relevant: https://developer.atlassian.com/cloud/jira/service-desk-ops/rest/v1/api-group-integration-events/
+func (provider *AlertProvider) Send(ep *endpoint.Endpoint, alert *alert.Alert, result *endpoint.Result, resolved bool) error {
+	cfg, err := provider.GetConfig(ep.Group, alert)
+	if err != nil {
+		return err
+	}
+	err = provider.sendAlertRequest(cfg, ep, alert, result, resolved)
+	if err != nil {
+		return err
+	}
+	if resolved {
+		err = provider.closeAlert(cfg, ep, alert)
+		if err != nil {
+			return err
+		}
+	}
+	if alert.IsSendingOnResolved() {
+		if resolved {
+			// The alert has been resolved and there's no error, so we can clear the alert's ResolveKey
+			alert.ResolveKey = ""
+		} else {
+			alert.ResolveKey = cfg.AliasPrefix + buildKey(ep)
+		}
+	}
+	return nil
+}
+
+func (provider *AlertProvider) sendAlertRequest(cfg *Config, ep *endpoint.Endpoint, alert *alert.Alert, result *endpoint.Result, resolved bool) error {
+	payload := provider.buildCreateRequestBody(cfg, ep, alert, result, resolved)
+	return provider.sendRequest(cfg, restAPI, http.MethodPost, payload)
+}
+
+func (provider *AlertProvider) closeAlert(cfg *Config, ep *endpoint.Endpoint, alert *alert.Alert) error {
+	payload := provider.buildCloseRequestBody(ep, alert)
+	url := restAPI + "/" + cfg.AliasPrefix + buildKey(ep) + "/close?identifierType=alias"
+	return provider.sendRequest(cfg, url, http.MethodPost, payload)
+}
+
+func (provider *AlertProvider) sendRequest(cfg *Config, url, method string, payload interface{}) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("error build alert with payload %v: %w", payload, err)
+	}
+	request, err := http.NewRequest(method, url, bytes.NewBuffer(body))
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", "GenieKey "+cfg.APIKey)
+	response, err := client.GetHTTPClient(nil).Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	if response.StatusCode > 399 {
+		rBody, _ := io.ReadAll(response.Body)
+		return fmt.Errorf("call to provider alert returned status code %d: %s", response.StatusCode, string(rBody))
+	}
+	return nil
+}
+
+func (provider *AlertProvider) buildCreateRequestBody(cfg *Config, ep *endpoint.Endpoint, alert *alert.Alert, result *endpoint.Result, resolved bool) alertCreateRequest {
+	var message, description string
+	if resolved {
+		message = fmt.Sprintf("RESOLVED: %s - %s", ep.Name, alert.GetDescription())
+		description = fmt.Sprintf("An alert for *%s* has been resolved after passing successfully %d time(s) in a row", ep.DisplayName(), alert.SuccessThreshold)
+	} else {
+		message = fmt.Sprintf("%s - %s", ep.Name, alert.GetDescription())
+		description = fmt.Sprintf("An alert for *%s* has been triggered due to having failed %d time(s) in a row", ep.DisplayName(), alert.FailureThreshold)
+	}
+	if ep.Group != "" {
+		message = fmt.Sprintf("[%s] %s", ep.Group, message)
+	}
+	var formattedConditionResults string
+	for _, conditionResult := range result.ConditionResults {
+		var prefix string
+		if conditionResult.Success {
+			prefix = "▣"
+		} else {
+			prefix = "▢"
+		}
+		formattedConditionResults += fmt.Sprintf("%s - `%s`\n", prefix, conditionResult.Condition)
+	}
+	description = description + "\n" + formattedConditionResults
+	key := buildKey(ep)
+	details := map[string]string{
+		"endpoint:url":    ep.URL,
+		"endpoint:group":  ep.Group,
+		"result:hostname": result.Hostname,
+		"result:ip":       result.IP,
+		"result:dns_code": result.DNSRCode,
+		"result:errors":   strings.Join(result.Errors, ","),
+	}
+	for k, v := range details {
+		if v == "" {
+			delete(details, k)
+		}
+	}
+	if result.HTTPStatus > 0 {
+		details["result:http_status"] = strconv.Itoa(result.HTTPStatus)
+	}
+	return alertCreateRequest{
+		Message:     message,
+		Description: description,
+		Source:      cfg.Source,
+		Priority:    cfg.Priority,
+		Alias:       cfg.AliasPrefix + key,
+		Entity:      cfg.EntityPrefix + key,
+		Tags:        cfg.Tags,
+		Details:     details,
+	}
+}
+
+func (provider *AlertProvider) buildCloseRequestBody(ep *endpoint.Endpoint, alert *alert.Alert) alertCloseRequest {
+	return alertCloseRequest{
+		Source: buildKey(ep),
+		Note:   fmt.Sprintf("RESOLVED: %s - %s", ep.Name, alert.GetDescription()),
+	}
+}
+
+// GetDefaultAlert returns the provider's default alert configuration
+func (provider *AlertProvider) GetDefaultAlert() *alert.Alert {
+	return provider.DefaultAlert
+}
+
+// GetConfig returns the configuration for the provider with the overrides applied
+func (provider *AlertProvider) GetConfig(group string, alert *alert.Alert) (*Config, error) {
+	cfg := provider.DefaultConfig
+	// Handle alert overrides
+	if len(alert.ProviderOverride) != 0 {
+		overrideConfig := Config{}
+		if err := yaml.Unmarshal(alert.ProviderOverrideAsBytes(), &overrideConfig); err != nil {
+			return nil, err
+		}
+		cfg.Merge(&overrideConfig)
+	}
+	// Validate the configuration
+	err := cfg.Validate()
+	return &cfg, err
+}
+
+// ValidateOverrides validates the alert's provider override and, if present, the group override
+func (provider *AlertProvider) ValidateOverrides(group string, alert *alert.Alert) error {
+	_, err := provider.GetConfig(group, alert)
+	return err
+}
+
+func buildKey(ep *endpoint.Endpoint) string {
+	name := toKebabCase(ep.Name)
+	if ep.Group == "" {
+		return name
+	}
+	return toKebabCase(ep.Group) + "-" + name
+}
+
+func toKebabCase(val string) string {
+	return strings.ToLower(strings.ReplaceAll(val, " ", "-"))
+}
+
+type alertCreateRequest struct {
+	Message     string            `json:"message"`
+	Priority    string            `json:"priority"`
+	Source      string            `json:"source"`
+	Entity      string            `json:"entity"`
+	Alias       string            `json:"alias"`
+	Description string            `json:"description"`
+	Tags        []string          `json:"tags,omitempty"`
+	Details     map[string]string `json:"details"`
+}
+
+type alertCloseRequest struct {
+	Source string `json:"source"`
+	Note   string `json:"note"`
+}

--- a/alerting/provider/jsm/jsm.go
+++ b/alerting/provider/jsm/jsm.go
@@ -21,7 +21,8 @@ const (
 )
 
 var (
-	ErrAPIKeyNotSet = errors.New("api-key not set")
+	ErrAPIKeyNotSet           = errors.New("api-key not set")
+	ErrDuplicateGroupOverride = errors.New("duplicate group override")
 )
 
 type Config struct {
@@ -99,10 +100,28 @@ type AlertProvider struct {
 
 	// DefaultAlert is the default alert configuration to use for endpoints with an alert of the appropriate type
 	DefaultAlert *alert.Alert `yaml:"default-alert,omitempty"`
+
+	// Overrides is a list of Override that may be prioritized over the default configuration
+	Overrides []Override `yaml:"overrides,omitempty"`
+}
+
+// Override is a case under which the default integration is overridden
+type Override struct {
+	Group  string `yaml:"group"`
+	Config `yaml:",inline"`
 }
 
 // Validate the provider's configuration
 func (provider *AlertProvider) Validate() error {
+	registeredGroups := make(map[string]bool)
+	if provider.Overrides != nil {
+		for _, override := range provider.Overrides {
+			if isAlreadyRegistered := registeredGroups[override.Group]; isAlreadyRegistered || override.Group == "" {
+				return ErrDuplicateGroupOverride
+			}
+			registeredGroups[override.Group] = true
+		}
+	}
 	return provider.DefaultConfig.Validate()
 }
 
@@ -236,6 +255,15 @@ func (provider *AlertProvider) GetDefaultAlert() *alert.Alert {
 // GetConfig returns the configuration for the provider with the overrides applied
 func (provider *AlertProvider) GetConfig(group string, alert *alert.Alert) (*Config, error) {
 	cfg := provider.DefaultConfig
+	// Handle group overrides
+	if provider.Overrides != nil {
+		for _, override := range provider.Overrides {
+			if group == override.Group {
+				cfg.Merge(&override.Config)
+				break
+			}
+		}
+	}
 	// Handle alert overrides
 	if len(alert.ProviderOverride) != 0 {
 		overrideConfig := Config{}

--- a/alerting/provider/jsm/jsm_test.go
+++ b/alerting/provider/jsm/jsm_test.go
@@ -1,0 +1,361 @@
+package jsm
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/TwiN/gatus/v5/alerting/alert"
+	"github.com/TwiN/gatus/v5/client"
+	"github.com/TwiN/gatus/v5/config/endpoint"
+	"github.com/TwiN/gatus/v5/test"
+)
+
+func TestAlertProvider_Validate(t *testing.T) {
+	invalidProvider := AlertProvider{DefaultConfig: Config{APIKey: ""}}
+	if err := invalidProvider.Validate(); err == nil {
+		t.Error("provider shouldn't have been valid")
+	}
+	validProvider := AlertProvider{DefaultConfig: Config{APIKey: "00000000-0000-0000-0000-000000000000"}}
+	if err := validProvider.Validate(); err != nil {
+		t.Error("provider should've been valid")
+	}
+}
+
+func TestAlertProvider_Send(t *testing.T) {
+	defer client.InjectHTTPClient(nil)
+	description := "my bad alert description"
+	scenarios := []struct {
+		Name             string
+		Provider         AlertProvider
+		Alert            alert.Alert
+		Resolved         bool
+		MockRoundTripper test.MockRoundTripper
+		ExpectedError    bool
+	}{
+		{
+			Name:          "triggered",
+			Provider:      AlertProvider{DefaultConfig: Config{APIKey: "00000000-0000-0000-0000-000000000000"}},
+			Alert:         alert.Alert{Description: &description, SuccessThreshold: 1, FailureThreshold: 1},
+			Resolved:      false,
+			ExpectedError: false,
+			MockRoundTripper: test.MockRoundTripper(func(r *http.Request) *http.Response {
+				return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}
+			}),
+		},
+		{
+			Name:          "triggered-error",
+			Provider:      AlertProvider{DefaultConfig: Config{APIKey: "00000000-0000-0000-0000-000000000000"}},
+			Alert:         alert.Alert{Description: &description, SuccessThreshold: 5, FailureThreshold: 3},
+			Resolved:      false,
+			ExpectedError: true,
+			MockRoundTripper: test.MockRoundTripper(func(r *http.Request) *http.Response {
+				return &http.Response{StatusCode: http.StatusInternalServerError, Body: http.NoBody}
+			}),
+		},
+		{
+			Name:          "resolved",
+			Provider:      AlertProvider{DefaultConfig: Config{APIKey: "00000000-0000-0000-0000-000000000000"}},
+			Alert:         alert.Alert{Description: &description, SuccessThreshold: 5, FailureThreshold: 3},
+			Resolved:      true,
+			ExpectedError: false,
+			MockRoundTripper: test.MockRoundTripper(func(r *http.Request) *http.Response {
+				return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}
+			}),
+		},
+		{
+			Name:          "resolved-error",
+			Provider:      AlertProvider{DefaultConfig: Config{APIKey: "00000000-0000-0000-0000-000000000000"}},
+			Alert:         alert.Alert{Description: &description, SuccessThreshold: 5, FailureThreshold: 3},
+			Resolved:      true,
+			ExpectedError: true,
+			MockRoundTripper: test.MockRoundTripper(func(r *http.Request) *http.Response {
+				return &http.Response{StatusCode: http.StatusInternalServerError, Body: http.NoBody}
+			}),
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			client.InjectHTTPClient(&http.Client{Transport: scenario.MockRoundTripper})
+			err := scenario.Provider.Send(
+				&endpoint.Endpoint{Name: "endpoint-name"},
+				&scenario.Alert,
+				&endpoint.Result{
+					ConditionResults: []*endpoint.ConditionResult{
+						{Condition: "[CONNECTED] == true", Success: scenario.Resolved},
+						{Condition: "[STATUS] == 200", Success: scenario.Resolved},
+					},
+				},
+				scenario.Resolved,
+			)
+			if scenario.ExpectedError && err == nil {
+				t.Error("expected error, got none")
+			}
+			if !scenario.ExpectedError && err != nil {
+				t.Error("expected no error, got", err.Error())
+			}
+		})
+	}
+}
+
+func TestAlertProvider_buildCreateRequestBody(t *testing.T) {
+	t.Parallel()
+	description := "alert description"
+	scenarios := []struct {
+		Name     string
+		Provider *AlertProvider
+		Alert    *alert.Alert
+		Endpoint *endpoint.Endpoint
+		Result   *endpoint.Result
+		Resolved bool
+		want     alertCreateRequest
+	}{
+		{
+			Name:     "missing all params (unresolved)",
+			Provider: &AlertProvider{DefaultConfig: Config{APIKey: "00000000-0000-0000-0000-000000000000"}},
+			Alert:    &alert.Alert{},
+			Endpoint: &endpoint.Endpoint{},
+			Result:   &endpoint.Result{},
+			Resolved: false,
+			want: alertCreateRequest{
+				Message:     " - ",
+				Priority:    "P1",
+				Source:      "gatus",
+				Entity:      "gatus-",
+				Alias:       "gatus-healthcheck-",
+				Description: "An alert for ** has been triggered due to having failed 0 time(s) in a row\n",
+				Tags:        nil,
+				Details:     map[string]string{},
+			},
+		},
+		{
+			Name:     "missing all params (resolved)",
+			Provider: &AlertProvider{DefaultConfig: Config{APIKey: "00000000-0000-0000-0000-000000000000"}},
+			Alert:    &alert.Alert{},
+			Endpoint: &endpoint.Endpoint{},
+			Result:   &endpoint.Result{},
+			Resolved: true,
+			want: alertCreateRequest{
+				Message:     "RESOLVED:  - ",
+				Priority:    "P1",
+				Source:      "gatus",
+				Entity:      "gatus-",
+				Alias:       "gatus-healthcheck-",
+				Description: "An alert for ** has been resolved after passing successfully 0 time(s) in a row\n",
+				Tags:        nil,
+				Details:     map[string]string{},
+			},
+		},
+		{
+			Name:     "with default options (unresolved)",
+			Provider: &AlertProvider{DefaultConfig: Config{APIKey: "00000000-0000-0000-0000-000000000000"}},
+			Alert: &alert.Alert{
+				Description:      &description,
+				FailureThreshold: 3,
+			},
+			Endpoint: &endpoint.Endpoint{
+				Name: "my super app",
+			},
+			Result: &endpoint.Result{
+				ConditionResults: []*endpoint.ConditionResult{
+					{
+						Condition: "[STATUS] == 200",
+						Success:   true,
+					},
+					{
+						Condition: "[BODY] == OK",
+						Success:   false,
+					},
+				},
+			},
+			Resolved: false,
+			want: alertCreateRequest{
+				Message:     "my super app - " + description,
+				Priority:    "P1",
+				Source:      "gatus",
+				Entity:      "gatus-my-super-app",
+				Alias:       "gatus-healthcheck-my-super-app",
+				Description: "An alert for *my super app* has been triggered due to having failed 3 time(s) in a row\n▣ - `[STATUS] == 200`\n▢ - `[BODY] == OK`\n",
+				Tags:        nil,
+				Details:     map[string]string{},
+			},
+		},
+		{
+			Name: "with custom options (resolved)",
+			Provider: &AlertProvider{
+				DefaultConfig: Config{
+					Priority:     "P5",
+					EntityPrefix: "oompa-",
+					AliasPrefix:  "loompa-",
+					Source:       "gatus-hc",
+					Tags:         []string{"do-ba-dee-doo"},
+				},
+			},
+			Alert: &alert.Alert{
+				Description:      &description,
+				SuccessThreshold: 4,
+			},
+			Endpoint: &endpoint.Endpoint{
+				Name: "my mega app",
+			},
+			Result: &endpoint.Result{
+				ConditionResults: []*endpoint.ConditionResult{
+					{
+						Condition: "[STATUS] == 200",
+						Success:   true,
+					},
+				},
+			},
+			Resolved: true,
+			want: alertCreateRequest{
+				Message:     "RESOLVED: my mega app - " + description,
+				Priority:    "P5",
+				Source:      "gatus-hc",
+				Entity:      "oompa-my-mega-app",
+				Alias:       "loompa-my-mega-app",
+				Description: "An alert for *my mega app* has been resolved after passing successfully 4 time(s) in a row\n▣ - `[STATUS] == 200`\n",
+				Tags:        []string{"do-ba-dee-doo"},
+				Details:     map[string]string{},
+			},
+		},
+		{
+			Name: "with default options and details (unresolved)",
+			Provider: &AlertProvider{
+				DefaultConfig: Config{Tags: []string{"foo"}, APIKey: "00000000-0000-0000-0000-000000000000"},
+			},
+			Alert: &alert.Alert{
+				Description:      &description,
+				FailureThreshold: 6,
+			},
+			Endpoint: &endpoint.Endpoint{
+				Name:  "my app",
+				Group: "end game",
+				URL:   "https://my.go/app",
+			},
+			Result: &endpoint.Result{
+				HTTPStatus: 400,
+				Hostname:   "my.go",
+				Errors:     []string{"error 01", "error 02"},
+				Success:    false,
+				ConditionResults: []*endpoint.ConditionResult{
+					{
+						Condition: "[STATUS] == 200",
+						Success:   false,
+					},
+				},
+			},
+			Resolved: false,
+			want: alertCreateRequest{
+				Message:     "[end game] my app - " + description,
+				Priority:    "P1",
+				Source:      "gatus",
+				Entity:      "gatus-end-game-my-app",
+				Alias:       "gatus-healthcheck-end-game-my-app",
+				Description: "An alert for *end game/my app* has been triggered due to having failed 6 time(s) in a row\n▢ - `[STATUS] == 200`\n",
+				Tags:        []string{"foo"},
+				Details: map[string]string{
+					"endpoint:url":       "https://my.go/app",
+					"endpoint:group":     "end game",
+					"result:hostname":    "my.go",
+					"result:errors":      "error 01,error 02",
+					"result:http_status": "400",
+				},
+			},
+		},
+	}
+	for _, scenario := range scenarios {
+		actual := scenario
+		t.Run(actual.Name, func(t *testing.T) {
+			_ = scenario.Provider.Validate()
+			if got := actual.Provider.buildCreateRequestBody(&scenario.Provider.DefaultConfig, actual.Endpoint, actual.Alert, actual.Result, actual.Resolved); !reflect.DeepEqual(got, actual.want) {
+				t.Errorf("got:\n%v\nwant:\n%v", got, actual.want)
+			}
+		})
+	}
+}
+
+func TestAlertProvider_buildCloseRequestBody(t *testing.T) {
+	t.Parallel()
+	description := "alert description"
+	scenarios := []struct {
+		Name     string
+		Provider *AlertProvider
+		Alert    *alert.Alert
+		Endpoint *endpoint.Endpoint
+		want     alertCloseRequest
+	}{
+		{
+			Name:     "Missing all values",
+			Provider: &AlertProvider{},
+			Alert:    &alert.Alert{},
+			Endpoint: &endpoint.Endpoint{},
+			want: alertCloseRequest{
+				Source: "",
+				Note:   "RESOLVED:  - ",
+			},
+		},
+		{
+			Name:     "Basic values",
+			Provider: &AlertProvider{},
+			Alert: &alert.Alert{
+				Description: &description,
+			},
+			Endpoint: &endpoint.Endpoint{
+				Name: "endpoint name",
+			},
+			want: alertCloseRequest{
+				Source: "endpoint-name",
+				Note:   "RESOLVED: endpoint name - alert description",
+			},
+		},
+	}
+	for _, scenario := range scenarios {
+		actual := scenario
+		t.Run(actual.Name, func(t *testing.T) {
+			if got := actual.Provider.buildCloseRequestBody(actual.Endpoint, actual.Alert); !reflect.DeepEqual(got, actual.want) {
+				t.Errorf("buildCloseRequestBody() = %v, want %v", got, actual.want)
+			}
+		})
+	}
+}
+
+func TestAlertProvider_GetConfig(t *testing.T) {
+	scenarios := []struct {
+		Name           string
+		Provider       AlertProvider
+		InputAlert     alert.Alert
+		ExpectedOutput Config
+	}{
+		{
+			Name: "provider-no-override-should-default",
+			Provider: AlertProvider{
+				DefaultConfig: Config{APIKey: "00000000-0000-0000-0000-000000000000"},
+			},
+			InputAlert:     alert.Alert{},
+			ExpectedOutput: Config{APIKey: "00000000-0000-0000-0000-000000000000"},
+		},
+		{
+			Name: "provider-with-alert-override--alert-override-should-take-precedence",
+			Provider: AlertProvider{
+				DefaultConfig: Config{APIKey: "00000000-0000-0000-0000-000000000000"},
+			},
+			InputAlert:     alert.Alert{ProviderOverride: map[string]any{"api-key": "00000000-0000-0000-0000-000000000001"}},
+			ExpectedOutput: Config{APIKey: "00000000-0000-0000-0000-000000000001"},
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			got, err := scenario.Provider.GetConfig("", &scenario.InputAlert)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if got.APIKey != scenario.ExpectedOutput.APIKey {
+				t.Errorf("expected APIKey to be %s, got %s", scenario.ExpectedOutput.APIKey, got.APIKey)
+			}
+			// Test ValidateOverrides as well, since it really just calls GetConfig
+			if err = scenario.Provider.ValidateOverrides("", &scenario.InputAlert); err != nil {
+				t.Errorf("unexpected error: %s", err)
+			}
+		})
+	}
+}

--- a/alerting/provider/jsm/jsm_test.go
+++ b/alerting/provider/jsm/jsm_test.go
@@ -22,6 +22,32 @@ func TestAlertProvider_Validate(t *testing.T) {
 	}
 }
 
+func TestAlertProvider_ValidateWithOverride(t *testing.T) {
+	providerWithInvalidOverrideGroup := AlertProvider{
+		Overrides: []Override{
+			{
+				Config: Config{APIKey: "00000000-0000-0000-0000-000000000001"},
+				Group:  "",
+			},
+		},
+	}
+	if err := providerWithInvalidOverrideGroup.Validate(); err == nil {
+		t.Error("provider Group shouldn't have been valid")
+	}
+	providerWithValidOverride := AlertProvider{
+		DefaultConfig: Config{APIKey: "00000000-0000-0000-0000-000000000000"},
+		Overrides: []Override{
+			{
+				Config: Config{APIKey: "00000000-0000-0000-0000-000000000001"},
+				Group:  "group",
+			},
+		},
+	}
+	if err := providerWithValidOverride.Validate(); err != nil {
+		t.Error("provider should've been valid")
+	}
+}
+
 func TestAlertProvider_Send(t *testing.T) {
 	defer client.InjectHTTPClient(nil)
 	description := "my bad alert description"
@@ -323,29 +349,79 @@ func TestAlertProvider_GetConfig(t *testing.T) {
 	scenarios := []struct {
 		Name           string
 		Provider       AlertProvider
+		InputGroup     string
 		InputAlert     alert.Alert
 		ExpectedOutput Config
 	}{
 		{
-			Name: "provider-no-override-should-default",
+			Name: "provider-no-override-specify-no-group-should-default",
 			Provider: AlertProvider{
 				DefaultConfig: Config{APIKey: "00000000-0000-0000-0000-000000000000"},
+				Overrides:     nil,
 			},
+			InputGroup:     "",
 			InputAlert:     alert.Alert{},
 			ExpectedOutput: Config{APIKey: "00000000-0000-0000-0000-000000000000"},
 		},
 		{
-			Name: "provider-with-alert-override--alert-override-should-take-precedence",
+			Name: "provider-no-override-specify-group-should-default",
 			Provider: AlertProvider{
 				DefaultConfig: Config{APIKey: "00000000-0000-0000-0000-000000000000"},
+				Overrides:     nil,
 			},
+			InputGroup:     "group",
+			InputAlert:     alert.Alert{},
+			ExpectedOutput: Config{APIKey: "00000000-0000-0000-0000-000000000000"},
+		},
+		{
+			Name: "provider-with-override-specify-no-group-should-default",
+			Provider: AlertProvider{
+				DefaultConfig: Config{APIKey: "00000000-0000-0000-0000-000000000000"},
+				Overrides: []Override{
+					{
+						Group:  "group",
+						Config: Config{APIKey: "00000000-0000-0000-0000-000000000001"},
+					},
+				},
+			},
+			InputGroup:     "",
+			InputAlert:     alert.Alert{},
+			ExpectedOutput: Config{APIKey: "00000000-0000-0000-0000-000000000000"},
+		},
+		{
+			Name: "provider-with-override-specify-group-should-override",
+			Provider: AlertProvider{
+				DefaultConfig: Config{APIKey: "00000000-0000-0000-0000-000000000000"},
+				Overrides: []Override{
+					{
+						Group:  "group",
+						Config: Config{APIKey: "00000000-0000-0000-0000-000000000001"},
+					},
+				},
+			},
+			InputGroup:     "group",
+			InputAlert:     alert.Alert{},
+			ExpectedOutput: Config{APIKey: "00000000-0000-0000-0000-000000000001"},
+		},
+		{
+			Name: "provider-with-group-override-and-alert-override--alert-override-should-take-precedence",
+			Provider: AlertProvider{
+				DefaultConfig: Config{APIKey: "00000000-0000-0000-0000-000000000000"},
+				Overrides: []Override{
+					{
+						Group:  "group",
+						Config: Config{APIKey: "00000000-0000-0000-0000-000000000001"},
+					},
+				},
+			},
+			InputGroup:     "group",
 			InputAlert:     alert.Alert{ProviderOverride: map[string]any{"api-key": "00000000-0000-0000-0000-000000000001"}},
 			ExpectedOutput: Config{APIKey: "00000000-0000-0000-0000-000000000001"},
 		},
 	}
 	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
-			got, err := scenario.Provider.GetConfig("", &scenario.InputAlert)
+			got, err := scenario.Provider.GetConfig(scenario.InputGroup, &scenario.InputAlert)
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}
@@ -353,7 +429,7 @@ func TestAlertProvider_GetConfig(t *testing.T) {
 				t.Errorf("expected APIKey to be %s, got %s", scenario.ExpectedOutput.APIKey, got.APIKey)
 			}
 			// Test ValidateOverrides as well, since it really just calls GetConfig
-			if err = scenario.Provider.ValidateOverrides("", &scenario.InputAlert); err != nil {
+			if err = scenario.Provider.ValidateOverrides(scenario.InputGroup, &scenario.InputAlert); err != nil {
 				t.Errorf("unexpected error: %s", err)
 			}
 		})

--- a/alerting/provider/provider.go
+++ b/alerting/provider/provider.go
@@ -17,6 +17,7 @@ import (
 	"github.com/TwiN/gatus/v5/alerting/provider/ifttt"
 	"github.com/TwiN/gatus/v5/alerting/provider/ilert"
 	"github.com/TwiN/gatus/v5/alerting/provider/incidentio"
+	"github.com/TwiN/gatus/v5/alerting/provider/jsm"
 	"github.com/TwiN/gatus/v5/alerting/provider/line"
 	"github.com/TwiN/gatus/v5/alerting/provider/matrix"
 	"github.com/TwiN/gatus/v5/alerting/provider/mattermost"
@@ -107,6 +108,7 @@ var (
 	_ AlertProvider = (*ifttt.AlertProvider)(nil)
 	_ AlertProvider = (*ilert.AlertProvider)(nil)
 	_ AlertProvider = (*incidentio.AlertProvider)(nil)
+	_ AlertProvider = (*jsm.AlertProvider)(nil)
 	_ AlertProvider = (*line.AlertProvider)(nil)
 	_ AlertProvider = (*matrix.AlertProvider)(nil)
 	_ AlertProvider = (*mattermost.AlertProvider)(nil)
@@ -149,6 +151,7 @@ var (
 	_ Config[ifttt.Config]          = (*ifttt.Config)(nil)
 	_ Config[ilert.Config]          = (*ilert.Config)(nil)
 	_ Config[incidentio.Config]     = (*incidentio.Config)(nil)
+	_ Config[jsm.Config]     		= (*jsm.Config)(nil)
 	_ Config[line.Config]           = (*line.Config)(nil)
 	_ Config[matrix.Config]         = (*matrix.Config)(nil)
 	_ Config[mattermost.Config]     = (*mattermost.Config)(nil)

--- a/config/config.go
+++ b/config/config.go
@@ -609,6 +609,7 @@ func ValidateAlertingConfig(alertingConfig *alerting.Config, endpoints []*endpoi
 		alert.TypeIFTTT,
 		alert.TypeIlert,
 		alert.TypeIncidentIO,
+		alert.TypeJSM,
 		alert.TypeLine,
 		alert.TypeMatrix,
 		alert.TypeMattermost,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
Jira Service Management is the successor of Opsgenie and implements the same API on a different API endpoint. 
I copied over the code and adjusted the api-endpoint and the namings.

Additionally, I added the option to do group based overrides of the config to add e.g. multiple API-Keys.

Based on the comment in #1581



## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable.
