### PR TITLE
fix(jsonpath): prevent panic on negative array index

### DIFF
--- a/jsonpath/jsonpath.go
+++ b/jsonpath/jsonpath.go
@@ -87,7 +87,7 @@ func extractValue(currentKey string, value interface{}) interface{} {
 			}
 		}
 		arrayIndex, err := strconv.Atoi(index)
-		if err != nil {
+		if err != nil || arrayIndex < 0 {
 			return nil
 		}
 		currentKeyWithoutIndex := currentKey[:startOfBracket]

--- a/jsonpath/jsonpath_test.go
+++ b/jsonpath/jsonpath_test.go
@@ -174,6 +174,38 @@ func TestEval(t *testing.T) {
 			ExpectedOutputLength: 18,
 			ExpectedError:        false,
 		},
+		{
+			Name:                 "negative-index-on-keyed-array",
+			Path:                 "data[-1]",
+			Data:                 `{"data": [1, 2, 3]}`,
+			ExpectedOutput:       "",
+			ExpectedOutputLength: 0,
+			ExpectedError:        true,
+		},
+		{
+			Name:                 "negative-index-on-root-array",
+			Path:                 "[-1]",
+			Data:                 `[1, 2, 3]`,
+			ExpectedOutput:       "",
+			ExpectedOutputLength: 0,
+			ExpectedError:        true,
+		},
+		{
+			Name:                 "negative-index-followed-by-key",
+			Path:                 "data[-1].name",
+			Data:                 `{"data": [{"name": "value"}]}`,
+			ExpectedOutput:       "",
+			ExpectedOutputLength: 0,
+			ExpectedError:        true,
+		},
+		{
+			Name:                 "negative-index-nested-array",
+			Path:                 "data[0][-1]",
+			Data:                 `{"data": [[1, 2, 3]]}`,
+			ExpectedOutput:       "",
+			ExpectedOutputLength: 0,
+			ExpectedError:        true,
+		},
 	}
 	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {


### PR DESCRIPTION
A jsonpath condition with a negative array index (e.g. `[BODY].data[-1]` or `[BODY][-1]`) crashes the entire Gatus process.

## Problem

In `extractValue`, the array bounds checks are `len(array) > arrayIndex`. A negative index satisfies that check (`3 > -1` is `true`), so execution reaches `array[arrayIndex]` with a negative index:

```
runtime error: index out of range [-1]
```

Condition evaluation runs in the watchdog's per-endpoint goroutine, and there is no `recover()` in that path, so a single endpoint configured with a negative jsonpath index takes the whole process down on every check.

Reachable purely from user configuration, e.g.:

```yaml
conditions:
  - "[BODY].data[-1] == something"
```

(also `[BODY][-1]`, `[BODY].data[-1].name`).

## Fix

Guard against negative indices alongside the existing `strconv.Atoi` error check, so an out-of-range negative index returns `nil` and is treated as an invalid path — the same behaviour as an out-of-range positive index — instead of panicking. The single guard covers both the root-array and keyed-array branches because `arrayIndex` is parsed once before either access.

## Tests

Adds `TestEval` scenarios for negative indices on keyed arrays, root arrays, and a negative index followed by a key. `go test ./...` passes and `gofmt` is clean.

---

Made by an AI agent (Claude Code, model Claude Opus 4.8).