### PR TITLE
fix: Route for remote endpoint detailed view

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -77,14 +77,14 @@ func (a *API) createRouter(cfg *config.Config) *fiber.App {
 	////////////////////////
 	unprotectedAPIRouter := apiRouter.Group("/")
 	unprotectedAPIRouter.Get("/v1/config", ConfigHandler{securityConfig: cfg.Security, config: cfg}.GetConfig)
-	unprotectedAPIRouter.Get("/v1/endpoints/:key/health/badge.svg", HealthBadge)
-	unprotectedAPIRouter.Get("/v1/endpoints/:key/health/badge.shields", HealthBadgeShields)
-	unprotectedAPIRouter.Get("/v1/endpoints/:key/uptimes/:duration", UptimeRaw)
-	unprotectedAPIRouter.Get("/v1/endpoints/:key/uptimes/:duration/badge.svg", UptimeBadge)
-	unprotectedAPIRouter.Get("/v1/endpoints/:key/response-times/:duration", ResponseTimeRaw)
-	unprotectedAPIRouter.Get("/v1/endpoints/:key/response-times/:duration/badge.svg", ResponseTimeBadge(cfg))
-	unprotectedAPIRouter.Get("/v1/endpoints/:key/response-times/:duration/chart.svg", ResponseTimeChart)
-	unprotectedAPIRouter.Get("/v1/endpoints/:key/response-times/:duration/history", ResponseTimeHistory)
+	unprotectedAPIRouter.Get("/v1/endpoints/:key/health/badge.svg", queryRemoteOrLocalHandler(cfg, HealthBadge, "HealthBadge"))
+	unprotectedAPIRouter.Get("/v1/endpoints/:key/health/badge.shields", queryRemoteOrLocalHandler(cfg, HealthBadgeShields, "HealthBadgeShields"))
+	unprotectedAPIRouter.Get("/v1/endpoints/:key/uptimes/:duration", queryRemoteOrLocalHandler(cfg, UptimeRaw, "UptimeRaw"))
+	unprotectedAPIRouter.Get("/v1/endpoints/:key/uptimes/:duration/badge.svg", queryRemoteOrLocalHandler(cfg, UptimeBadge, "UptimeBadge"))
+	unprotectedAPIRouter.Get("/v1/endpoints/:key/response-times/:duration", queryRemoteOrLocalHandler(cfg, ResponseTimeRaw, "ResponseTimeRaw"))
+	unprotectedAPIRouter.Get("/v1/endpoints/:key/response-times/:duration/badge.svg", queryRemoteOrLocalHandlerWithCfg(cfg, ResponseTimeBadge, "ResponseTimeBadge"))
+	unprotectedAPIRouter.Get("/v1/endpoints/:key/response-times/:duration/chart.svg", queryRemoteOrLocalHandler(cfg, ResponseTimeChart, "ResponseTimeChart"))
+	unprotectedAPIRouter.Get("/v1/endpoints/:key/response-times/:duration/history", queryRemoteOrLocalHandler(cfg, ResponseTimeHistory, "ResponseTimeHistory"))
 	// This endpoint requires authz with bearer token, so technically it is protected
 	unprotectedAPIRouter.Post("/v1/endpoints/:key/external", CreateExternalEndpointResult(cfg))
 	// SPA
@@ -129,8 +129,10 @@ func (a *API) createRouter(cfg *config.Config) *fiber.App {
 		}
 	}
 	protectedAPIRouter.Get("/v1/endpoints/statuses", EndpointStatuses(cfg))
+	// Remote endpoint statuses cannot be proxied as-is because we
+	// need to edit the JSON on the go to replace local key with remote key
 	protectedAPIRouter.Get("/v1/endpoints/:key/statuses", EndpointStatus(cfg))
 	protectedAPIRouter.Get("/v1/suites/statuses", SuiteStatuses(cfg))
