### PR TITLE
fix: Allow config with only remote instances

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -46,8 +46,8 @@ const (
 )
 
 var (
-	// ErrNoEndpointOrSuiteInConfig is an error returned when a configuration file or directory has no endpoints configured
-	ErrNoEndpointOrSuiteInConfig = errors.New("configuration should contain at least one endpoint or suite")
+	// ErrNoEndpointOrSuiteOrRemoteInConfig is an error returned when a configuration file or directory has no endpoints configured
+	ErrNoEndpointOrSuiteOrRemoteInConfig = errors.New("configuration should contain at least one endpoint or suite or remote")
 
 	// ErrConfigFileNotFound is an error returned when a configuration file could not be found
 	ErrConfigFileNotFound = errors.New("configuration file not found")
@@ -292,8 +292,8 @@ func parseAndValidateConfigBytes(yamlBytes []byte) (config *Config, err error) {
 		return
 	}
 	// Check if the configuration file at least has endpoints configured
-	if config == nil || (len(config.Endpoints) == 0 && len(config.Suites) == 0) {
-		err = ErrNoEndpointOrSuiteInConfig
+	if config == nil || (len(config.Endpoints) == 0 && len(config.Suites) == 0 && (config.Remote == nil || len(config.Remote.Instances) == 0)) {
+		err = ErrNoEndpointOrSuiteOrRemoteInConfig
 	} else {
 		// XXX: Remove this in v6.0.0
 		if config.Debug {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -139,7 +139,7 @@ endpoints:
 			pathAndFiles: map[string]string{
 				"config.yaml": "",
 			},
-			expectedError: ErrNoEndpointOrSuiteInConfig,
+			expectedError: ErrNoEndpointOrSuiteOrRemoteInConfig,
 		},
 		{
 			name:       "dir-with-two-config-files",
@@ -741,8 +741,20 @@ badconfig:
 	if err == nil {
 		t.Error("An error should've been returned")
 	}
-	if err != ErrNoEndpointOrSuiteInConfig {
-		t.Error("The error returned should have been of type ErrNoEndpointOrSuiteInConfig")
+	if err != ErrNoEndpointOrSuiteOrRemoteInConfig {
+		t.Error("The error returned should have been of type ErrNoEndpointOrSuiteOrRemoteInConfig")
+	}
+}
+
+func TestParseAndValidateOnlyRemote(t *testing.T) {
+	_, err := parseAndValidateConfigBytes([]byte(`
+remote:
+  instances:
+    - endpoint-prefix: remote
+      url: "https://gatus.example.com/api/v1/endpoints/statuses"
+`))
+	if err != nil {
+		t.Error("Only having remote config shouldn't be an error")
 	}
 }
 
@@ -1848,8 +1860,8 @@ endpoints:
 
 func TestParseAndValidateConfigBytesWithNoEndpoints(t *testing.T) {
 	_, err := parseAndValidateConfigBytes([]byte(``))
-	if !errors.Is(err, ErrNoEndpointOrSuiteInConfig) {
-		t.Error("The error returned should have been of type ErrNoEndpointOrSuiteInConfig")
+	if !errors.Is(err, ErrNoEndpointOrSuiteOrRemoteInConfig) {
+		t.Error("The error returned should have been of type ErrNoEndpointOrSuiteOrRemoteInConfig")
 	}
 }
 


### PR DESCRIPTION
Another small PR.

I run gatus on my servers, but i want to have an in-memory session on my laptop with only remote instances. Before this PR, that would fail with: `panic: error parsing config: configuration should contain at least one endpoint or suite`.

I'm simply checking if there's actually remote instances configured, and if so not triggering the error.

I changed the error name to reflect this and added a small test.