### PR TITLE
fix(endpoint): formatDuration strips trailing zero digits from durations ending in zero

### DIFF
--- a/config/endpoint/condition.go
+++ b/config/endpoint/condition.go
@@ -246,11 +246,17 @@ func formatDuration(d time.Duration) string {
 	if s == "0s" {
 		return "0s"
 	}
-	// Remove trailing "0s" if present
-	if strings.HasSuffix(s, "0s") {
+	// Remove a trailing zero-seconds component, e.g. "1h30m0s" -> "1h30m".
+	// We match "m0s" (rather than just "0s") so that we only strip a genuine
+	// zero-seconds component and not the trailing zero of a value like "30s".
+	if strings.HasSuffix(s, "m0s") {
 		s = strings.TrimSuffix(s, "0s")
-		// Remove trailing "0m" if present after removing "0s"
-		s = strings.TrimSuffix(s, "0m")
+		// Then remove a trailing zero-minutes component, e.g. "336h0m" -> "336h".
+		// We match "h0m" (rather than just "0m") so that we don't strip the
+		// trailing zero of a value like "30m" (turning "1h30m" into "1h3").
+		if strings.HasSuffix(s, "h0m") {
+			s = strings.TrimSuffix(s, "0m")
+		}
 	}
 	return s
 }

--- a/config/endpoint/condition_test.go
+++ b/config/endpoint/condition_test.go
@@ -862,3 +862,29 @@ func TestConditionEvaluateWithMixedValidAndInvalidContext(t *testing.T) {
 		t.Errorf("Incorrect condition display\nExpected: %s\nActual:   %s", expectedDisplay, actualDisplay)
 	}
 }
+
+func TestFormatDuration(t *testing.T) {
+	scenarios := []struct {
+		name     string
+		duration time.Duration
+		expected string
+	}{
+		{name: "zero", duration: 0, expected: "0s"},
+		{name: "seconds-only", duration: 45 * time.Second, expected: "45s"},
+		{name: "seconds-ending-in-zero", duration: 30 * time.Second, expected: "30s"},
+		{name: "minutes-only", duration: 50 * time.Minute, expected: "50m"},
+		{name: "minutes-and-zero-seconds", duration: 30 * time.Minute, expected: "30m"},
+		{name: "hours-and-zero-minutes", duration: 336 * time.Hour, expected: "336h"},
+		{name: "hours-and-minutes-ending-in-zero", duration: time.Hour + 30*time.Minute, expected: "1h30m"},
+		{name: "hours-and-minutes", duration: 2*time.Hour + 10*time.Minute, expected: "2h10m"},
+		{name: "hours-zero-minutes-and-seconds", duration: time.Hour + 15*time.Second, expected: "1h0m15s"},
+		{name: "all-components", duration: time.Hour + 30*time.Minute + 15*time.Second, expected: "1h30m15s"},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			if output := formatDuration(scenario.duration); output != scenario.expected {
+				t.Errorf("expected formatDuration(%s) to be %q, got %q", scenario.duration, scenario.expected, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`formatDuration` (in `config/endpoint/condition.go`) is meant to drop unnecessary
zero components when displaying a duration (e.g. `336h0m0s` → `336h`,
`1h30m0s` → `1h30m`). It does so with unconditional suffix trims:

```go
if strings.HasSuffix(s, "0s") {
    s = strings.TrimSuffix(s, "0s")
    s = strings.TrimSuffix(s, "0m")
}
```

`strings.TrimSuffix` removes the literal suffix wherever it matches — including the
trailing zero of a *real* value — so any duration whose minutes or seconds end in
`0` gets mangled:

| input | got | want |
|---|---|---|
| `1h30m0s` | `1h3` | `1h30m` |
| `2h10m0s` | `2h1` | `2h10m` |
| `50m0s`   | `5`   | `50m` |
| `30s`     | `3`   | `30s` |

This surfaces in condition display strings for duration-based checks (e.g.
`[CERTIFICATE_EXPIRATION]`, `[DOMAIN_EXPIRATION]`, and conditions using duration
literals like `48h`).

## Fix

Only strip a component when it's a genuine *zero* component:
- trim `0s` only when the suffix is `m0s` (a real zero-seconds component, not the
  `0` of `30s`),
- then trim `0m` only when the suffix is `h0m` (not the `0` of `30m`).

No behavior change for the already-correct cases (`336h0m0s` → `336h`,
`1h0m15s` unchanged).

## Tests

Adds `TestFormatDuration` covering zero, seconds-only, values ending in zero,
and mixed components. `go test ./config/endpoint/` passes; `gofmt` clean.