-	protectedAPIRouter.Get("/v1/suites/:key/statuses", SuiteStatus(cfg))
+	protectedAPIRouter.Get("/v1/suites/:key/statuses", queryRemoteOrLocalHandlerWithCfg(cfg, SuiteStatus, "SuiteStatus"))
 	return app
 }

--- a/api/endpoint_status.go
+++ b/api/endpoint_status.go
@@ -1,10 +1,14 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
 
 	"github.com/TwiN/gatus/v5/client"
 	"github.com/TwiN/gatus/v5/config"
@@ -57,7 +61,9 @@ func getEndpointStatusesFromRemoteInstances(remoteConfig *remote.Config) ([]*end
 	}
 	var endpointStatusesFromAllRemotes []*endpoint.Status
 	httpClient := client.GetHTTPClient(remoteConfig.ClientConfig)
+	remoteCount := 0
 	for _, instance := range remoteConfig.Instances {
+		remoteCount = remoteCount + 1
 		response, err := httpClient.Get(instance.URL)
 		if err != nil {
 			// Log the error but continue with other instances
@@ -73,6 +79,7 @@ func getEndpointStatusesFromRemoteInstances(remoteConfig *remote.Config) ([]*end
 		_ = response.Body.Close()
 		for _, endpointStatus := range endpointStatuses {
 			endpointStatus.Name = instance.EndpointPrefix + endpointStatus.Name
+			endpointStatus.Key = fmt.Sprint("_gatus_remote_", remoteCount, "_", endpointStatus.Key)
 		}
 		endpointStatusesFromAllRemotes = append(endpointStatusesFromAllRemotes, endpointStatuses...)
 	}
@@ -92,6 +99,27 @@ func EndpointStatus(cfg *config.Config) fiber.Handler {
 			logr.Errorf("[api.EndpointStatus] Failed to decode key: %s", err.Error())
 			return c.Status(400).SendString("invalid key encoding")
 		}
+
+		if strings.HasPrefix(key, "_gatus_remote_") {
+			r := regexp.MustCompile("_gatus_remote_(\\d+)_(.*)")
+			regexResult := r.FindStringSubmatch(key)
+			if regexResult == nil {
+				return c.Status(400).SendString(fmt.Sprint("invalid remote key: ", key))
+			}
+
+			remoteNr, err := strconv.Atoi(regexResult[1])
+			if err != nil {
+				return c.Status(400).SendString(fmt.Sprint("invalid non-numeric requested remote: ", regexResult[1]))
+			}
+			remoteKey := regexResult[2]
+
+			if remoteNr < 1 || remoteNr > len(cfg.Remote.Instances) {
+				return c.Status(404).SendString(fmt.Sprint("requested remote does not exist: ", remoteNr))
+			}
+
+			return EndpointStatusFromRemoteInstance(c, cfg, remoteNr, remoteKey, page, pageSize)
+		}
+
 		endpointStatus, err := store.Get().GetEndpointStatusByKey(key, paging.NewEndpointStatusParams().WithResults(page, pageSize).WithEvents(1, cfg.Storage.MaximumNumberOfEvents))
 		if err != nil {
 			if errors.Is(err, common.ErrEndpointNotFound) {
@@ -112,4 +140,50 @@ func EndpointStatus(cfg *config.Config) fiber.Handler {
 		c.Set("Content-Type", "application/json")
 		return c.Status(200).Send(output)
 	}
+}
+
+// EndpointStatusFromRemoteInstance retrieves a single remote endpoint.Status endpoint name
+func EndpointStatusFromRemoteInstance(c *fiber.Ctx, cfg *config.Config, remoteNr int, key string, page int, pageSize int) error {
+	instance := cfg.Remote.Instances[remoteNr-1]
+	remoteConfig := cfg.Remote
+	httpClient := client.GetHTTPClient(remoteConfig.ClientConfig)
+
+	// TODO: better integration
+	newUrl := fmt.Sprint("/endpoints/", key, "/statuses?page=", page, "&pageSize=", pageSize)
+	url := strings.Replace(instance.URL, "/endpoints/statuses", newUrl, 1)
+
+	response, err := httpClient.Get(url)
+	if err != nil {
+		// Log the error but continue with other instances
+		msg := fmt.Sprintf("[api.getEndpointStatusFromRemoteInstance] Failed to retrieve endpoint status for %s from %s: %s", key, url, err.Error())
+		return c.Status(500).SendString(msg)
+	}
+
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(response.Body)
+	defer response.Body.Close()
+
+	// If the remote returned an error, return it as-is
+	if response.StatusCode != 200 {
+		logr.Debugf("Remote endpoint URL %s returned error code %d", url, response.StatusCode)
+		return c.Status(response.StatusCode).Send(buf.Bytes())
+	}
+
+	var endpointStatus endpoint.Status
+	if err = json.NewDecoder(buf).Decode(&endpointStatus); err != nil {
+		msg := fmt.Sprintf("[api.getEndpointStatusFromRemoteInstance] Failed to decode endpoint status for %s from %s: %s", key, url, err.Error())
+		return c.Status(500).SendString(msg)
+	}
+	_ = response.Body.Close()
+
+	endpointStatus.Name = instance.EndpointPrefix + endpointStatus.Name
+	endpointStatus.Key = fmt.Sprint("_gatus_remote_", remoteNr, "_", endpointStatus.Key)
+
+	output, err := json.Marshal(endpointStatus)
+	if err != nil {
+		logr.Errorf("[api.EndpointStatusFromRemoteInstance] Unable to marshal object to JSON: %s", err.Error())
+		return c.Status(500).SendString("unable to marshal object to JSON")
+	}
+	c.Set("Content-Type", "application/json")
+	return c.Status(200).Send(output)
 }

--- a/api/endpoint_status_test.go
+++ b/api/endpoint_status_test.go
@@ -7,11 +7,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/TwiN/gatus/v5/client"
 	"github.com/TwiN/gatus/v5/config"
 	"github.com/TwiN/gatus/v5/config/endpoint"
+	"github.com/TwiN/gatus/v5/config/remote"
 	"github.com/TwiN/gatus/v5/storage"
 	"github.com/TwiN/gatus/v5/storage/store"
+	"github.com/TwiN/gatus/v5/test"
 	"github.com/TwiN/gatus/v5/watchdog"
+	"github.com/TwiN/logr"
 )
 
 var (
@@ -225,6 +229,116 @@ func TestEndpointStatuses(t *testing.T) {
 			}
 			if string(body) != scenario.ExpectedBody {
 				t.Errorf("expected:\n %s\n\ngot:\n %s", scenario.ExpectedBody, string(body))
+			}
+		})
+	}
+}
+
+// Here we test that a gatus instance can call detailed status
+// of a remote instance endpoint.
+func TestEndpointStatusFromRemoteInstance(t *testing.T) {
+	defer store.Get().Clear()
+	defer cache.Clear()
+
+	cfg := &config.Config{
+		Metrics: true,
+		Storage: &storage.Config{
+			MaximumNumberOfResults: storage.DefaultMaximumNumberOfResults,
+			MaximumNumberOfEvents:  storage.DefaultMaximumNumberOfEvents,
+		},
+		Endpoints: []*endpoint.Endpoint{
+			{
+				Name:  "frontend",
+				Group: "core",
+			},
+		},
+		Remote: &remote.Config{
+			Instances: []remote.Instance{remote.Instance{
+				EndpointPrefix: "from-b-",
+				URL:            "https://b.example.com/api/v1/endpoints/statuses",
+			}},
+			ClientConfig: client.GetDefaultConfig(),
+		},
+	}
+	api := New(cfg)
+	router := api.Router()
+
+	remoteApi := New(&config.Config{
+		Metrics: true,
+		Storage: &storage.Config{
+			MaximumNumberOfResults: storage.DefaultMaximumNumberOfResults,
+			MaximumNumberOfEvents:  storage.DefaultMaximumNumberOfEvents,
+		},
+		Endpoints: []*endpoint.Endpoint{
+			{
+				Name:  "frontend",
+				Group: "core",
+			},
+		},
+	})
+	remoteRouter := remoteApi.Router()
+
+	watchdog.UpdateEndpointStatus(cfg.Endpoints[0], &endpoint.Result{Success: true, Duration: time.Millisecond, Timestamp: time.Now()})
+
+	mockRoundTripper := test.MockRoundTripper(func(r *http.Request) *http.Response {
+		cache.Clear()
+		defer cache.Clear()
+		if r.Host == "b.example.com" {
+			logr.Infof("Mocking remote request to %s", r.URL)
+			response, err := remoteRouter.Test(r)
+			if err != nil {
+				panic("mocked request should not fail")
+			}
+			return response
+		} else {
+			panic("should only mock the remote endpoint")
+		}
+	})
+	client.InjectHTTPClient(&http.Client{Transport: mockRoundTripper})
+
+	type Scenario struct {
+		Name         string
+		Path         string
+		ExpectedCode int
+	}
+	scenarios := []Scenario{
+		{
+			Name:         "local-endpoint",
+			Path:         "/api/v1/endpoints/core_frontend/statuses",
+			ExpectedCode: http.StatusOK,
+		},
+		{
+			Name:         "remote-endpoint",
+			Path:         "/api/v1/endpoints/_gatus_remote_1_core_frontend/statuses",
+			ExpectedCode: http.StatusOK,
+		},
+		{
+			Name:         "remote-endpoint-with-params",
+			Path:         "/api/v1/endpoints/_gatus_remote_1_core_frontend/statuses?page=1",
+			ExpectedCode: http.StatusOK,
+		},
+		{
+			Name:         "remote-endpoint-missing",
+			Path:         "/api/v1/endpoints/_gatus_remote_1_core_backend/statuses",
+			ExpectedCode: http.StatusNotFound,
+		},
+		{
+			Name:         "malformed-remote",
+			Path:         "/api/v1/endpoints/_gatus_remote_FOOBAR_core_frontend/statuses",
+			ExpectedCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			request := httptest.NewRequest("GET", scenario.Path, http.NoBody)
+			response, err := router.Test(request)
+			if err != nil {
+				t.Error("Request failed or timed out", err)
+			}
+			defer response.Body.Close()
+			if response.StatusCode != scenario.ExpectedCode {
+				t.Errorf("%s %s should have returned %d, but returned %d instead", request.Method, request.URL, scenario.ExpectedCode, response.StatusCode)
 			}
 		})
 	}

