### PR TITLE
feat: `use-privileged-ping` configuration toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ If you want to test it locally, see [Docker](#docker).
 | `concurrency`                | Maximum number of endpoints/suites to monitor concurrently. Set to `0` for unlimited. See [Concurrency](#concurrency).                   | `3`           |
 | `disable-monitoring-lock`    | Whether to [disable the monitoring lock](#disable-monitoring-lock). **Deprecated**: Use `concurrency: 0` instead.                        | `false`       |
 | `skip-invalid-config-update` | Whether to ignore invalid configuration update. <br />See [Reloading configuration on the fly](#reloading-configuration-on-the-fly).     | `false`       |
+| `use-privileged-ping`        | Whether to use privileged pings. See [upstream docs](https://github.com/prometheus-community/pro-bing/blob/620801fe77f9ea5b10ded99e3d3a34ba6e521aff/README.md?plain=1#L89) for more info |
 | `web`                        | [Web configuration](#web).                                                                                                               | `{}`          |
 | `ui`                         | [UI configuration](#ui).                                                                                                                 | `{}`          |
 | `maintenance`                | [Maintenance configuration](#maintenance).                                                                                               | `{}`          |

--- a/client/client.go
+++ b/client/client.go
@@ -15,6 +15,7 @@ import (
 	"net/smtp"
 	"os"
 	"runtime"
+	"sync"
 	"strings"
 	"time"
 
@@ -42,6 +43,28 @@ var (
 	whoisExpirationDateCache = gocache.NewCache().WithMaxSize(10000).WithDefaultTTL(24 * time.Hour)
 	rdapClient               = rdap.NewClient(nil)
 )
+
+// PrivilegedPing holds the global state for enabling/disabling
+// privileged pings in ICMP endpoints.
+type PrivilegedPing struct {
+    mu sync.RWMutex
+	Enabled bool
+}
+
+var UsePrivilegedPing = &PrivilegedPing { Enabled: false }
+
+func (p *PrivilegedPing) Get() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.Enabled
+}
+
+func (p *PrivilegedPing) Set(enabled bool) {
+	UsePrivilegedPing.mu.Lock()
+	defer UsePrivilegedPing.mu.Unlock()
+	UsePrivilegedPing.Enabled = enabled
+}
+
 
 // GetHTTPClient returns the shared HTTP client, or the client from the configuration passed
 func GetHTTPClient(config *Config) *http.Client {
@@ -360,6 +383,7 @@ func Ping(address string, config *Config) (bool, time.Duration) {
 	pinger.SetNetwork(config.Network)
 	err := pinger.Run()
 	if err != nil {
+		logr.Warnf("Failed to initiate ping. Does the process have the proper capabilities?")
 		return false, 0
 	}
 	if pinger.Statistics() != nil {
@@ -388,7 +412,8 @@ func ShouldRunPingerAsPrivileged() bool {
 	// To actually check for cap_net_raw capabilities, we would need to add "kernel.org/pub/linux/libs/security/libcap/cap" to gatus.
 	// Or use a syscall and check for permission errors, but this requires platform specific compilation
 	// As a backstop we can simply check the effective user id and run as privileged when running as root
-	return os.Geteuid() == 0
+	// unless the user set `use_privileged_ping = true` in the config file.
+	return os.Geteuid() == 0 || UsePrivilegedPing.Get()
 }
 
 // QueryWebSocket opens a websocket connection, write `body` and return a message from the server

--- a/config/config.go
+++ b/config/config.go
@@ -83,6 +83,10 @@ type Config struct {
 	// Defaults to DefaultConcurrency. Set to 0 for unlimited concurrency.
 	Concurrency int `yaml:"concurrency,omitempty"`
 
+	// UsePrivilegedPing enables privileged pings in upstream pinging library,
+	// requiring CAP_NET_RAW+ep on most GNU/Linux systems.
+	UsePrivilegedPing bool `yaml:"use-privileged-ping,omitempty"`
+
 	// Security is the configuration for securing access to Gatus
 	Security *security.Config `yaml:"security,omitempty"`
 
@@ -339,6 +343,7 @@ func parseAndValidateConfigBytes(yamlBytes []byte) (config *Config, err error) {
 			return nil, err
 		}
 		ValidateAndSetConcurrencyDefaults(config)
+		client.UsePrivilegedPing.Set(config.UsePrivilegedPing)
 		// Cross-config changes
 		config.UI.MaximumNumberOfResults = config.Storage.MaximumNumberOfResults
 	}


### PR DESCRIPTION
Also picked from my branch, allow to use privileged ping under Linux, and add a small link to upstream docs about ping capabilities on Linux.

Why? So i can make a package / automated setup which does not mess with sysctl and only sets the `CAP_NET_RAW` capability via systemd:

```
[Unit]
Description=Gatus
Documentation=https://github.com/TwiN/gatus
After=network.target network-online.target
Requires=network-online.target

[Service]
Type=exec
User=gatus
Group=gatus
Environment=GATUS_CONFIG_PATH=/etc/gatus/gatus.yaml
ExecStart=/usr/local/bin/gatus
TimeoutStopSec=5s
LimitNOFILE=1048576
PrivateTmp=true
ProtectSystem=full
AmbientCapabilities=CAP_NET_RAW

[Install]
WantedBy=multi-user.target
```