### PR TITLE
feat: Implement zeroconf mdns discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ If you want to test it locally, see [Docker](#docker).
 | Parameter                    | Description                                                                                                                              | Default       |
 |:-----------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:--------------|
 | `metrics`                    | Whether to expose metrics at `/metrics`.                                                                                                 | `false`       |
+| `disable-zeroconf`           | Whether to disable zeroconf service autodiscovery.                                                                                       | `false`       |
 | `storage`                    | [Storage configuration](#storage).                                                                                                       | `{}`          |
 | `alerting`                   | [Alerting configuration](#alerting).                                                                                                     | `{}`          |
 | `announcements`              | [Announcements configuration](#announcements).                                                                                           | `[]`          |

--- a/config/config.go
+++ b/config/config.go
@@ -72,6 +72,9 @@ type Config struct {
 	// if the configuration file is updated while the application is running
 	SkipInvalidConfigUpdate bool `yaml:"skip-invalid-config-update,omitempty"`
 
+	// DisableZeroconf Whether to disable Zeroconf (mDNS) discovery
+	DisableZeroconf bool `yaml:"disable-zeroconf,omitempty"`
+
 	// DisableMonitoringLock Whether to disable the monitoring lock
 	// The monitoring lock is what prevents multiple endpoints from being processed at the same time.
 	// Disabling this may lead to inaccurate response times

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -539,6 +539,26 @@ endpoints:
 	}
 }
 
+func TestParseAndValidateConfigBytesWithDisableZeroconf(t *testing.T) {
+	config, err := parseAndValidateConfigBytes([]byte(`
+disable-zeroconf: true
+endpoints:
+  - name: website
+    url: https://twin.sh/health
+    conditions:
+      - "[STATUS] == 200"
+`))
+	if err != nil {
+		t.Error("expected no error, got", err.Error())
+	}
+	if config == nil {
+		t.Fatal("Config shouldn't have been nil")
+	}
+	if !config.DisableZeroconf {
+		t.Error("DisableZeroconf should've been true")
+	}
+}
+
 func TestParseAndValidateConfigBytesWithAddress(t *testing.T) {
 	config, err := parseAndValidateConfigBytes([]byte(`
 web:

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/google/go-github/v48 v48.2.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
+	github.com/hashicorp/mdns v1.0.7
 	github.com/ishidawataru/sctp v0.0.0-20251114114122-19ddcbc6aae2
 	github.com/lib/pq v1.12.3
 	github.com/miekg/dns v1.1.72

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/hashicorp/go-version v1.9.0 h1:CeOIz6k+LoN3qX9Z0tyQrPtiB1DFYRPfCIBtaX
 github.com/hashicorp/go-version v1.9.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
+github.com/hashicorp/mdns v1.0.7 h1:yWoQVMW5JOiDxQnIUcm3IDt0kCjf3TuXHDbdEKPsbAY=
+github.com/hashicorp/mdns v1.0.7/go.mod h1:yjuhYhZyPDqXXL48xC7cdpGwGUMwu7OViDmsuT5COvg=
 github.com/ishidawataru/sctp v0.0.0-20251114114122-19ddcbc6aae2 h1:36qep4gxKs+JgeHGWeQ040RyZdt9kQlLglL1rFVn/oQ=
 github.com/ishidawataru/sctp v0.0.0-20251114114122-19ddcbc6aae2/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=
 github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/TwiN/gatus/v5/metrics"
 	"github.com/TwiN/gatus/v5/storage/store"
 	"github.com/TwiN/gatus/v5/watchdog"
+	"github.com/TwiN/gatus/v5/zeroconf"
 	"github.com/TwiN/logr"
 )
 
@@ -52,10 +53,12 @@ func start(cfg *config.Config) {
 	go controller.Handle(cfg)
 	metrics.InitializePrometheusMetrics(cfg, nil)
 	watchdog.Monitor(cfg)
+	zeroconf.Initialize(cfg)
 	go listenToConfigurationFileChanges(cfg)
 }
 
 func stop(cfg *config.Config) {
+	zeroconf.Shutdown()
 	watchdog.Shutdown(cfg)
 	controller.Shutdown()
 	metrics.UnregisterPrometheusMetrics()

--- a/main.go
+++ b/main.go
@@ -53,7 +53,9 @@ func start(cfg *config.Config) {
 	go controller.Handle(cfg)
 	metrics.InitializePrometheusMetrics(cfg, nil)
 	watchdog.Monitor(cfg)
-	zeroconf.Initialize(cfg)
+	if !cfg.DisableZeroconf {
+		zeroconf.Initialize(cfg)
+	}
 	go listenToConfigurationFileChanges(cfg)
 }
 

--- a/zeroconf/zeroconf.go
+++ b/zeroconf/zeroconf.go
@@ -1,0 +1,90 @@
+package zeroconf
+
+import (
+	"net"
+	"sync"
+
+	"github.com/TwiN/gatus/v5/config"
+	"github.com/TwiN/logr"
+	"github.com/hashicorp/mdns"
+)
+
+const (
+	instanceName = "gatus"
+	hostName     = "gatus.local."
+)
+
+var (
+	server *mdns.Server
+	mutex  sync.Mutex
+)
+
+func Initialize(cfg *config.Config) {
+	mutex.Lock()
+	defer mutex.Unlock()
+	service, err := mdns.NewMDNSService(instanceName, "_http._tcp", "", hostName, cfg.Web.Port, localIPs(), []string{"path=/"})
+	if err != nil {
+		logr.Errorf("[zeroconf.Initialize] Failed to create mDNS service info: %s", err.Error())
+		return
+	}
+	s, err := mdns.NewServer(&mdns.Config{Zone: service})
+	if err != nil {
+		logr.Errorf("[zeroconf.Initialize] Failed to start mDNS server: %s", err.Error())
+		return
+	}
+	server = s
+	logr.Infof("[zeroconf.Initialize] Advertising Gatus as '%s' (%s) on port %d via mDNS", instanceName, hostName, cfg.Web.Port)
+}
+
+func Shutdown() {
+	mutex.Lock()
+	defer mutex.Unlock()
+	if server != nil {
+		if err := server.Shutdown(); err != nil {
+			logr.Errorf("[zeroconf.Shutdown] Failed to shut down mDNS server: %s", err.Error())
+		}
+		server = nil
+		logr.Info("[zeroconf.Shutdown] Stopped advertising Gatus via mDNS")
+	}
+}
+
+func localIPs() []net.IP {
+	var ips []net.IP
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		logr.Warnf("[zeroconf.localIPs] Failed to list network interfaces, falling back to auto-detection: %s", err.Error())
+		return nil
+	}
+
+	for _, iface := range interfaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+
+		if iface.Name == "docker0" || len(iface.Name) > 3 && iface.Name[:3] == "br-" {
+			continue
+		}
+
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+
+			if ip == nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() {
+				continue
+			}
+
+			ips = append(ips, ip)
+		}
+	}
+	return ips
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
This PR enables Zeroconf service discovery. This is to enable the Home Assistant integration I am working on to automatically discover and configure itself when Gatus is running on the local network

Currently enabled by default ~~with no way to turn off. If its preferable, could add a config option to disable it. Thoughts?~~ There is now a config flag (`disable-zeroconf`) to disable this feature if required.

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
Tested locally, seems to be working as expected
- [x] Updated documentation in `README.md`, if applicable.