--- a/api/util.go
+++ b/api/util.go
@@ -1,8 +1,16 @@
 package api
 
 import (
+	"fmt"
+	"io"
+	"net/url"
+	"regexp"
 	"strconv"
+	"strings"
 
+	"github.com/TwiN/gatus/v5/client"
+	"github.com/TwiN/gatus/v5/config"
+	"github.com/TwiN/logr"
 	"github.com/gofiber/fiber/v2"
 )
 
@@ -43,4 +51,100 @@ func extractPageAndPageSizeFromRequest(c *fiber.Ctx, maximumNumberOfResults int)
 		pageSize = DefaultPageSize
 	}
 	return
+}
+
+func queryRemoteHandler(c *fiber.Ctx, cfg *config.Config, logName string, key string) error {
+	r := regexp.MustCompile("_gatus_remote_(\\d+)_(.*)")
+	regexResult := r.FindStringSubmatch(key)
+	if regexResult == nil {
+		return c.Status(400).SendString(fmt.Sprint("invalid remote key: ", key))
+	}
+
+	remoteNr, err := strconv.Atoi(regexResult[1])
+	if err != nil {
+		return c.Status(400).SendString(fmt.Sprint("invalid non-numeric requested remote: ", regexResult[1]))
+	}
+	remoteKey := regexResult[2]
+
+	if remoteNr < 1 || remoteNr > len(cfg.Remote.Instances) {
+		return c.Status(404).SendString(fmt.Sprint("requested remote does not exist: ", remoteNr))
+	}
+
+	instance := cfg.Remote.Instances[remoteNr-1]
+	remoteKey = strings.Replace(remoteKey, instance.EndpointPrefix, "", 1)
+	remoteConfig := cfg.Remote
+	httpClient := client.GetHTTPClient(remoteConfig.ClientConfig)
+
+	// TODO: better integration
+	remoteApi, err := url.Parse(instance.URL)
+	if err != nil {
+		return c.Status(400).SendString(fmt.Sprint("Failed to parse remote URL: ", instance.URL))
+	}
+
+	// Assume scheme is identical which may be a problem if accessed from the client in the future
+	newUrlStr := fmt.Sprint(remoteApi.Scheme, "://", remoteApi.Host)
+	newUrl, err := url.Parse(newUrlStr)
+	if err != nil {
+		return c.Status(400).SendString(fmt.Sprint("Failed to parse remote base URL: ", newUrlStr))
+	}
+
+	originalUrl, err := url.Parse(c.OriginalURL())
+	if err != nil {
+		return c.Status(400).SendString(fmt.Sprint("Failed to parse original URL: ", c.OriginalURL()))
+	}
+
+	newUrl.Path = strings.Replace(originalUrl.Path, key, remoteKey, 1)
+	newUrl.RawQuery = originalUrl.RawQuery
+
+	logr.Infof("Querying remote endpoint %s", newUrl.String())
+	response, err := httpClient.Get(newUrl.String())
+	if err != nil {
+		msg := fmt.Sprintf("[api.%s/helper] Failed to query %s from remote %s: %s", logName, key, newUrl, err.Error())
+		return c.Status(500).SendString(msg)
+	}
+
+	contentType := response.Header.Get("Content-Type")
+	output, err := io.ReadAll(response.Body)
+	if err != nil {
+		msg := fmt.Sprintf("[api.%s] Failed to read remote response for %s from %s: %s", logName, key, newUrl, err.Error())
+		return c.Status(500).SendString(msg)
+	}
+	_ = response.Body.Close()
+
+	c.Set("Content-Type", contentType)
+	c.Set("Gatus-Remote", newUrlStr)
+	return c.Status(response.StatusCode).Send(output)
+}
+
+func queryRemoteOrLocalHandler(cfg *config.Config, localHandler func(*fiber.Ctx) error, logName string) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		key, err := url.QueryUnescape(c.Params("key"))
+		if err != nil {
+			return c.Status(400).SendString("invalid key encoding")
+		}
+
+		if !strings.HasPrefix(key, "_gatus_remote_") {
+			// Not querying a remote key, passing to the local handler
+			return localHandler(c)
+		}
+
+		return queryRemoteHandler(c, cfg, logName, key)
+	}
+}
+
+func queryRemoteOrLocalHandlerWithCfg(cfg *config.Config, localHandler func(*config.Config) fiber.Handler, logName string) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		key, err := url.QueryUnescape(c.Params("key"))
+		if err != nil {
+			return c.Status(400).SendString("invalid key encoding")
+		}
+
+		if !strings.HasPrefix(key, "_gatus_remote_") {
+			// Not querying a remote key, passing to the local handler
+			localHandler(cfg)(c)
+			return nil
+		}
+
+		return queryRemoteHandler(c, cfg, logName, key)
+	}
 }


### PR DESCRIPTION
I was bothered that when i clicked on a remote endpoint no data was shown at all. I implemented it.

It's a bit hacky:

- relies on iteration count to identify the endpoint (should only make problems when dynamically reloading config, and even then, it will only produce an error, not panic)
- takes the remote endpoints URI and rewrites it on the go, a future improvement would be to use a remote API URL and build a proper API client
- compiles a regex on the go (could be globally compiled once, or we could do without a regex at all as a performance improvement)

It's not perfect but since remote instances is an alpha feature i think it fits the bill, and it's useful for me so i thought i'd share it with others and not just keep it on my branch.