### PR TITLE
feat: Filter remote endpoints by group (filter-groups)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2839,6 +2839,9 @@ There are two main use cases for this:
 - You have multiple Gatus instances running on different machines, and you wish to visually expose the statuses through a single dashboard
 - You have one or more Gatus instances that are not publicly accessible (e.g. behind a firewall), and you wish to retrieve
 
+It is possible to filter imported endpoints with the `filter-groups` parameter. This is for example useful if you have separate
+gatus instances, but would like to perform inter-site connectivity tests.
+
 This is an experimental feature. It may be removed or updated in a breaking manner at any time. Furthermore,
 there are known issues with this feature. If you'd like to provide some feedback, please write a comment in [#64](https://github.com/TwiN/gatus/issues/64).
 Use at your own risk.
@@ -2848,6 +2851,7 @@ Use at your own risk.
 | `remote`                           | Remote configuration                           | `{}`          |
 | `remote.instances`                 | List of remote instances                       | Required `[]` |
 | `remote.instances.endpoint-prefix` | String to prefix all endpoint names with       | `""`          |
+| `remote.instances.filter-groups`   | List of groups to import (default all)         | `[]`          |
 | `remote.instances.url`             | URL from which to retrieve endpoint statuses   | Required `""` |
 | `remote.client`                    | [Client configuration](#client-configuration). | `{}`          |
 

--- a/api/endpoint_status.go
+++ b/api/endpoint_status.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
+	"strings"
 
 	"github.com/TwiN/gatus/v5/client"
 	"github.com/TwiN/gatus/v5/config"
@@ -71,11 +73,26 @@ func getEndpointStatusesFromRemoteInstances(remoteConfig *remote.Config) ([]*end
 			continue
 		}
 		_ = response.Body.Close()
+
+		ignoredEndpoints := []string{}
 		for _, endpointStatus := range endpointStatuses {
+			if len(instance.FilterGroups) > 0 && !slices.Contains(instance.FilterGroups, endpointStatus.Group) {
+				ignoredEndpoints = append(ignoredEndpoints, endpointStatus.Name)
+				continue
+			}
 			endpointStatus.Name = instance.EndpointPrefix + endpointStatus.Name
+			endpointStatusesFromAllRemotes = append(endpointStatusesFromAllRemotes, endpointStatus)
 		}
-		endpointStatusesFromAllRemotes = append(endpointStatusesFromAllRemotes, endpointStatuses...)
+
+		if len(ignoredEndpoints) > 0 {
+			logr.Debugf(
+				"[api.getEndpointStatusesFromRemoteInstances] Ignored remote endpoints which are not in the filtered groups (%s): %s",
+				strings.Join(instance.FilterGroups, ", "),
+				strings.Join(ignoredEndpoints, ", "),
+			)
+		}
 	}
+
 	// Only return nil, error if no remote instances were successfully processed
 	if len(endpointStatusesFromAllRemotes) == 0 && remoteConfig.Instances != nil {
 		return nil, fmt.Errorf("failed to retrieve endpoint statuses from all remote instances")

--- a/config/remote/remote.go
+++ b/config/remote/remote.go
@@ -17,8 +17,9 @@ type Config struct {
 }
 
 type Instance struct {
-	EndpointPrefix string `yaml:"endpoint-prefix"`
-	URL            string `yaml:"url"`
+	EndpointPrefix string   `yaml:"endpoint-prefix"`
+	FilterGroups   []string `yaml:"filter-groups"`
+	URL            string   `yaml:"url"`
 }
 
 func (c *Config) ValidateAndSetDefaults() error {


### PR DESCRIPTION
I wanted to be able to monitor electrical downtime on my machines (rare, but does happen). Since gatus has no way of knowing when a check was not performed (due to the instance being offline), i'm using the remote instances feature.

In order to avoid adding too much stuff to each instance's UI, and only add remote reachability tests, i'm filtering by groups.

Example config `site1.yaml`:

```yaml
storage:
  type: "sqlite"
  path: "gatus.sqlite"
remote:
  instances:
    - endpoint-prefix: "from-site2 "
      filter-groups: [ "site1" ]
      url: "https://site2.example.com/api/v1/endpoints/statuses"
endpoints:
  - name: router
    url: "icmp://192.168.1.1"
    group: site1
    interval: 5s
    conditions:
      - "[CONNECTED] == true"
  - name: site2
    url: "icmp://IP2"
    group: site2
    interval: 5s
    conditions:
      - "[CONNECTED] == true"
```

Example config `site2.yaml`:

```yaml
storage:
  type: "sqlite"
  path: "gatus.sqlite"
remote:
  instances:
    - endpoint-prefix: "from-site1 "
      filter-groups: [ "site2" ]
      url: "https://site1.example.com/api/v1/endpoints/statuses"
endpoints:
  - name: router
    url: "icmp://192.168.2.1"
    group: site2
    interval: 5s
    conditions:
      - "[CONNECTED] == true"
  - name: site1
    url: "icmp://IP1"
    group: site1
    interval: 5s
    conditions:
      - "[CONNECTED] == true"
```

I did not add a test because the remote feature is marked alpha and i didn't find remote tests.