### PR TITLE
Exclude remote-from-remote endpoints via `instance.include-remote`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2847,6 +2847,7 @@ Use at your own risk.
 | `remote.instances`                 | List of remote instances                       | Required `[]` |
 | `remote.instances.endpoint-prefix` | String to prefix all endpoint names with       | `""`          |
 | `remote.instances.url`             | URL from which to retrieve endpoint statuses   | Required `""` |
+| `remote.instances.include-remote`  | Include remote endpoints from remote instance  | true          |
 | `remote.client`                    | [Client configuration](#client-configuration). | `{}`          |
 
 ```yaml

--- a/api/endpoint_status.go
+++ b/api/endpoint_status.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/TwiN/gatus/v5/client"
 	"github.com/TwiN/gatus/v5/config"
@@ -22,7 +23,16 @@ import (
 func EndpointStatuses(cfg *config.Config) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		page, pageSize := extractPageAndPageSizeFromRequest(c, cfg.Storage.MaximumNumberOfResults)
-		value, exists := cache.Get(fmt.Sprintf("endpoint-status-%d-%d", page, pageSize))
+
+		// Does the client request remote endpoints? By default yes, for web UI display
+		// and for backwards compatibility. Remote instance queries should have remote=false to
+		// avoid duplicates.
+		remoteQuery := c.Query("remote", "true")
+		// remote query param value is case-insensitive (eg. `TRUE` and `True` are also truthy values)
+		includeRemote := strings.EqualFold(remoteQuery, "true")
+		logr.Debugf("Received EndpointStatuses request with remote=%t")
+
+		value, exists := cache.Get(fmt.Sprintf("endpoint-status-%d-%d-%t", page, pageSize, includeRemote))
 		var data []byte
 		if !exists {
 			endpointStatuses, err := store.Get().GetAllEndpointStatuses(paging.NewEndpointStatusParams().WithResults(page, pageSize))
@@ -31,10 +41,12 @@ func EndpointStatuses(cfg *config.Config) fiber.Handler {
 				return c.Status(500).SendString(err.Error())
 			}
 			// ALPHA: Retrieve endpoint statuses from remote instances
-			if endpointStatusesFromRemote, err := getEndpointStatusesFromRemoteInstances(cfg.Remote); err != nil {
-				logr.Errorf("[handler.EndpointStatuses] Silently failed to retrieve endpoint statuses from remote: %s", err.Error())
-			} else if endpointStatusesFromRemote != nil {
-				endpointStatuses = append(endpointStatuses, endpointStatusesFromRemote...)
+			if includeRemote {
+				if endpointStatusesFromRemote, err := getEndpointStatusesFromRemoteInstances(cfg.Remote); err != nil {
+					logr.Errorf("[handler.EndpointStatuses] Silently failed to retrieve endpoint statuses from remote: %s", err.Error())
+				} else if endpointStatusesFromRemote != nil {
+					endpointStatuses = append(endpointStatuses, endpointStatusesFromRemote...)
+				}
 			}
 			// Marshal endpoint statuses to JSON
 			data, err = json.Marshal(endpointStatuses)
@@ -42,13 +54,31 @@ func EndpointStatuses(cfg *config.Config) fiber.Handler {
 				logr.Errorf("[api.EndpointStatuses] Unable to marshal object to JSON: %s", err.Error())
 				return c.Status(500).SendString("unable to marshal object to JSON")
 			}
-			cache.SetWithTTL(fmt.Sprintf("endpoint-status-%d-%d", page, pageSize), data, cacheTTL)
+			cache.SetWithTTL(fmt.Sprintf("endpoint-status-%d-%d-%t", page, pageSize, includeRemote), data, cacheTTL)
 		} else {
 			data = value.([]byte)
 		}
 		c.Set("Content-Type", "application/json")
 		return c.Status(200).Send(data)
 	}
+}
+
+func formatRemoteInstanceQueryParams(originalURL string, includeRemote bool) (string, error) {
+	parsedOriginalURL, err := url.Parse(originalURL)
+	if err != nil {
+		return "", err
+	}
+
+	// Here we passed url by value not by reference, so we can modify the instance
+	// without changing the actual settings.
+	query := parsedOriginalURL.Query()
+	if includeRemote {
+		query.Set("remote", "true")
+	} else {
+		query.Set("remote", "false")
+	}
+	parsedOriginalURL.RawQuery = query.Encode()
+	return parsedOriginalURL.String(), nil
 }
 
 func getEndpointStatusesFromRemoteInstances(remoteConfig *remote.Config) ([]*endpoint.Status, error) {
@@ -58,7 +88,13 @@ func getEndpointStatusesFromRemoteInstances(remoteConfig *remote.Config) ([]*end
 	var endpointStatusesFromAllRemotes []*endpoint.Status
 	httpClient := client.GetHTTPClient(remoteConfig.ClientConfig)
 	for _, instance := range remoteConfig.Instances {
-		response, err := httpClient.Get(instance.URL)
+		newurl, err := formatRemoteInstanceQueryParams(instance.URL, *instance.IncludeRemote)
+		if err != nil {
+			// Log the error but continue with other instances
+			logr.Errorf("[api.getEndpointStatusesFromRemoteInstances] Invalid remote instance URL %s: %s", instance.URL, err.Error())
+			continue
+		}
+		response, err := httpClient.Get(newurl)
 		if err != nil {
 			// Log the error but continue with other instances
 			logr.Errorf("[api.getEndpointStatusesFromRemoteInstances] Failed to retrieve endpoint statuses from %s: %s", instance.URL, err.Error())

--- a/api/endpoint_status_test.go
+++ b/api/endpoint_status_test.go
@@ -4,14 +4,19 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/TwiN/gatus/v5/client"
 	"github.com/TwiN/gatus/v5/config"
 	"github.com/TwiN/gatus/v5/config/endpoint"
+	"github.com/TwiN/gatus/v5/config/remote"
 	"github.com/TwiN/gatus/v5/storage"
 	"github.com/TwiN/gatus/v5/storage/store"
+	"github.com/TwiN/gatus/v5/test"
 	"github.com/TwiN/gatus/v5/watchdog"
+	"github.com/TwiN/logr"
 )
 
 var (
@@ -79,6 +84,9 @@ var (
 			},
 		},
 	}
+
+	apiAURL = "https://a.example.com/api/v1/endpoints/statuses"
+	apiBURL = "https://b.example.com/api/v1/endpoints/statuses"
 )
 
 func TestEndpointStatus(t *testing.T) {
@@ -142,7 +150,7 @@ func TestEndpointStatus(t *testing.T) {
 			}
 			response, err := router.Test(request)
 			if err != nil {
-				return
+				t.Error("Request failed or timed out", err)
 			}
 			if response.StatusCode != scenario.ExpectedCode {
 				t.Errorf("%s %s should have returned %d, but returned %d instead", request.Method, request.URL, scenario.ExpectedCode, response.StatusCode)
@@ -213,7 +221,7 @@ func TestEndpointStatuses(t *testing.T) {
 			request := httptest.NewRequest("GET", scenario.Path, http.NoBody)
 			response, err := router.Test(request)
 			if err != nil {
-				return
+				t.Error("Request failed or timed out", err)
 			}
 			defer response.Body.Close()
 			if response.StatusCode != scenario.ExpectedCode {
@@ -229,3 +237,534 @@ func TestEndpointStatuses(t *testing.T) {
 		})
 	}
 }
+
+// Here we test that a gatus instance respects the `remote` query param
+// in the /api/v1/endpoints/statuses URL. We do not test the include remote.
+func TestEndpointStatusesRespectsIncludeRemoteQuery(t *testing.T) {
+	defer store.Get().Clear()
+	defer cache.Clear()
+	firstResult := &testSuccessfulResult
+	secondResult := &testUnsuccessfulResult
+	store.Get().InsertEndpointResult(&testEndpoint, firstResult)
+	store.Get().InsertEndpointResult(&testEndpoint, secondResult)
+	// Can't be bothered dealing with timezone issues on the worker that runs the automated tests
+	firstResult.Timestamp = time.Time{}
+	secondResult.Timestamp = time.Time{}
+
+	cfg := &config.Config{
+		Metrics: true,
+		Storage: &storage.Config{
+			MaximumNumberOfResults: storage.DefaultMaximumNumberOfResults,
+			MaximumNumberOfEvents:  storage.DefaultMaximumNumberOfEvents,
+		},
+	}
+	api := New(cfg)
+	router := api.Router()
+
+	remoteApi := New(&config.Config{
+		Metrics: true,
+		Storage: &storage.Config{
+			MaximumNumberOfResults: storage.DefaultMaximumNumberOfResults,
+			MaximumNumberOfEvents:  storage.DefaultMaximumNumberOfEvents,
+		},
+	})
+	remoteRouter := remoteApi.Router()
+
+	mockRoundTripper := test.MockRoundTripper(func(r *http.Request) *http.Response {
+		cache.Clear()
+		defer cache.Clear()
+		if r.Host == "a.example.com" {
+			logr.Infof("Mocking remote request to %s", r.URL)
+			response, err := remoteRouter.Test(r)
+			if err != nil {
+				panic("mocked request should not fail")
+			}
+			return response
+		} else {
+			panic("should only mock the remote endpoint")
+		}
+	})
+	client.InjectHTTPClient(&http.Client{Transport: mockRoundTripper})
+
+	// We use the same endpoint answers in both the local and remote instances
+	expectedBody := `[{"name":"name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z"},{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z"}]}]`
+	expectedBodyWithRemote := `[{"name":"name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z"},{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z"}]},{"name":"remote-name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z"},{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z"}]}]`
+
+	type Scenario struct {
+		Name         string
+		Path         string
+		ExpectedCode int
+		ExpectedBody string
+	}
+	scenarios := []Scenario{
+		{
+			Name:         "remote-query-default",
+			Path:         "/api/v1/endpoints/statuses",
+			ExpectedCode: http.StatusOK,
+			ExpectedBody: expectedBodyWithRemote,
+		},
+		{
+			Name:         "remote-query-true",
+			Path:         "/api/v1/endpoints/statuses?remote=true",
+			ExpectedCode: http.StatusOK,
+			ExpectedBody: expectedBodyWithRemote,
+		},
+		{
+			Name:         "remote-query-false",
+			Path:         "/api/v1/endpoints/statuses?remote=false",
+			ExpectedCode: http.StatusOK,
+			ExpectedBody: expectedBody,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			falseVal := false
+			cfg.Remote = &remote.Config{
+				Instances: []*remote.Instance{&remote.Instance{
+					EndpointPrefix: "remote-",
+					URL:            apiAURL,
+					IncludeRemote:  &falseVal,
+				}},
+				ClientConfig: client.GetDefaultConfig(),
+			}
+			request := httptest.NewRequest("GET", scenario.Path, http.NoBody)
+			response, err := router.Test(request)
+			if err != nil {
+				t.Error("Request failed or timed out", err)
+			}
+			defer response.Body.Close()
+			if response.StatusCode != scenario.ExpectedCode {
+				t.Errorf("%s %s should have returned %d, but returned %d instead", request.Method, request.URL, scenario.ExpectedCode, response.StatusCode)
+			}
+			body, err := io.ReadAll(response.Body)
+			if err != nil {
+				t.Error("expected err to be nil, but was", err)
+			}
+			if string(body) != scenario.ExpectedBody {
+				t.Errorf("expected:\n %s\n\ngot:\n %s", scenario.ExpectedBody, string(body))
+			}
+		})
+	}
+}
+
+// Here we test that the `include-remote` setting is respected
+// when building remote API queries. This does not check that an actual
+// remote instance behaves properly.
+func TestEndpointStatusesRespectsIncludeRemoteConfig(t *testing.T) {
+	defer store.Get().Clear()
+	defer cache.Clear()
+	firstResult := &testSuccessfulResult
+	secondResult := &testUnsuccessfulResult
+	store.Get().InsertEndpointResult(&testEndpoint, firstResult)
+	store.Get().InsertEndpointResult(&testEndpoint, secondResult)
+	// Can't be bothered dealing with timezone issues on the worker that runs the automated tests
+	firstResult.Timestamp = time.Time{}
+	secondResult.Timestamp = time.Time{}
+
+	instanceAcfg := &config.Config{
+		// Used to disambiguate instances
+		Metrics: true,
+		Storage: &storage.Config{
+			MaximumNumberOfResults: storage.DefaultMaximumNumberOfResults,
+			MaximumNumberOfEvents:  storage.DefaultMaximumNumberOfEvents,
+		},
+	}
+	instanceAapi := New(instanceAcfg)
+	instanceArouter := instanceAapi.Router()
+
+	expectedBodyB := `[{"name":"name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z"},{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z"}]}]`
+	expectedBodyBWithRemoteFromA := `[{"name":"name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z"},{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z"}]},{"name":"from-a-name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z"},{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z"}]}]`
+
+	mockRoundTripper := test.MockRoundTripper(func(r *http.Request) *http.Response {
+		cache.Clear()
+		defer cache.Clear()
+		if r.Host == "b.example.com" {
+			logr.Infof("Mocking remote instance B request to %s", r.URL)
+			if r.URL.Query().Get("remote") == "true" {
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(expectedBodyBWithRemoteFromA))}
+			} else {
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(expectedBodyB))}
+			}
+		} else {
+			panic("should only mock the remote endpoint")
+		}
+	})
+	client.InjectHTTPClient(&http.Client{Transport: mockRoundTripper})
+
+	// We use the same endpoint answers in both the local and remote instances
+	expectedBodyAWithRemoteFromB := `[{"name":"name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z"},{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z"}]},{"name":"from-b-name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z"},{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z"}]}]`
+	expectedBodyAWithRemoteFromBAndA := `[{"name":"name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z"},{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z"}]},{"name":"from-b-name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z"},{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z"}]},{"name":"from-b-from-a-name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z"},{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z"}]}]`
+
+	type Scenario struct {
+		Name          string
+		Path          string
+		IncludeRemote bool
+		ExpectedCode  int
+		ExpectedBody  string
+	}
+	scenarios := []Scenario{
+		{
+			Name:          "remote-include-remote-true",
+			Path:          "/api/v1/endpoints/statuses",
+			IncludeRemote: true,
+			ExpectedCode:  http.StatusOK,
+			ExpectedBody:  expectedBodyAWithRemoteFromBAndA,
+		},
+		{
+			Name:          "remote-include-remote-false",
+			Path:          "/api/v1/endpoints/statuses",
+			IncludeRemote: false,
+			ExpectedCode:  http.StatusOK,
+			ExpectedBody:  expectedBodyAWithRemoteFromB,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		// The cache does not account for config changes for instance.IncludeRemote
+		// so the second scenario always fails if we don't clear the cache because the API
+		// cache defaults to 10s.
+		cache.Clear()
+		t.Run(scenario.Name, func(t *testing.T) {
+			logr.Infof("Starting scenario %s", scenario.Name)
+			instanceAcfg.Remote = &remote.Config{
+				Instances: []*remote.Instance{&remote.Instance{
+					EndpointPrefix: "from-b-",
+					URL:            apiBURL,
+					IncludeRemote:  &scenario.IncludeRemote,
+				}},
+				ClientConfig: client.GetDefaultConfig(),
+			}
+			request := httptest.NewRequest("GET", scenario.Path, http.NoBody)
+			response, err := instanceArouter.Test(request)
+			if err != nil {
+				t.Error("Request failed or timed out", err)
+			}
+
+			defer response.Body.Close()
+			if response.StatusCode != scenario.ExpectedCode {
+				t.Errorf("%s %s should have returned %d, but returned %d instead", request.Method, request.URL, scenario.ExpectedCode, response.StatusCode)
+			}
+			body, err := io.ReadAll(response.Body)
+			if err != nil {
+				t.Error("expected err to be nil, but was", err)
+			}
+			if string(body) != scenario.ExpectedBody {
+				t.Errorf("expected:\n %s\n\ngot:\n %s", scenario.ExpectedBody, string(body))
+			}
+		})
+	}
+}
+
+// Here we test that in remote instance config, `include-remote` setting
+// is respected. This test will fail if TestEndpointStatusesRespectsIncludeRemoteConfig
+// fails because this is an integration test, not a unit test.
+func TestEndpointStatusesRespectsIncludeRemoteIntegration(t *testing.T) {
+	defer store.Get().Clear()
+	defer cache.Clear()
+	firstResult := &testSuccessfulResult
+	secondResult := &testUnsuccessfulResult
+	store.Get().InsertEndpointResult(&testEndpoint, firstResult)
+	store.Get().InsertEndpointResult(&testEndpoint, secondResult)
+	// Can't be bothered dealing with timezone issues on the worker that runs the automated tests
+	firstResult.Timestamp = time.Time{}
+	secondResult.Timestamp = time.Time{}
+
+	instanceAcfg := &config.Config{
+		// Used to disambiguate instances
+		Metrics: true,
+		Storage: &storage.Config{
+			MaximumNumberOfResults: storage.DefaultMaximumNumberOfResults,
+			MaximumNumberOfEvents:  storage.DefaultMaximumNumberOfEvents,
+		},
+	}
+	instanceAapi := New(instanceAcfg)
+	instanceArouter := instanceAapi.Router()
+
+	falseVal := false
+	instanceBcfg := &config.Config{
+		// Used to disambiguate instances
+		Metrics: true,
+		Storage: &storage.Config{
+			MaximumNumberOfResults: storage.DefaultMaximumNumberOfResults,
+			MaximumNumberOfEvents:  storage.DefaultMaximumNumberOfEvents,
+		},
+		Remote: &remote.Config{
+			Instances: []*remote.Instance{&remote.Instance{
+				EndpointPrefix: "from-a-",
+				URL:            apiAURL,
+				IncludeRemote:  &falseVal,
+			}},
+			ClientConfig: client.GetDefaultConfig(),
+		},
+	}
+	instanceBapi := New(instanceBcfg)
+	instanceBrouter := instanceBapi.Router()
+
+	mockRoundTripper := test.MockRoundTripper(func(r *http.Request) *http.Response {
+		cache.Clear()
+		defer cache.Clear()
+		if r.Host == "a.example.com" {
+			logr.Infof("Mocking remote instance A request to %s", r.URL)
+			response, err := instanceArouter.Test(r)
+			if err != nil {
+				panic("mocked request should not fail")
+			}
+			return response
+		} else if r.Host == "b.example.com" {
+			logr.Infof("Mocking remote instance B request to %s", r.URL)
+			response, err := instanceBrouter.Test(r)
+			if err != nil {
+				panic("mocked request should not fail")
+			}
+			return response
+		} else {
+			panic("should only mock the remote endpoint")
+		}
+	})
+	client.InjectHTTPClient(&http.Client{Transport: mockRoundTripper})
+
+	// We use the same endpoint answers in both the local and remote instances
+	expectedBodyWithRemoteFromB := `[{"name":"name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z"},{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z"}]},{"name":"from-b-name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z"},{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z"}]}]`
+	expectedBodyWithRemoteFromBAndA := `[{"name":"name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z"},{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z"}]},{"name":"from-b-name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z"},{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z"}]},{"name":"from-b-from-a-name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z"},{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z"}]}]`
+
+	type Scenario struct {
+		Name          string
+		Path          string
+		IncludeRemote bool
+		ExpectedCode  int
+		ExpectedBody  string
+	}
+	scenarios := []Scenario{
+		{
+			Name:          "remote-include-remote-true",
+			Path:          "/api/v1/endpoints/statuses",
+			IncludeRemote: true,
+			ExpectedCode:  http.StatusOK,
+			ExpectedBody:  expectedBodyWithRemoteFromBAndA,
+		},
+		{
+			Name:          "remote-include-remote-false",
+			Path:          "/api/v1/endpoints/statuses",
+			IncludeRemote: false,
+			ExpectedCode:  http.StatusOK,
+			ExpectedBody:  expectedBodyWithRemoteFromB,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		// The cache does not account for config changes for instance.IncludeRemote
+		// so the second scenario always fails if we don't clear the cache because the API
+		// cache defaults to 10s.
+		cache.Clear()
+		t.Run(scenario.Name, func(t *testing.T) {
+			logr.Infof("Starting scenario %s", scenario.Name)
+			instanceAcfg.Remote = &remote.Config{
+				Instances: []*remote.Instance{&remote.Instance{
+					EndpointPrefix: "from-b-",
+					URL:            apiBURL,
+					IncludeRemote:  &scenario.IncludeRemote,
+				}},
+				ClientConfig: client.GetDefaultConfig(),
+			}
+			request := httptest.NewRequest("GET", scenario.Path, http.NoBody)
+			response, err := instanceArouter.Test(request)
+			if err != nil {
+				t.Error("Request failed or timed out", err)
+			}
+			defer response.Body.Close()
+			if response.StatusCode != scenario.ExpectedCode {
+				t.Errorf("%s %s should have returned %d, but returned %d instead", request.Method, request.URL, scenario.ExpectedCode, response.StatusCode)
+			}
+			body, err := io.ReadAll(response.Body)
+			if err != nil {
+				t.Error("expected err to be nil, but was", err)
+			}
+			if string(body) != scenario.ExpectedBody {
+				t.Errorf("expected:\n %s\n\ngot:\n %s", scenario.ExpectedBody, string(body))
+			}
+		})
+	}
+}
+
+// Here we test that remote endpoint formatting depending on `instance.include-remote`
+// adds the query params properly and respects any existing param.
+func TestEndpointStatusesFormatQueryParams(t *testing.T) {
+	type Scenario struct {
+		Name          string
+		InstanceURL   string
+		ExpectedURL   string
+		ExpectedError bool
+		IncludeRemote bool
+	}
+	scenarios := []Scenario{
+		{
+			Name:          "remote-include-remote-true-noparams",
+			InstanceURL:   "https://a.example.com/api/v1/endpoints/statuses",
+			ExpectedURL:   "https://a.example.com/api/v1/endpoints/statuses?remote=true",
+			ExpectedError: false,
+			IncludeRemote: true,
+		},
+		{
+			Name:          "remote-include-remote-false-noparams",
+			InstanceURL:   "https://a.example.com/api/v1/endpoints/statuses",
+			ExpectedURL:   "https://a.example.com/api/v1/endpoints/statuses?remote=false",
+			ExpectedError: false,
+			IncludeRemote: false,
+		},
+		{
+			Name:          "remote-include-remote-true-someparams",
+			InstanceURL:   "https://a.example.com/api/v1/endpoints/statuses?action=foo",
+			ExpectedURL:   "https://a.example.com/api/v1/endpoints/statuses?action=foo&remote=true",
+			ExpectedError: false,
+			IncludeRemote: true,
+		},
+		{
+			Name:          "remote-include-remote-false-someparams",
+			InstanceURL:   "https://a.example.com/api/v1/endpoints/statuses?action=foo",
+			ExpectedURL:   "https://a.example.com/api/v1/endpoints/statuses?action=foo&remote=false",
+			ExpectedError: false,
+			IncludeRemote: false,
+		},
+		// Turns out i don't know how to produce a URL that fails url.Parse validation.
+		// Leaivng the `ExpectedError` here in case it ever becomes handy.
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			foundURL, err := formatRemoteInstanceQueryParams(scenario.InstanceURL, scenario.IncludeRemote)
+			if err != nil {
+				if scenario.ExpectedError {
+					return
+				}
+
+				t.Errorf("scenario %s should not error: %s", scenario.Name, err.Error())
+			}
+			if foundURL != scenario.ExpectedURL {
+				t.Errorf("scenario %s expected:\n %s\n\ngot:\n %s", scenario.Name, scenario.ExpectedURL, foundURL)
+			}
+		})
+	}
+}
+
+// // This test will probably fail because at no point do we set remote=false anywhere
+// // so it should timeout after exhausting a lot of resources. Why does it work?
+// func TestEndpointStatusesInfiniteRecursion(t *testing.T) {
+// 	defer store.Get().Clear()
+// 	defer cache.Clear()
+// 	firstResult := &testSuccessfulResult
+// 	secondResult := &testUnsuccessfulResult
+// 	store.Get().InsertEndpointResult(&testEndpoint, firstResult)
+// 	store.Get().InsertEndpointResult(&testEndpoint, secondResult)
+// 	// Can't be bothered dealing with timezone issues on the worker that runs the automated tests
+// 	firstResult.Timestamp = time.Time{}
+// 	secondResult.Timestamp = time.Time{}
+
+// 	instanceAcfg := &config.Config{
+// 		// Used to disambiguate instances
+// 		Metrics: true,
+// 		Storage: &storage.Config{
+// 			MaximumNumberOfResults: storage.DefaultMaximumNumberOfResults,
+// 			MaximumNumberOfEvents:  storage.DefaultMaximumNumberOfEvents,
+// 		},
+// 	}
+// 	instanceAapi := New(instanceAcfg)
+// 	instanceArouter := instanceAapi.Router()
+
+// 	trueVal := true
+// 	instanceBcfg := &config.Config{
+// 		// Used to disambiguate instances
+// 		Metrics: true,
+// 		Storage: &storage.Config{
+// 			MaximumNumberOfResults: storage.DefaultMaximumNumberOfResults,
+// 			MaximumNumberOfEvents:  storage.DefaultMaximumNumberOfEvents,
+// 		},
+// 		Remote: &remote.Config{
+// 			Instances: []*remote.Instance{&remote.Instance{
+// 				EndpointPrefix: "from-a-",
+// 				URL:            apiAURL,
+// 				IncludeRemote:  &trueVal,
+// 			}},
+// 			ClientConfig: client.GetDefaultConfig(),
+// 		},
+// 	}
+// 	instanceBapi := New(instanceBcfg)
+// 	instanceBrouter := instanceBapi.Router()
+
+// 	mockRoundTripper := test.MockRoundTripper(func(r *http.Request) *http.Response {
+// 		cache.Clear()
+// 		defer cache.Clear()
+// 		if r.Host == "a.example.com" {
+// 			logr.Infof("Mocking remote instance A request to %s", r.URL)
+// 			response, err := instanceArouter.Test(r)
+// 			if err != nil {
+// 				panic("mocked request should not fail")
+// 			}
+// 			return response
+// 		} else if r.Host == "b.example.com" {
+// 			logr.Infof("Mocking remote instance B request to %s", r.URL)
+// 			response, err := instanceBrouter.Test(r)
+// 			if err != nil {
+// 				panic("mocked request should not fail")
+// 			}
+// 			return response
+// 		} else {
+// 			panic("should only mock the remote endpoint")
+// 		}
+// 	})
+// 	client.InjectHTTPClient(&http.Client{Transport: mockRoundTripper})
+
+// 	// We use the same endpoint answers in both the local and remote instances
+// 	expectedBodyWithRemoteFromBAndA := `[{"name":"name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z"},{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z"}]},{"name":"from-b-name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z"},{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z"}]},{"name":"from-b-from-a-name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z"},{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z"}]}]`
+
+// 	type Scenario struct {
+// 		Name          string
+// 		Path          string
+// 		IncludeRemote bool
+// 		ExpectedCode  int
+// 		ExpectedBody  string
+// 	}
+// 	scenarios := []Scenario{
+// 		{
+// 			Name:          "remote-include-remote-true",
+// 			Path:          "/api/v1/endpoints/statuses",
+// 			IncludeRemote: true,
+// 			ExpectedCode:  http.StatusOK,
+// 			ExpectedBody:  expectedBodyWithRemoteFromBAndA,
+// 		},
+// 	}
+
+// 	for _, scenario := range scenarios {
+// 		// The cache does not account for config changes for instance.IncludeRemote
+// 		// so the second scenario always fails if we don't clear the cache because the API
+// 		// cache defaults to 10s.
+// 		cache.Clear()
+// 		t.Run(scenario.Name, func(t *testing.T) {
+// 			logr.Infof("Starting scenario %s", scenario.Name)
+// 			instanceAcfg.Remote = &remote.Config{
+// 				Instances: []*remote.Instance{&remote.Instance{
+// 					EndpointPrefix: "from-b-",
+// 					URL:            apiBURL,
+// 					IncludeRemote:  &scenario.IncludeRemote,
+// 				}},
+// 				ClientConfig: client.GetDefaultConfig(),
+// 			}
+// 			request := httptest.NewRequest("GET", scenario.Path, http.NoBody)
+// 			response, err := instanceArouter.Test(request)
+// 			if err != nil {
+// 				t.Error("Request failed or timed out", err)
+// 			}
+// 			defer response.Body.Close()
+// 			if response.StatusCode != scenario.ExpectedCode {
+// 				t.Errorf("%s %s should have returned %d, but returned %d instead", request.Method, request.URL, scenario.ExpectedCode, response.StatusCode)
+// 			}
+// 			body, err := io.ReadAll(response.Body)
+// 			if err != nil {
+// 				t.Error("expected err to be nil, but was", err)
+// 			}
+// 			if string(body) != scenario.ExpectedBody {
+// 				t.Errorf("expected:\n %s\n\ngot:\n %s", scenario.ExpectedBody, string(body))
+// 			}
+// 		})
+// 	}
+// }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2629,3 +2629,95 @@ func TestResolveTunnelForClientConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestParseAndValidateConfigRemoteInstancesIncludeRemoteFlag(t *testing.T) {
+	scenarios := []struct {
+		name                  string
+		expectedIncludeRemote []bool
+		config                string
+	}{
+		{
+			name:                  "from-remote-include-remote-default",
+			expectedIncludeRemote: []bool{true},
+			config: `
+endpoints:
+  # We include one endpoint until we can start with only remote instances
+  # See https://github.com/TwiN/gatus/pull/1719
+  - name: ep1
+    url: https://twin.sh/health
+    conditions:
+      - "[STATUS] == 200"
+remote:
+  instances:
+    - endpoint-prefix: "remote-"
+      url: "https://gatus.example.com/api/v1/endpoint/statuses"`,
+		},
+		{
+			name:                  "from-remote-include-remote-true",
+			expectedIncludeRemote: []bool{true},
+			config: `
+endpoints:
+  # We include one endpoint until we can start with only remote instances
+  # See https://github.com/TwiN/gatus/pull/1719
+  - name: ep1
+    url: https://twin.sh/health
+    conditions:
+      - "[STATUS] == 200"
+remote:
+  instances:
+    - endpoint-prefix: "remote-"
+      url: "https://gatus.example.com/api/v1/endpoint/statuses"
+      include-remote: true`,
+		},
+		{
+			name:                  "from-remote-include-remote-false",
+			expectedIncludeRemote: []bool{false},
+			config: `
+endpoints:
+  # We include one endpoint until we can start with only remote instances
+  # See https://github.com/TwiN/gatus/pull/1719
+  - name: ep1
+    url: https://twin.sh/health
+    conditions:
+      - "[STATUS] == 200"
+remote:
+  instances:
+    - endpoint-prefix: "remote-"
+      url: "https://gatus.example.com/api/v1/endpoint/statuses"
+      include-remote: false`,
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			cfg, err := parseAndValidateConfigBytes([]byte(scenario.config))
+			if err != nil {
+				t.Errorf("Scenario %s shouldn't have returned an error: %v", scenario.name, err)
+			}
+
+			if cfg.Remote == nil {
+				t.Errorf("Scenario %s cfg.Remote shouldn't be nil", scenario.name)
+			}
+
+			if len(cfg.Remote.Instances) != len(scenario.expectedIncludeRemote) {
+				t.Errorf(
+					"Scenario %s number of found remote instances (%d) does not match expected number of remote instances (%d)",
+					scenario.name,
+					len(cfg.Remote.Instances),
+					len(scenario.expectedIncludeRemote),
+				)
+			}
+
+			for idx, instance := range cfg.Remote.Instances {
+				if *instance.IncludeRemote != scenario.expectedIncludeRemote[idx] {
+					t.Errorf(
+						"Scenario %s remote instance %s had include-remote %t, expected %t",
+						scenario.name,
+						instance.EndpointPrefix,
+						*instance.IncludeRemote,
+						scenario.expectedIncludeRemote[idx],
+					)
+				}
+			}
+		})
+	}
+}

