### PR TITLE
feat(client): Allow configuration of client cookie storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,6 +654,7 @@ the client used to send the request.
 | `client.tls.renegotiation`             | Type of renegotiation support to provide. (`never`, `freely`, `once`).        | `"never"`       |
 | `client.network`                       | The network to use for ICMP endpoint client (`ip`, `ip4` or `ip6`).           | `"ip"`          |
 | `client.tunnel`                        | Name of the SSH tunnel to use for this endpoint. See [Tunneling](#tunneling). | `""`            |
+| `client.store-cookies`                 | Whether to store cookies between requests.                                    | `false`         |
 
 
 > 📝 Some of these parameters are ignored based on the type of endpoint. For instance, there's no certificate involved
@@ -666,6 +667,7 @@ client:
   insecure: false
   ignore-redirect: false
   timeout: 10s
+  store-cookies: false
 ```
 
 Note that this configuration is only available under `endpoints[]`, `alerting.mattermost` and `alerting.custom`.

--- a/client/config.go
+++ b/client/config.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"net/http/cookiejar"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -34,6 +35,7 @@ var (
 		IgnoreRedirect: false,
 		Timeout:        defaultTimeout,
 		Network:        "ip",
+		StoreCookies:   false,
 	}
 )
 
@@ -81,6 +83,9 @@ type Config struct {
 
 	// ResolvedTunnel is the resolved SSH tunnel for this specific Config
 	ResolvedTunnel *sshtunnel.SSHTunnel `yaml:"-"`
+
+	// StoreCookies determines whether cookies are stored and included across requests.
+	StoreCookies bool `yaml:"store-cookies,omitempty"`
 
 	httpClient *http.Client
 }
@@ -279,6 +284,13 @@ func (c *Config) getHTTPClient() *http.Client {
 					return c.ResolvedTunnel.Dial(network, addr)
 				}
 			}
+		}
+		if c.StoreCookies {
+			jar, err := cookiejar.New(nil)
+			if err != nil {
+				logr.Fatalf("Failed to initialize cookie jar: %v", err)
+			}
+			c.httpClient.Jar = jar
 		}
 	}
 	return c.httpClient

--- a/client/config.go
+++ b/client/config.go
@@ -288,7 +288,7 @@ func (c *Config) getHTTPClient() *http.Client {
 		if c.StoreCookies {
 			jar, err := cookiejar.New(nil)
 			if err != nil {
-				logr.Fatalf("Failed to initialize cookie jar: %v", err)
+				logr.Fatalf("[client.getHTTPClient] Failed to initialize cookie jar: %v", err)
 			}
 			c.httpClient.Jar = jar
 		}

--- a/client/config_test.go
+++ b/client/config_test.go
@@ -17,6 +17,9 @@ func TestConfig_getHTTPClient(t *testing.T) {
 	if insecureClient.Timeout != defaultTimeout {
 		t.Error("expected Config.Timeout to default the HTTP client to a timeout of 10s")
 	}
+	if insecureClient.Jar != nil {
+		t.Error("expected Config.StoreCookies to default the HTTP client to not store cookies")
+	}
 	request, _ := http.NewRequest("GET", "", nil)
 	if err := insecureClient.CheckRedirect(request, nil); err != nil {
 		t.Error("expected Config.IgnoreRedirect set to false to cause the HTTP client's CheckRedirect to return nil")
@@ -31,9 +34,21 @@ func TestConfig_getHTTPClient(t *testing.T) {
 	if secureClient.Timeout != 5*time.Second {
 		t.Error("expected Config.Timeout to cause the HTTP client to have a timeout of 5s")
 	}
+	if insecureClient.Jar != nil {
+		t.Error("expected Config.StoreCookies to default the HTTP client to not store cookies")
+	}
 	request, _ = http.NewRequest("GET", "", nil)
 	if err := secureClient.CheckRedirect(request, nil); err != http.ErrUseLastResponse {
 		t.Error("expected Config.IgnoreRedirect set to true to cause the HTTP client's CheckRedirect to return http.ErrUseLastResponse")
+	}
+}
+
+func TestConfig_getHTTPClient_withCookieJar(t *testing.T) {
+	config := &Config{StoreCookies: true}
+	config.ValidateAndSetDefaults()
+	client := config.getHTTPClient()
+	if client.Jar == nil {
+		t.Error("expected Config.StoreCookies to cause the HTTP client to have a CookieJar")
 	}
 }
 


### PR DESCRIPTION
Fixes #1711 

## Summary
The client configuration now allows a CookieJar to be set by a new client setting, `store-cookies`. The default behavior does not change where cookies are not stored or sent to subsequent requests.

The motivation for this feature is to be able to monitor services behind an authentication sidecar (like [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy)) without bypassing the sidecar. [oauth2-proxy intercepts an unauthenticated request and redirects the client to a login area](https://oauth2-proxy.github.io/oauth2-proxy/#architecture). Once the client authenticates (automatically with mTLS for this example), they are redirected back to their original route with the addition of an authentication cookie. oauth2-proxy verifies this cookie and then allows the request to the targeted backend service.

Storing cookies allows an endpoint check to authenticate via mTLS through an authentication sidecar by storing and sending the cookie set during an authentication redirect chain. Subsequent checks are able to reuse the cookie and allow the authentication sidecar to validate or start a new authentication flow.

## Checklist
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Updated documentation in `README.md`, if applicable.
