### PR TITLE
docs(alerting): Revise HomeAssistant alerts and add Home Assistant integration info

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ Have any feedback or questions? [Create a discussion](https://github.com/TwiN/ga
   - [Helm Chart](#helm-chart)
   - [Terraform](#terraform)
     - [Kubernetes](#kubernetes)
-- [Native Home Assistant Integration](#native-home-assistant-integration)
 - [Running the tests](#running-the-tests)
 - [Using in Production](#using-in-production)
 - [FAQ](#faq)
@@ -847,7 +846,7 @@ endpoints:
 | `alerting.gitlab`          | Configuration for alerts of type `gitlab`. <br />See [Configuring GitLab alerts](#configuring-gitlab-alerts).                           | `{}`    |
 | `alerting.googlechat`      | Configuration for alerts of type `googlechat`. <br />See [Configuring Google Chat alerts](#configuring-google-chat-alerts).             | `{}`    |
 | `alerting.gotify`          | Configuration for alerts of type `gotify`. <br />See [Configuring Gotify alerts](#configuring-gotify-alerts).                           | `{}`    |
-| `alerting.homeassistant`   | Configuration for alerts of type `homeassistant`. <br />See [Configuring HomeAssistant alerts](#configuring-homeassistant-alerts).| `{}`    |
+| `alerting.homeassistant`   | Configuration for alerts of type `homeassistant`. <br />See [Configuring HomeAssistant alerts](#configuring-homeassistant-alerts).      | `{}`    |
 | `alerting.ifttt`           | Configuration for alerts of type `ifttt`. <br />See [Configuring IFTTT alerts](#configuring-ifttt-alerts).                              | `{}`    |
 | `alerting.ilert`           | Configuration for alerts of type `ilert`. <br />See [Configuring ilert alerts](#configuring-ilert-alerts).                              | `{}`    |
 | `alerting.incident-io`     | Configuration for alerts of type `incident-io`. <br />See [Configuring Incident.io alerts](#configuring-incidentio-alerts).             | `{}`    |
@@ -1304,8 +1303,8 @@ Here's an example of what the notifications look like:
 
 #### Configuring HomeAssistant alerts
 
-[!NOTE]
-It is recommended to use the [Native Home Assistant Integration](#native-home-assistant-integration) instead.
+> [!NOTE]
+> It is recommended to use the native Home Assistant integration instead (see below).
 
 | Parameter                                  | Description                                                                            | Default Value |
 |:-------------------------------------------|:---------------------------------------------------------------------------------------|:--------------|
@@ -1380,6 +1379,61 @@ To get your HomeAssistant long-lived access token:
 4. Click "Create Token"
 5. Give it a name (e.g., "Gatus")
 6. Copy the token - you'll only see it once!
+
+##### Native Home Assistant Integration
+
+Gatus can be integrated into [Home Assistant](https://www.home-assistant.io/) to monitor the status of your endpoints directly from your home automation dashboard.
+
+[![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=gatus)
+
+<details>
+  <summary>Configuration & Automation Examples</summary>
+
+###### Configuration
+
+To add the integration, click the button above or:
+
+1. In Home Assistant, navigate to **Settings** > **Devices & Services**.
+2. Click **Add Integration** in the bottom-right corner.
+3. Search for **Gatus** and select it.
+4. Enter the base URL of your Gatus instance (e.g., `http://192.168.1.50:8080`).
+
+Home Assistant will create a binary sensor for each endpoint configured in Gatus. Because these sensors use the `connectivity` device class, they will show as `Connected` (Up) when the endpoint is healthy, and `Disconnected` (Down) when the endpoint is unhealthy.
+
+###### Automation Example
+
+You can easily set up a UI automation in Home Assistant to receive mobile notifications if any endpoint goes down:
+
+1. Navigate to **Settings** > **Automations & Scenes** > **Create Automation** > **Create new automation**.
+2. Under **Triggers**, click **Add Trigger** and select **State**.
+3. In the **Entity** field, select the Gatus binary sensor(s) you want to monitor.
+4. Set the **To** field to `off` (since a state of `off` represents a disconnected/down endpoint).
+5. Under **Actions**, click **Add Action** and select **Perform action**.
+6. Select your notification service (e.g., `Send a notification via mobile_app_<your_device_name>`).
+7. Set the **Message** field. You can use template values to dynamically include the endpoint name:
+   ```yaml
+   message: "The endpoint {{ trigger.to_state.name }} is down!"
+   ```
+
+For advanced users, here is the YAML representation of the automation:
+
+```yaml
+alias: "Notify when Gatus endpoint goes down"
+description: "Sends a mobile notification if a Gatus endpoint goes down"
+trigger:
+  - platform: state
+    entity_id:
+      - binary_sensor.website
+      - binary_sensor.make_sure_header_is_rendered
+    to: "off"
+action:
+  - action: notify.mobile_app_your_device_name
+    data:
+      title: "Gatus Alert"
+      message: "The endpoint {{ trigger.to_state.name }} is down!"
+```
+
+</details>
 
 
 #### Configuring IFTTT alerts
@@ -2910,56 +2964,6 @@ To get more details, please check [chart's configuration](https://github.com/Twi
 #### Kubernetes
 
 Gatus can be deployed on Kubernetes using Terraform by using the following module: [terraform-kubernetes-gatus](https://github.com/TwiN/terraform-kubernetes-gatus).
-
-## Native Home Assistant Integration
-
-Gatus can be integrated into [Home Assistant](https://www.home-assistant.io/) to monitor the status of your endpoints directly from your home automation dashboard.
-
-[![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=gatus)
-
-### Configuration
-
-To add the integration, click the button above or:
-
-1. In Home Assistant, navigate to **Settings** > **Devices & Services**.
-2. Click **Add Integration** in the bottom-right corner.
-3. Search for **Gatus** and select it.
-4. Enter the base URL of your Gatus instance (e.g., `http://192.168.1.50:8080`).
-
-Home Assistant will create a binary sensor for each endpoint configured in Gatus. Because these sensors use the `connectivity` device class, they will show as `Connected` (Up) when the endpoint is healthy, and `Disconnected` (Down) when the endpoint is unhealthy.
-
-### Automation Example
-
-You can easily set up a UI automation in Home Assistant to receive mobile notifications if any endpoint goes down:
-
-1. Navigate to **Settings** > **Automations & Scenes** > **Create Automation** > **Create new automation**.
-2. Under **Triggers**, click **Add Trigger** and select **State**.
-3. In the **Entity** field, select the Gatus binary sensor(s) you want to monitor.
-4. Set the **To** field to `off` (since a state of `off` represents a disconnected/down endpoint).
-5. Under **Actions**, click **Add Action** and select **Perform action**.
-6. Select your notification service (e.g., `Send a notification via mobile_app_<your_device_name>`).
-7. Set the **Message** field. You can use template values to dynamically include the endpoint name:
-   ```yaml
-   message: "The endpoint {{ trigger.to_state.name }} is down!"
-   ```
-
-For advanced users, here is the YAML representation of the automation:
-
-```yaml
-alias: "Notify when Gatus endpoint goes down"
-description: "Sends a mobile notification if a Gatus endpoint goes down"
-trigger:
-  - platform: state
-    entity_id:
-      - binary_sensor.website
-      - binary_sensor.make_sure_header_is_rendered
-    to: "off"
-action:
-  - action: notify.mobile_app_your_device_name
-    data:
-      title: "Gatus Alert"
-      message: "The endpoint {{ trigger.to_state.name }} is down!"
-```
 
 
 ## Running the tests

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Have any feedback or questions? [Create a discussion](https://github.com/TwiN/ga
     - [Configuring GitLab alerts](#configuring-gitlab-alerts)
     - [Configuring Google Chat alerts](#configuring-google-chat-alerts)
     - [Configuring Gotify alerts](#configuring-gotify-alerts)
-    - [Configuring HomeAssistant alerts](#configuring-homeassistant-alerts)
+    - [Configuring HomeAssistant alerts (Legacy)](#configuring-homeassistant-alerts-legacy)
     - [Configuring IFTTT alerts](#configuring-ifttt-alerts)
     - [Configuring Ilert alerts](#configuring-ilert-alerts)
     - [Configuring Incident.io alerts](#configuring-incidentio-alerts)
@@ -112,6 +112,7 @@ Have any feedback or questions? [Create a discussion](https://github.com/TwiN/ga
   - [Helm Chart](#helm-chart)
   - [Terraform](#terraform)
     - [Kubernetes](#kubernetes)
+- [Home Assistant Integration](#home-assistant-integration)
 - [Running the tests](#running-the-tests)
 - [Using in Production](#using-in-production)
 - [FAQ](#faq)
@@ -846,7 +847,7 @@ endpoints:
 | `alerting.gitlab`          | Configuration for alerts of type `gitlab`. <br />See [Configuring GitLab alerts](#configuring-gitlab-alerts).                           | `{}`    |
 | `alerting.googlechat`      | Configuration for alerts of type `googlechat`. <br />See [Configuring Google Chat alerts](#configuring-google-chat-alerts).             | `{}`    |
 | `alerting.gotify`          | Configuration for alerts of type `gotify`. <br />See [Configuring Gotify alerts](#configuring-gotify-alerts).                           | `{}`    |
-| `alerting.homeassistant`   | Configuration for alerts of type `homeassistant`. <br />See [Configuring HomeAssistant alerts](#configuring-homeassistant-alerts).      | `{}`    |
+| `alerting.homeassistant`   | Configuration for alerts of type `homeassistant` (Legacy). <br />See [Configuring HomeAssistant alerts (Legacy)](#configuring-homeassistant-alerts-legacy).| `{}`    |
 | `alerting.ifttt`           | Configuration for alerts of type `ifttt`. <br />See [Configuring IFTTT alerts](#configuring-ifttt-alerts).                              | `{}`    |
 | `alerting.ilert`           | Configuration for alerts of type `ilert`. <br />See [Configuring ilert alerts](#configuring-ilert-alerts).                              | `{}`    |
 | `alerting.incident-io`     | Configuration for alerts of type `incident-io`. <br />See [Configuring Incident.io alerts](#configuring-incidentio-alerts).             | `{}`    |
@@ -1301,7 +1302,11 @@ Here's an example of what the notifications look like:
 ![Gotify notifications](.github/assets/gotify-alerts.png)
 
 
-#### Configuring HomeAssistant alerts
+#### Configuring HomeAssistant alerts (Legacy)
+
+[!NOTE]
+This method of pushing alerts from Gatus to Home Assistant via custom events is legacy. It is recommended to use the official [Home Assistant Integration](#home-assistant-integration) instead.
+
 | Parameter                                  | Description                                                                            | Default Value |
 |:-------------------------------------------|:---------------------------------------------------------------------------------------|:--------------|
 | `alerting.homeassistant.url`               | HomeAssistant instance URL                                                             | Required `""` |
@@ -2905,6 +2910,57 @@ To get more details, please check [chart's configuration](https://github.com/Twi
 #### Kubernetes
 
 Gatus can be deployed on Kubernetes using Terraform by using the following module: [terraform-kubernetes-gatus](https://github.com/TwiN/terraform-kubernetes-gatus).
+
+## Home Assistant Integration
+
+Gatus can be integrated into [Home Assistant](https://www.home-assistant.io/) to monitor the status of your endpoints directly from your home automation dashboard.
+
+[![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=gatus)
+
+### Configuration
+
+To add the integration, click the button above or:
+
+1. In Home Assistant, navigate to **Settings** > **Devices & Services**.
+2. Click **Add Integration** in the bottom-right corner.
+3. Search for **Gatus** and select it.
+4. Enter the base URL of your Gatus instance (e.g., `http://192.168.1.50:8080`).
+
+Home Assistant will create a binary sensor for each endpoint configured in Gatus. Because these sensors use the `connectivity` device class, they will show as `Connected` (Up) when the endpoint i>
+
+### Automation Example
+
+You can easily set up a UI automation in Home Assistant to receive mobile notifications if any endpoint goes down:
+
+1. Navigate to **Settings** > **Automations & Scenes** > **Create Automation** > **Create new automation**.
+2. Under **Triggers**, click **Add Trigger** and select **State**.
+3. In the **Entity** field, select the Gatus binary sensor(s) you want to monitor.
+4. Set the **To** field to `off` (since a state of `off` represents a disconnected/down endpoint).
+5. Under **Actions**, click **Add Action** and select **Perform action**.
+6. Select your notification service (e.g., `Send a notification via mobile_app_<your_device_name>`).
+7. Set the **Message** field. You can use template values to dynamically include the endpoint name:
+   ```yaml
+   message: "The endpoint {{ trigger.to_state.name }} is down!"
+   ```
+
+For advanced users, here is the YAML representation of the automation:
+
+```yaml
+alias: "Notify when Gatus endpoint goes down"
+description: "Sends a mobile notification if a Gatus endpoint goes down"
+trigger:
+  - platform: state
+    entity_id:
+      - binary_sensor.website
+      - binary_sensor.make_sure_header_is_rendered
+    to: "off"
+action:
+  - action: notify.mobile_app_your_device_name
+    data:
+      title: "Gatus Alert"
+      message: "The endpoint {{ trigger.to_state.name }} is down!"
+```
+
 
 ## Running the tests
 ```console

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Have any feedback or questions? [Create a discussion](https://github.com/TwiN/ga
     - [Configuring GitLab alerts](#configuring-gitlab-alerts)
     - [Configuring Google Chat alerts](#configuring-google-chat-alerts)
     - [Configuring Gotify alerts](#configuring-gotify-alerts)
-    - [Configuring HomeAssistant alerts (Legacy)](#configuring-homeassistant-alerts-legacy)
+    - [Configuring HomeAssistant alerts](#configuring-homeassistant-alerts)
     - [Configuring IFTTT alerts](#configuring-ifttt-alerts)
     - [Configuring Ilert alerts](#configuring-ilert-alerts)
     - [Configuring Incident.io alerts](#configuring-incidentio-alerts)
@@ -112,7 +112,7 @@ Have any feedback or questions? [Create a discussion](https://github.com/TwiN/ga
   - [Helm Chart](#helm-chart)
   - [Terraform](#terraform)
     - [Kubernetes](#kubernetes)
-- [Home Assistant Integration](#home-assistant-integration)
+- [Native Home Assistant Integration](#native-home-assistant-integration)
 - [Running the tests](#running-the-tests)
 - [Using in Production](#using-in-production)
 - [FAQ](#faq)
@@ -847,7 +847,7 @@ endpoints:
 | `alerting.gitlab`          | Configuration for alerts of type `gitlab`. <br />See [Configuring GitLab alerts](#configuring-gitlab-alerts).                           | `{}`    |
 | `alerting.googlechat`      | Configuration for alerts of type `googlechat`. <br />See [Configuring Google Chat alerts](#configuring-google-chat-alerts).             | `{}`    |
 | `alerting.gotify`          | Configuration for alerts of type `gotify`. <br />See [Configuring Gotify alerts](#configuring-gotify-alerts).                           | `{}`    |
-| `alerting.homeassistant`   | Configuration for alerts of type `homeassistant` (Legacy). <br />See [Configuring HomeAssistant alerts (Legacy)](#configuring-homeassistant-alerts-legacy).| `{}`    |
+| `alerting.homeassistant`   | Configuration for alerts of type `homeassistant`. <br />See [Configuring HomeAssistant alerts](#configuring-homeassistant-alerts).| `{}`    |
 | `alerting.ifttt`           | Configuration for alerts of type `ifttt`. <br />See [Configuring IFTTT alerts](#configuring-ifttt-alerts).                              | `{}`    |
 | `alerting.ilert`           | Configuration for alerts of type `ilert`. <br />See [Configuring ilert alerts](#configuring-ilert-alerts).                              | `{}`    |
 | `alerting.incident-io`     | Configuration for alerts of type `incident-io`. <br />See [Configuring Incident.io alerts](#configuring-incidentio-alerts).             | `{}`    |
@@ -1302,10 +1302,10 @@ Here's an example of what the notifications look like:
 ![Gotify notifications](.github/assets/gotify-alerts.png)
 
 
-#### Configuring HomeAssistant alerts (Legacy)
+#### Configuring HomeAssistant alerts
 
 [!NOTE]
-This method of pushing alerts from Gatus to Home Assistant via custom events is legacy. It is recommended to use the official [Home Assistant Integration](#home-assistant-integration) instead.
+It is recommended to use the [Native Home Assistant Integration](#native-home-assistant-integration) instead.
 
 | Parameter                                  | Description                                                                            | Default Value |
 |:-------------------------------------------|:---------------------------------------------------------------------------------------|:--------------|
@@ -2911,7 +2911,7 @@ To get more details, please check [chart's configuration](https://github.com/Twi
 
 Gatus can be deployed on Kubernetes using Terraform by using the following module: [terraform-kubernetes-gatus](https://github.com/TwiN/terraform-kubernetes-gatus).
 
-## Home Assistant Integration
+## Native Home Assistant Integration
 
 Gatus can be integrated into [Home Assistant](https://www.home-assistant.io/) to monitor the status of your endpoints directly from your home automation dashboard.
 

--- a/README.md
+++ b/README.md
@@ -2926,7 +2926,7 @@ To add the integration, click the button above or:
 3. Search for **Gatus** and select it.
 4. Enter the base URL of your Gatus instance (e.g., `http://192.168.1.50:8080`).
 
-Home Assistant will create a binary sensor for each endpoint configured in Gatus. Because these sensors use the `connectivity` device class, they will show as `Connected` (Up) when the endpoint i>
+Home Assistant will create a binary sensor for each endpoint configured in Gatus. Because these sensors use the `connectivity` device class, they will show as `Connected` (Up) when the endpoint is healthy, and `Disconnected` (Down) when the endpoint is unhealthy.
 
 ### Automation Example
 


### PR DESCRIPTION
## Summary

I have authored an integration for Home Assistant that has been accepted and will be merged into the next release in August. This means that every Home Assistant install will include official support for Gatus out of the box, and will allow a much easier experience than current. This PR updates the README to reflect these changes. 

I have left the existing instructions in the README marked as Legacy with a note to use the integration. Might be an idea to just remove the section altogether in the future? I leave this decision to the maintainers.

Note: Please do not merge before Home Assistant Release 2026.8. I will mark PR as draft until the release has been made.


## Checklist
- [x] Updated documentation in `README.md`, if applicable.
