### PR TITLE
fix(config): use resolved config path when walking config directory

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -218,7 +218,7 @@ func LoadConfiguration(configPath string) (*Config, error) {
 	}
 	var config *Config
 	if fileInfo.IsDir() {
-		err := walkConfigDir(configPath, func(path string, d fs.DirEntry, err error) error {
+		err := walkConfigDir(usedConfigPath, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return fmt.Errorf("error walking path %s: %w", path, err)
 			}


### PR DESCRIPTION
## Problem

When `LoadConfiguration` resolves a default path to a directory, `walkConfigDir` was called with the raw `configPath` argument (which may be empty) instead of the resolved `usedConfigPath`. This caused `walkConfigDir` to walk from the current working directory instead of the intended config directory, silently skipping all config files.

This is particularly problematic in containerized environments (Kubernetes, Cloud Run) where `GATUS_CONFIG_PATH` is unset and one of the default paths resolves to a directory.

## Fix

One-line change: use `usedConfigPath` instead of `configPath` when calling `walkConfigDir`.

```diff
- err := walkConfigDir(configPath, func(path string, d fs.DirEntry, err error) error {
+ err := walkConfigDir(usedConfigPath, func(path string, d fs.DirEntry, err error) error {
```

No behavior change when the caller explicitly passes a directory, since `configPath == usedConfigPath` in that case. Only the "argument is empty, default resolves to a directory" path changes, and that path is currently broken.

Fixes #456
Closes #1629