### PR TITLE
Add Flowtriq alerting provider for DDoS correlation

### DIFF
--- a/alerting/alert/type.go
+++ b/alerting/alert/type.go
@@ -23,6 +23,9 @@ const (
 	// TypeEmail is the Type for the email alerting provider
 	TypeEmail Type = "email"
 
+	// TypeFlowtriq is the Type for the flowtriq alerting provider
+	TypeFlowtriq Type = "flowtriq"
+
 	// TypeGitHub is the Type for the github alerting provider
 	TypeGitHub Type = "github"
 

--- a/alerting/config.go
+++ b/alerting/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/TwiN/gatus/v5/alerting/provider/datadog"
 	"github.com/TwiN/gatus/v5/alerting/provider/discord"
 	"github.com/TwiN/gatus/v5/alerting/provider/email"
+	"github.com/TwiN/gatus/v5/alerting/provider/flowtriq"
 	"github.com/TwiN/gatus/v5/alerting/provider/gitea"
 	"github.com/TwiN/gatus/v5/alerting/provider/github"
 	"github.com/TwiN/gatus/v5/alerting/provider/gitlab"
@@ -69,6 +70,9 @@ type Config struct {
 
 	// Email is the configuration for the email alerting provider
 	Email *email.AlertProvider `yaml:"email,omitempty"`
+
+	// Flowtriq is the configuration for the flowtriq alerting provider
+	Flowtriq *flowtriq.AlertProvider `yaml:"flowtriq,omitempty"`
 
 	// GitHub is the configuration for the github alerting provider
 	GitHub *github.AlertProvider `yaml:"github,omitempty"`

--- a/alerting/provider/flowtriq/flowtriq.go
+++ b/alerting/provider/flowtriq/flowtriq.go
@@ -1,0 +1,184 @@
+package flowtriq
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/TwiN/gatus/v5/alerting/alert"
+	"github.com/TwiN/gatus/v5/client"
+	"github.com/TwiN/gatus/v5/config/endpoint"
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	ErrWebhookURLNotSet        = errors.New("webhook URL not set")
+	ErrDuplicateGroupOverride  = errors.New("duplicate group override")
+)
+
+type Config struct {
+	WebhookURL string `yaml:"webhook-url"`
+	APIKey     string `yaml:"api-key,omitempty"`
+}
+
+func (cfg *Config) Validate() error {
+	if len(cfg.WebhookURL) == 0 {
+		return ErrWebhookURLNotSet
+	}
+	return nil
+}
+
+func (cfg *Config) Merge(override *Config) {
+	if len(override.WebhookURL) > 0 {
+		cfg.WebhookURL = override.WebhookURL
+	}
+	if len(override.APIKey) > 0 {
+		cfg.APIKey = override.APIKey
+	}
+}
+
+// AlertProvider is the configuration necessary for sending an alert using Flowtriq
+type AlertProvider struct {
+	DefaultConfig Config `yaml:",inline"`
+
+	// DefaultAlert is the default alert configuration to use for endpoints with an alert of the appropriate type
+	DefaultAlert *alert.Alert `yaml:"default-alert,omitempty"`
+
+	// Overrides is a list of Override that may be prioritized over the default configuration
+	Overrides []Override `yaml:"overrides,omitempty"`
+}
+
+// Override is a case under which the default integration is overridden
+type Override struct {
+	Group  string `yaml:"group"`
+	Config `yaml:",inline"`
+}
+
+// Validate the provider's configuration
+func (provider *AlertProvider) Validate() error {
+	registeredGroups := make(map[string]bool)
+	if provider.Overrides != nil {
+		for _, override := range provider.Overrides {
+			if len(override.Group) == 0 {
+				return ErrDuplicateGroupOverride
+			}
+			if _, ok := registeredGroups[override.Group]; ok {
+				return ErrDuplicateGroupOverride
+			}
+			registeredGroups[override.Group] = true
+		}
+	}
+	return provider.DefaultConfig.Validate()
+}
+
+// Send an alert using the provider
+func (provider *AlertProvider) Send(ep *endpoint.Endpoint, alert *alert.Alert, result *endpoint.Result, resolved bool) error {
+	cfg, err := provider.GetConfig(ep.Group, alert)
+	if err != nil {
+		return err
+	}
+	buffer := bytes.NewBuffer(provider.buildRequestBody(cfg, ep, alert, result, resolved))
+	request, err := http.NewRequest(http.MethodPost, cfg.WebhookURL, buffer)
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	if len(cfg.APIKey) > 0 {
+		request.Header.Set("Authorization", "Bearer "+cfg.APIKey)
+	}
+	response, err := client.GetHTTPClient(nil).Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	if response.StatusCode > 399 {
+		body, _ := io.ReadAll(response.Body)
+		return fmt.Errorf("call to provider alert returned status code %d: %s", response.StatusCode, string(body))
+	}
+	return nil
+}
+
+type Body struct {
+	EndpointName string            `json:"endpoint_name"`
+	Group        string            `json:"group,omitempty"`
+	Status       string            `json:"status"`
+	Description  string            `json:"description,omitempty"`
+	Message      string            `json:"message"`
+	Conditions   []ConditionResult `json:"conditions,omitempty"`
+}
+
+type ConditionResult struct {
+	Condition string `json:"condition"`
+	Success   bool   `json:"success"`
+}
+
+// buildRequestBody builds the request body for the provider
+func (provider *AlertProvider) buildRequestBody(cfg *Config, ep *endpoint.Endpoint, alert *alert.Alert, result *endpoint.Result, resolved bool) []byte {
+	var message, status string
+	if resolved {
+		status = "RESOLVED"
+		message = "An alert has been resolved after passing successfully " + strconv.Itoa(alert.SuccessThreshold) + " time(s) in a row"
+	} else {
+		status = "TRIGGERED"
+		message = "An alert has been triggered due to having failed " + strconv.Itoa(alert.FailureThreshold) + " time(s) in a row"
+	}
+	if len(alert.GetDescription()) > 0 {
+		message += " with the following description: " + alert.GetDescription()
+	}
+	var conditions []ConditionResult
+	for _, conditionResult := range result.ConditionResults {
+		conditions = append(conditions, ConditionResult{
+			Condition: conditionResult.Condition,
+			Success:   conditionResult.Success,
+		})
+	}
+	body, _ := json.Marshal(Body{
+		EndpointName: ep.DisplayName(),
+		Group:        ep.Group,
+		Status:       status,
+		Description:  alert.GetDescription(),
+		Message:      message,
+		Conditions:   conditions,
+	})
+	return body
+}
+
+// GetDefaultAlert returns the provider's default alert configuration
+func (provider *AlertProvider) GetDefaultAlert() *alert.Alert {
+	return provider.DefaultAlert
+}
+
+// GetConfig returns the configuration for the provider with the overrides applied
+func (provider *AlertProvider) GetConfig(group string, alert *alert.Alert) (*Config, error) {
+	cfg := provider.DefaultConfig
+	// Handle group overrides
+	if provider.Overrides != nil {
+		for _, override := range provider.Overrides {
+			if group == override.Group {
+				cfg.Merge(&override.Config)
+				break
+			}
+		}
+	}
+	// Handle alert overrides
+	if len(alert.ProviderOverride) != 0 {
+		overrideConfig := Config{}
+		if err := yaml.Unmarshal(alert.ProviderOverrideAsBytes(), &overrideConfig); err != nil {
+			return nil, err
+		}
+		cfg.Merge(&overrideConfig)
+	}
+	// Validate the configuration
+	err := cfg.Validate()
+	return &cfg, err
+}
+
+// ValidateOverrides validates the alert's provider override and, if present, the group override
+func (provider *AlertProvider) ValidateOverrides(group string, alert *alert.Alert) error {
+	_, err := provider.GetConfig(group, alert)
+	return err
+}

--- a/alerting/provider/flowtriq/flowtriq_test.go
+++ b/alerting/provider/flowtriq/flowtriq_test.go
@@ -1,0 +1,266 @@
+package flowtriq
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/TwiN/gatus/v5/alerting/alert"
+	"github.com/TwiN/gatus/v5/config/endpoint"
+)
+
+func TestAlertProvider_Validate(t *testing.T) {
+	scenarios := []struct {
+		name     string
+		provider AlertProvider
+		expected bool
+	}{
+		{
+			name:     "valid",
+			provider: AlertProvider{DefaultConfig: Config{WebhookURL: "https://app.flowtriq.com/webhook/gatus"}},
+			expected: true,
+		},
+		{
+			name:     "valid-with-api-key",
+			provider: AlertProvider{DefaultConfig: Config{WebhookURL: "https://app.flowtriq.com/webhook/gatus", APIKey: "test-key"}},
+			expected: true,
+		},
+		{
+			name:     "missing-webhook-url",
+			provider: AlertProvider{DefaultConfig: Config{WebhookURL: ""}},
+			expected: false,
+		},
+		{
+			name:     "no-override-group-name",
+			provider: AlertProvider{DefaultConfig: Config{WebhookURL: "https://app.flowtriq.com/webhook/gatus"}, Overrides: []Override{{}}},
+			expected: false,
+		},
+		{
+			name:     "duplicate-override-group-names",
+			provider: AlertProvider{DefaultConfig: Config{WebhookURL: "https://app.flowtriq.com/webhook/gatus"}, Overrides: []Override{{Group: "g"}, {Group: "g"}}},
+			expected: false,
+		},
+		{
+			name:     "valid-override",
+			provider: AlertProvider{DefaultConfig: Config{WebhookURL: "https://app.flowtriq.com/webhook/gatus"}, Overrides: []Override{{Group: "g1", Config: Config{WebhookURL: "https://other.flowtriq.com/webhook/gatus"}}}},
+			expected: true,
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			err := scenario.provider.Validate()
+			if scenario.expected && err != nil {
+				t.Error("expected no error, got", err.Error())
+			}
+			if !scenario.expected && err == nil {
+				t.Error("expected error, got none")
+			}
+		})
+	}
+}
+
+func TestAlertProvider_buildRequestBody(t *testing.T) {
+	firstDescription := "description-1"
+	secondDescription := "description-2"
+	scenarios := []struct {
+		Name         string
+		Provider     AlertProvider
+		Alert        alert.Alert
+		Resolved     bool
+		ExpectedBody string
+	}{
+		{
+			Name:         "triggered",
+			Provider:     AlertProvider{DefaultConfig: Config{WebhookURL: "https://app.flowtriq.com/webhook/gatus"}},
+			Alert:        alert.Alert{Description: &firstDescription, SuccessThreshold: 5, FailureThreshold: 3},
+			Resolved:     false,
+			ExpectedBody: `{"endpoint_name":"endpoint-name","status":"TRIGGERED","description":"description-1","message":"An alert has been triggered due to having failed 3 time(s) in a row with the following description: description-1","conditions":[{"condition":"[CONNECTED] == true","success":false},{"condition":"[STATUS] == 200","success":false}]}`,
+		},
+		{
+			Name:         "resolved",
+			Provider:     AlertProvider{DefaultConfig: Config{WebhookURL: "https://app.flowtriq.com/webhook/gatus"}},
+			Alert:        alert.Alert{Description: &secondDescription, SuccessThreshold: 5, FailureThreshold: 3},
+			Resolved:     true,
+			ExpectedBody: `{"endpoint_name":"endpoint-name","status":"RESOLVED","description":"description-2","message":"An alert has been resolved after passing successfully 5 time(s) in a row with the following description: description-2","conditions":[{"condition":"[CONNECTED] == true","success":true},{"condition":"[STATUS] == 200","success":true}]}`,
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			cfg, err := scenario.Provider.GetConfig("", &scenario.Alert)
+			if err != nil {
+				t.Error("expected no error, got", err.Error())
+			}
+			body := scenario.Provider.buildRequestBody(
+				cfg,
+				&endpoint.Endpoint{Name: "endpoint-name"},
+				&scenario.Alert,
+				&endpoint.Result{
+					ConditionResults: []*endpoint.ConditionResult{
+						{Condition: "[CONNECTED] == true", Success: scenario.Resolved},
+						{Condition: "[STATUS] == 200", Success: scenario.Resolved},
+					},
+				},
+				scenario.Resolved,
+			)
+			if string(body) != scenario.ExpectedBody {
+				t.Errorf("expected:\n%s\ngot:\n%s", scenario.ExpectedBody, body)
+			}
+			out := make(map[string]interface{})
+			if err := json.Unmarshal(body, &out); err != nil {
+				t.Error("expected body to be valid JSON, got error:", err.Error())
+			}
+		})
+	}
+}
+
+func TestAlertProvider_Send(t *testing.T) {
+	description := "description-1"
+	scenarios := []struct {
+		Name            string
+		Provider        AlertProvider
+		Alert           alert.Alert
+		Resolved        bool
+		Group           string
+		ExpectedBody    string
+		ExpectedHeaders map[string]string
+	}{
+		{
+			Name:         "triggered",
+			Provider:     AlertProvider{DefaultConfig: Config{WebhookURL: "https://app.flowtriq.com/webhook/gatus"}},
+			Alert:        alert.Alert{Description: &description, SuccessThreshold: 5, FailureThreshold: 3},
+			Resolved:     false,
+			Group:        "",
+			ExpectedBody: `{"endpoint_name":"endpoint-name","status":"TRIGGERED","description":"description-1","message":"An alert has been triggered due to having failed 3 time(s) in a row with the following description: description-1","conditions":[{"condition":"[CONNECTED] == true","success":false},{"condition":"[STATUS] == 200","success":false}]}`,
+			ExpectedHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+		},
+		{
+			Name:         "triggered-with-api-key",
+			Provider:     AlertProvider{DefaultConfig: Config{WebhookURL: "https://app.flowtriq.com/webhook/gatus", APIKey: "my-api-key"}},
+			Alert:        alert.Alert{Description: &description, SuccessThreshold: 5, FailureThreshold: 3},
+			Resolved:     false,
+			Group:        "",
+			ExpectedBody: `{"endpoint_name":"endpoint-name","status":"TRIGGERED","description":"description-1","message":"An alert has been triggered due to having failed 3 time(s) in a row with the following description: description-1","conditions":[{"condition":"[CONNECTED] == true","success":false},{"condition":"[STATUS] == 200","success":false}]}`,
+			ExpectedHeaders: map[string]string{
+				"Content-Type":  "application/json",
+				"Authorization": "Bearer my-api-key",
+			},
+		},
+		{
+			Name:     "resolved-with-group",
+			Provider: AlertProvider{DefaultConfig: Config{WebhookURL: "https://app.flowtriq.com/webhook/gatus"}, Overrides: []Override{{Group: "test-group", Config: Config{APIKey: "override-key"}}}},
+			Alert:    alert.Alert{Description: &description, SuccessThreshold: 5, FailureThreshold: 3},
+			Resolved: true,
+			Group:    "test-group",
+			ExpectedBody: `{"endpoint_name":"test-group/endpoint-name","group":"test-group","status":"RESOLVED","description":"description-1","message":"An alert has been resolved after passing successfully 5 time(s) in a row with the following description: description-1","conditions":[{"condition":"[CONNECTED] == true","success":true},{"condition":"[STATUS] == 200","success":true}]}`,
+			ExpectedHeaders: map[string]string{
+				"Content-Type":  "application/json",
+				"Authorization": "Bearer override-key",
+			},
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				for header, value := range scenario.ExpectedHeaders {
+					if value != req.Header.Get(header) {
+						t.Errorf("expected: %s, got: %s", value, req.Header.Get(header))
+					}
+				}
+				body, _ := io.ReadAll(req.Body)
+				if string(body) != scenario.ExpectedBody {
+					t.Errorf("expected:\n%s\ngot:\n%s", scenario.ExpectedBody, body)
+				}
+				rw.Write([]byte(`OK`))
+			}))
+			defer server.Close()
+
+			scenario.Provider.DefaultConfig.WebhookURL = server.URL
+			err := scenario.Provider.Send(
+				&endpoint.Endpoint{Name: "endpoint-name", Group: scenario.Group},
+				&scenario.Alert,
+				&endpoint.Result{
+					ConditionResults: []*endpoint.ConditionResult{
+						{Condition: "[CONNECTED] == true", Success: scenario.Resolved},
+						{Condition: "[STATUS] == 200", Success: scenario.Resolved},
+					},
+				},
+				scenario.Resolved,
+			)
+			if err != nil {
+				t.Error("Encountered an error on Send: ", err)
+			}
+		})
+	}
+}
+
+func TestAlertProvider_GetConfig(t *testing.T) {
+	scenarios := []struct {
+		Name           string
+		Provider       AlertProvider
+		InputGroup     string
+		InputAlert     alert.Alert
+		ExpectedOutput Config
+	}{
+		{
+			Name: "provider-no-override-specify-no-group-should-default",
+			Provider: AlertProvider{
+				DefaultConfig: Config{WebhookURL: "https://app.flowtriq.com/webhook/gatus", APIKey: "default-key"},
+				Overrides:     nil,
+			},
+			InputGroup:     "",
+			InputAlert:     alert.Alert{},
+			ExpectedOutput: Config{WebhookURL: "https://app.flowtriq.com/webhook/gatus", APIKey: "default-key"},
+		},
+		{
+			Name: "provider-with-override-specify-group-should-override",
+			Provider: AlertProvider{
+				DefaultConfig: Config{WebhookURL: "https://app.flowtriq.com/webhook/gatus", APIKey: "default-key"},
+				Overrides: []Override{
+					{
+						Group:  "group",
+						Config: Config{WebhookURL: "https://other.flowtriq.com/webhook/gatus", APIKey: "group-key"},
+					},
+				},
+			},
+			InputGroup:     "group",
+			InputAlert:     alert.Alert{},
+			ExpectedOutput: Config{WebhookURL: "https://other.flowtriq.com/webhook/gatus", APIKey: "group-key"},
+		},
+		{
+			Name: "provider-with-group-override-and-alert-override--alert-override-should-take-precedence",
+			Provider: AlertProvider{
+				DefaultConfig: Config{WebhookURL: "https://app.flowtriq.com/webhook/gatus", APIKey: "default-key"},
+				Overrides: []Override{
+					{
+						Group:  "group",
+						Config: Config{WebhookURL: "https://group.flowtriq.com/webhook/gatus"},
+					},
+				},
+			},
+			InputGroup:     "group",
+			InputAlert:     alert.Alert{ProviderOverride: map[string]any{"webhook-url": "https://alert.flowtriq.com/webhook/gatus"}},
+			ExpectedOutput: Config{WebhookURL: "https://alert.flowtriq.com/webhook/gatus", APIKey: "default-key"},
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			got, err := scenario.Provider.GetConfig(scenario.InputGroup, &scenario.InputAlert)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if got.WebhookURL != scenario.ExpectedOutput.WebhookURL {
+				t.Errorf("expected webhook-url %s, got %s", scenario.ExpectedOutput.WebhookURL, got.WebhookURL)
+			}
+			if got.APIKey != scenario.ExpectedOutput.APIKey {
+				t.Errorf("expected api-key %s, got %s", scenario.ExpectedOutput.APIKey, got.APIKey)
+			}
+			if err = scenario.Provider.ValidateOverrides(scenario.InputGroup, &scenario.InputAlert); err != nil {
+				t.Errorf("unexpected error: %s", err)
+			}
+		})
+	}
+}