--- a/config/remote/remote.go
+++ b/config/remote/remote.go
@@ -10,7 +10,7 @@ import (
 
 type Config struct {
 	// Instances is a list of remote instances to retrieve endpoint statuses from.
-	Instances []Instance `yaml:"instances,omitempty"`
+	Instances []*Instance `yaml:"instances,omitempty"`
 
 	// ClientConfig is the configuration of the client used to communicate with the provider's target
 	ClientConfig *client.Config `yaml:"client,omitempty"`
@@ -19,6 +19,7 @@ type Config struct {
 type Instance struct {
 	EndpointPrefix string `yaml:"endpoint-prefix"`
 	URL            string `yaml:"url"`
+	IncludeRemote  *bool  `yaml:"include-remote,omitempty"`
 }
 
 func (c *Config) ValidateAndSetDefaults() error {
@@ -32,6 +33,21 @@ func (c *Config) ValidateAndSetDefaults() error {
 	if len(c.Instances) > 0 {
 		logr.Warn("WARNING: Your configuration is using 'remote', which is in alpha and may be updated/removed in future versions.")
 		logr.Warn("WARNING: See https://github.com/TwiN/gatus/issues/64 for more information")
+	}
+
+	foundDefaultIncludeRemote := false
+	defaultIncludeRemote := true
+	for _, instance := range c.Instances {
+		if instance.IncludeRemote == nil {
+			foundDefaultIncludeRemote = true
+			instance.IncludeRemote = &defaultIncludeRemote
+		}
+	}
+
+	if foundDefaultIncludeRemote {
+		logr.Warn("WARNING: There is a new remote instance setting `include-remote` which may be used (when `false`) to avoid duplicate entries.")
+		logr.Warn("WARNING: The default value is `true` for backwards-compatibility, but please set a value explicitly to avoid this message.")
+		logr.Warn("WARNING: See https://github.com/TwiN/gatus/pull/1721 for more information")
 	}
 	return nil
 }


### PR DESCRIPTION
Adding a new setting in remote instance setting: ~~`include_remote`~~ (bool) -> renamed `include-remote` for consistency with `endpoint-prefix`.

When enabled, remote instances from the queried remote instance will be included (some sort of recursion if you will). This was the default behavior until now, but can lead to duplicates, like having both `endpoint1` and `from-site1 endpoint1`  on your `site1` dashboard.

~~**This PR changes the default behavior** to note include remote endpoints from the queried remote instances. This should also help some pathological case when one remote instance was slow to respond which would trickle down on other instances (this is still happening, but only with the instances you declare directly in your config file).~~

This PR has been edited and now doesn't change the default behavior, but will print a message on config (re)load when no explicit value has been set, inciting users to update their config to remove the warning.