### PR TITLE
feat: Allow serving with unix domain sockets (`web.socket` in config)

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,7 @@ Allows you to configure how and where the dashboard is being served.
 | `web`                      | Web configuration                                                                           | `{}`      |
 | `web.address`              | Address to listen on.                                                                       | `0.0.0.0` |
 | `web.port`                 | Port to listen on.                                                                          | `8080`    |
+| `web.socket`               | Unix domain socket to listen on (overrides `address`/`port` when set)                       | `""`      |       
 | `web.read-buffer-size`     | Buffer size for reading requests from a connection. Also limit for the maximum header size. | `8192`    |
 | `web.tls.certificate-file` | Optional public certificate file for TLS in PEM format.                                     | `""`      |
 | `web.tls.private-key-file` | Optional private key file for TLS in PEM format.                                            | `""`      |

--- a/config/web/web.go
+++ b/config/web/web.go
@@ -25,10 +25,15 @@ const (
 // Config is the structure which supports the configuration of the server listening to requests
 type Config struct {
 	// Address to listen on (defaults to 0.0.0.0 specified by DefaultAddress)
+	// Does not have any effect if Socket is set.
 	Address string `yaml:"address"`
 
 	// Port to listen on (default to 8080 specified by DefaultPort)
+	// Does not have any effect if Socket is set.
 	Port int `yaml:"port"`
+
+	// Unix domain socket to listen on. If unset, the default Port will be used instead.
+	Socket string `yaml:"socket,omitempty"`
 
 	// ReadBufferSize sets fiber.Config.ReadBufferSize, which is the buffer size for reading requests coming from a
 	// single connection and also acts as a limit for the maximum header size.

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"net"
 	"os"
 	"time"
 
@@ -25,18 +26,42 @@ func Handle(cfg *config.Config) {
 	if os.Getenv("ROUTER_TEST") == "true" {
 		return
 	}
-	logr.Info("[controller.Handle] Listening on " + cfg.Web.SocketAddress())
-	if cfg.Web.HasTLS() {
-		err := app.ListenTLS(cfg.Web.SocketAddress(), cfg.Web.TLS.CertificateFile, cfg.Web.TLS.PrivateKeyFile)
+
+	if cfg.Web.Socket != "" {
+		if cfg.Web.TLS != nil {
+			logr.Warn("[controller.Handle] Using socket mode: defined TLS settings will be ignored.")
+		}
+
+		logr.Info("[controller.Handle] Listening on " + cfg.Web.Socket)
+		uds_listener, err := net.Listen("unix", cfg.Web.Socket)
 		if err != nil {
-			logr.Fatalf("[controller.Handle] %s", err.Error())
+			logr.Fatalf("[controller.Handle] Socket creation failed: %s", err.Error())
+		}
+
+		err = os.Chmod(cfg.Web.Socket, 0660)
+		if err != nil {
+			logr.Fatalf("[controller.Handle] Failed to set 660 permissions on socket: %s", err.Error())
+		}
+
+		err = app.Listener(uds_listener)
+		if err != nil {
+			logr.Fatalf("[controller.Handle] Listening on socket failed: %s", err.Error())
 		}
 	} else {
-		err := app.Listen(cfg.Web.SocketAddress())
-		if err != nil {
-			logr.Fatalf("[controller.Handle] %s", err.Error())
+		logr.Info("[controller.Handle] Listening on " + cfg.Web.SocketAddress())
+		if cfg.Web.HasTLS() {
+			err := app.ListenTLS(cfg.Web.SocketAddress(), cfg.Web.TLS.CertificateFile, cfg.Web.TLS.PrivateKeyFile)
+			if err != nil {
+				logr.Fatalf("[controller.Handle] %s", err.Error())
+			}
+		} else {
+			err := app.Listen(cfg.Web.SocketAddress())
+			if err != nil {
+				logr.Fatalf("[controller.Handle] %s", err.Error())
+			}
 		}
 	}
+
 	logr.Info("[controller.Handle] Server has shut down successfully")
 }
 

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -92,6 +92,50 @@ func TestHandleTLS(t *testing.T) {
 	}
 }
 
+func TestHandleSocket(t *testing.T) {
+	scenarios := []struct {
+		name               string
+		socket             string
+		expectedStatusCode int
+	}{
+		{
+			name:               "good-socket-config",
+			socket:             "/tmp/gatus.socket",
+			expectedStatusCode: 200,
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Web: &web.Config{Socket: scenario.socket},
+				Endpoints: []*endpoint.Endpoint{
+					{Name: "frontend", Group: "core"},
+					{Name: "backend", Group: "core"},
+				},
+			}
+			if err := cfg.Web.ValidateAndSetDefaults(); err != nil {
+				t.Error("expected no error from web, got", err)
+			}
+			_ = os.Setenv("ROUTER_TEST", "true")
+			_ = os.Setenv("ENVIRONMENT", "dev")
+			defer os.Clearenv()
+			Handle(cfg)
+			defer Shutdown()
+			request := httptest.NewRequest("GET", "/health", http.NoBody)
+			response, err := app.Test(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if response.StatusCode != scenario.expectedStatusCode {
+				t.Errorf("%s %s should have returned %d, but returned %d instead", request.Method, request.URL, scenario.expectedStatusCode, response.StatusCode)
+			}
+			if app == nil {
+				t.Fatal("server should've been set (but because we set ROUTER_TEST, it shouldn't have been started)")
+			}
+		})
+	}
+}
+
 func TestShutdown(t *testing.T) {
 	// Pretend that we called controller.Handle(), which initializes the server variable
 	app = fiber.New()


### PR DESCRIPTION
Another small PR from my branch: allow to serve gatus from a unix domain socket. I'm not sure how that interacts with other platforms support, but it works fine on Linux.

The usecase:

- it's always hard to remember which port is assigned to which backend when dealing with firewall/reverse-proxy (was it 8080? 8081? 9999? 1111?), a UDS path makes it clear what service we're talking about
- it's possible to apply POSIX permissions on a socket to restrict who can access the service
- it's also supposedly more performant, but i don't think this matters much for gatus

Now i just use:

```
web:
  socket: `/var/run/gatus/gatus.sock`
```

The test i added does not test much. I could probably figure out a way for the http client to use the socket directly if this simple config test doesn't meet your standards.