--- a/alerting/provider/provider.go
+++ b/alerting/provider/provider.go
@@ -8,6 +8,7 @@ import (
 	"github.com/TwiN/gatus/v5/alerting/provider/datadog"
 	"github.com/TwiN/gatus/v5/alerting/provider/discord"
 	"github.com/TwiN/gatus/v5/alerting/provider/email"
+	"github.com/TwiN/gatus/v5/alerting/provider/flowtriq"
 	"github.com/TwiN/gatus/v5/alerting/provider/gitea"
 	"github.com/TwiN/gatus/v5/alerting/provider/github"
 	"github.com/TwiN/gatus/v5/alerting/provider/gitlab"
@@ -98,6 +99,7 @@ var (
 	_ AlertProvider = (*datadog.AlertProvider)(nil)
 	_ AlertProvider = (*discord.AlertProvider)(nil)
 	_ AlertProvider = (*email.AlertProvider)(nil)
+	_ AlertProvider = (*flowtriq.AlertProvider)(nil)
 	_ AlertProvider = (*gitea.AlertProvider)(nil)
 	_ AlertProvider = (*github.AlertProvider)(nil)
 	_ AlertProvider = (*gitlab.AlertProvider)(nil)
@@ -140,6 +142,7 @@ var (
 	_ Config[datadog.Config]        = (*datadog.Config)(nil)
 	_ Config[discord.Config]        = (*discord.Config)(nil)
 	_ Config[email.Config]          = (*email.Config)(nil)
+	_ Config[flowtriq.Config]       = (*flowtriq.Config)(nil)
 	_ Config[gitea.Config]          = (*gitea.Config)(nil)
 	_ Config[github.Config]         = (*github.Config)(nil)
 	_ Config[gitlab.Config]         = (*gitlab.Config)(nil)


### PR DESCRIPTION
Adds Flowtriq as an alerting provider. When monitored endpoints go down, Gatus can notify Flowtriq to correlate outages with DDoS attacks detected on the network layer.

### Changes

- New `flowtriq` alerting provider in `alerting/provider/flowtriq/`
- Config fields: `webhook-url` (required), `api-key` (optional)
- Sends structured JSON with endpoint name, status, description, message, and condition results
- Supports group overrides and alert-level provider overrides
- Registered in `alerting/config.go`, `alerting/provider/provider.go`, and `alerting/alert/type.go`
- Includes tests for validation, request body building, HTTP send, and config overrides

### Configuration example

```yaml
alerting:
  flowtriq:
    webhook-url: "https://app.flowtriq.com/webhook/gatus"
    api-key: "your-api-key"

endpoints:
  - name: example
    url: "https://example.com"
    alerts:
      - type: flowtriq
```