### PR TITLE
feat(pagerduty): include endpoint extra-labels as custom_details in alert payload

### DIFF
--- a/alerting/provider/pagerduty/pagerduty.go
+++ b/alerting/provider/pagerduty/pagerduty.go
@@ -122,9 +122,10 @@ type Body struct {
 }
 
 type Payload struct {
-	Summary  string `json:"summary"`
-	Source   string `json:"source"`
-	Severity string `json:"severity"`
+	Summary       string            `json:"summary"`
+	Source        string            `json:"source"`
+	Severity      string            `json:"severity"`
+	CustomDetails map[string]string `json:"custom_details,omitempty"`
 }
 
 // buildRequestBody builds the request body for the provider
@@ -139,15 +140,19 @@ func (provider *AlertProvider) buildRequestBody(cfg *Config, ep *endpoint.Endpoi
 		eventAction = "trigger"
 		resolveKey = ""
 	}
+	payload := Payload{
+		Summary:  message,
+		Source:   "Gatus",
+		Severity: "critical",
+	}
+	if len(ep.ExtraLabels) > 0 {
+		payload.CustomDetails = ep.ExtraLabels
+	}
 	body, _ := json.Marshal(Body{
 		RoutingKey:  cfg.IntegrationKey,
 		DedupKey:    resolveKey,
 		EventAction: eventAction,
-		Payload: Payload{
-			Summary:  message,
-			Source:   "Gatus",
-			Severity: "critical",
-		},
+		Payload:     payload,
 	})
 	return body
 }

--- a/alerting/provider/pagerduty/pagerduty_test.go
+++ b/alerting/provider/pagerduty/pagerduty_test.go
@@ -132,6 +132,7 @@ func TestAlertProvider_buildRequestBody(t *testing.T) {
 		Name         string
 		Provider     AlertProvider
 		Alert        alert.Alert
+		Endpoint     endpoint.Endpoint
 		Resolved     bool
 		ExpectedBody string
 	}{
@@ -139,6 +140,7 @@ func TestAlertProvider_buildRequestBody(t *testing.T) {
 			Name:         "triggered",
 			Provider:     AlertProvider{DefaultConfig: Config{IntegrationKey: "00000000000000000000000000000000"}},
 			Alert:        alert.Alert{Description: &description},
+			Endpoint:     endpoint.Endpoint{Name: "endpoint-name"},
 			Resolved:     false,
 			ExpectedBody: "{\"routing_key\":\"00000000000000000000000000000000\",\"dedup_key\":\"\",\"event_action\":\"trigger\",\"payload\":{\"summary\":\"TRIGGERED: endpoint-name - test\",\"source\":\"Gatus\",\"severity\":\"critical\"}}",
 		},
@@ -146,13 +148,14 @@ func TestAlertProvider_buildRequestBody(t *testing.T) {
 			Name:         "resolved",
 			Provider:     AlertProvider{DefaultConfig: Config{IntegrationKey: "00000000000000000000000000000000"}},
 			Alert:        alert.Alert{Description: &description, ResolveKey: "key"},
+			Endpoint:     endpoint.Endpoint{Name: "endpoint-name"},
 			Resolved:     true,
 			ExpectedBody: "{\"routing_key\":\"00000000000000000000000000000000\",\"dedup_key\":\"key\",\"event_action\":\"resolve\",\"payload\":{\"summary\":\"RESOLVED: endpoint-name - test\",\"source\":\"Gatus\",\"severity\":\"critical\"}}",
 		},
 	}
 	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
-			body := scenario.Provider.buildRequestBody(&scenario.Provider.DefaultConfig, &endpoint.Endpoint{Name: "endpoint-name"}, &scenario.Alert, &endpoint.Result{}, scenario.Resolved)
+			body := scenario.Provider.buildRequestBody(&scenario.Provider.DefaultConfig, &scenario.Endpoint, &scenario.Alert, &endpoint.Result{}, scenario.Resolved)
 			if string(body) != scenario.ExpectedBody {
 				t.Errorf("expected:\n%s\ngot:\n%s", scenario.ExpectedBody, body)
 			}
@@ -161,6 +164,45 @@ func TestAlertProvider_buildRequestBody(t *testing.T) {
 				t.Error("expected body to be valid JSON, got error:", err.Error())
 			}
 		})
+	}
+}
+
+func TestAlertProvider_buildRequestBodyWithExtraLabels(t *testing.T) {
+	description := "test"
+	ep := &endpoint.Endpoint{
+		Name:        "endpoint-name",
+		ExtraLabels: map[string]string{"environment": "production", "region": "es"},
+	}
+	provider := AlertProvider{DefaultConfig: Config{IntegrationKey: "00000000000000000000000000000000"}}
+	al := alert.Alert{Description: &description}
+	body := provider.buildRequestBody(&provider.DefaultConfig, ep, &al, &endpoint.Result{}, false)
+	var out Body
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("expected body to be valid JSON, got error: %s", err.Error())
+	}
+	if out.Payload.CustomDetails == nil {
+		t.Fatal("expected custom_details to be present")
+	}
+	if out.Payload.CustomDetails["environment"] != "production" {
+		t.Errorf("expected custom_details.environment=production, got %s", out.Payload.CustomDetails["environment"])
+	}
+	if out.Payload.CustomDetails["region"] != "es" {
+		t.Errorf("expected custom_details.region=es, got %s", out.Payload.CustomDetails["region"])
+	}
+}
+
+func TestAlertProvider_buildRequestBodyWithoutExtraLabels(t *testing.T) {
+	description := "test"
+	ep := &endpoint.Endpoint{Name: "endpoint-name"}
+	provider := AlertProvider{DefaultConfig: Config{IntegrationKey: "00000000000000000000000000000000"}}
+	al := alert.Alert{Description: &description}
+	body := provider.buildRequestBody(&provider.DefaultConfig, ep, &al, &endpoint.Result{}, false)
+	var out Body
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("expected body to be valid JSON, got error: %s", err.Error())
+	}
+	if out.Payload.CustomDetails != nil {
+		t.Error("expected custom_details to be absent when no extra-labels are defined")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `custom_details` to the PagerDuty event payload when an endpoint defines `extra-labels`
- When no `extra-labels` are present the field is omitted entirely (no breaking change)
- Follows the same pattern already used by the `incidentio` and `email` providers

## Example

```yaml
endpoints:
  - name: My Service
    url: https://example.com
    extra-labels:
      environment: production
      region: es
    alerts:
      - type: pagerduty
```

Results in a PagerDuty event with:
```json
{
  "payload": {
    "summary": "TRIGGERED: My Service - ...",
    "source": "Gatus",
    "severity": "critical",
    "custom_details": {
      "environment": "production",
      "region": "es"
    }
  }
}
```

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
