### PR TITLE
Support an explicit endpoint key to decouple identity from name

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ You can then configure alerts to be triggered when an endpoint is unhealthy once
 | `endpoints`                                     | List of endpoints to monitor.                                                                                                               | Required `[]`              |
 | `endpoints[].enabled`                           | Whether to monitor the endpoint.                                                                                                            | `true`                     |
 | `endpoints[].name`                              | Name of the endpoint. Can be anything.                                                                                                      | Required `""`              |
+| `endpoints[].key`                               | Explicit unique key used for storage and API routes instead of deriving it from group and name. <br />See [Endpoint key](#endpoint-key).   | `""`                       |
 | `endpoints[].group`                             | Group name. Used to group multiple endpoints together on the dashboard. <br />See [Endpoint groups](#endpoint-groups).                      | `""`                       |
 | `endpoints[].url`                               | URL to send the request to.                                                                                                                 | Required `""`              |
 | `endpoints[].method`                            | Request method.                                                                                                                             | `GET`                      |
@@ -329,6 +330,7 @@ For instance:
 | `external-endpoints`                      | List of endpoints to monitor.                                                                                                     | `[]`           |
 | `external-endpoints[].enabled`            | Whether to monitor the endpoint.                                                                                                  | `true`         |
 | `external-endpoints[].name`               | Name of the endpoint. Can be anything.                                                                                            | Required `""`  |
+| `external-endpoints[].key`                | Explicit unique key used for storage and API routes instead of deriving it from group and name. <br />See [Endpoint key](#endpoint-key). | `""`     |
 | `external-endpoints[].group`              | Group name. Used to group multiple endpoints together on the dashboard. <br />See [Endpoint groups](#endpoint-groups).            | `""`           |
 | `external-endpoints[].token`              | Bearer token required to push status to.                                                                                          | Required `""`  |
 | `external-endpoints[].alerts`             | List of all alerts for a given endpoint. <br />See [Alerting](#alerting).                                                         | `[]`           |
@@ -3310,6 +3312,28 @@ the same as restarting the application.
 
 > 📝 Updates may not be detected if the config file is bound instead of the config folder. See [#151](https://github.com/TwiN/gatus/issues/151).
 
+
+### Endpoint key
+By default, an endpoint's unique key is derived from its `group` and `name`.
+This key is what Gatus uses to store the endpoint's history and to build its API routes (e.g. `/api/v1/endpoints/{key}/...`), which means renaming an endpoint or moving it to a different group changes its key and orphans its existing history.
+
+Setting `key` lets you pin an endpoint's identity to a stable value (e.g. a UUID or a slug) so it survives changes to `name` and `group`:
+```yaml
+endpoints:
+  - name: My Frontend
+    key: 550e8400-e29b-41d4-a716-446655440000
+    url: "https://example.org/"
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+```
+The same field is available on `external-endpoints`.
+
+Notes:
+- The value is sanitized the same way derived keys are, so it is safe to use in storage and URLs. For UUIDs and slugs this is a no-op.
+- Because `_` is replaced by `-`, an explicit key can never reproduce a derived `group`/`name` key (those always contain a `_` separator). An explicit key therefore cannot be used to adopt the history of an existing grouped endpoint.
+- The key must be unique across all endpoints and external endpoints, just like the derived `group`/`name` key.
+- Adding or changing `key` on an endpoint that already has history is a one-time cutover: the history stored under the old key is orphaned (not migrated). This is expected.
 
 ### Endpoint groups
 Endpoint groups are used for grouping multiple endpoints together on the dashboard.

--- a/api/external_endpoint_test.go
+++ b/api/external_endpoint_test.go
@@ -174,3 +174,46 @@ func TestCreateExternalEndpointResult(t *testing.T) {
 		}
 	})
 }
+
+func TestCreateExternalEndpointResultWithExplicitKey(t *testing.T) {
+	defer store.Get().Clear()
+	defer cache.Clear()
+	cfg := &config.Config{
+		ExternalEndpoints: []*endpoint.ExternalEndpoint{
+			{
+				Name:        "A Human Readable Name",
+				Group:       "some-group",
+				ExplicitKey: "some-stable-uuid",
+				Token:       "token",
+			},
+		},
+		Maintenance: &maintenance.Config{},
+	}
+	api := New(cfg)
+	router := api.Router()
+	request := httptest.NewRequest("POST", "/api/v1/endpoints/some-stable-uuid/external?success=true", http.NoBody)
+	request.Header.Set("Authorization", "Bearer token")
+	response, err := router.Test(request)
+	if err != nil {
+		t.Fatalf("failed to push result: %s", err.Error())
+	}
+	defer response.Body.Close()
+	if response.StatusCode != 200 {
+		t.Fatalf("expected push to return 200, but returned %d instead", response.StatusCode)
+	}
+	// The result must be stored under the explicit key.
+	endpointStatus, err := store.Get().GetEndpointStatusByKey("some-stable-uuid", paging.NewEndpointStatusParams().WithResults(1, 1))
+	if err != nil {
+		t.Fatalf("failed to get endpoint status by explicit key: %s", err.Error())
+	}
+	if endpointStatus.Key != "some-stable-uuid" {
+		t.Errorf("expected stored key to be some-stable-uuid but got %s", endpointStatus.Key)
+	}
+	if len(endpointStatus.Results) != 1 || !endpointStatus.Results[0].Success {
+		t.Errorf("expected exactly one successful result under the explicit key")
+	}
+	// It must NOT be stored under the derived group_name key.
+	if derived, _ := store.Get().GetEndpointStatusByKey("some-group_a-human-readable-name", paging.NewEndpointStatusParams().WithResults(1, 1)); derived != nil && len(derived.Results) > 0 {
+		t.Errorf("result should not have been stored under the derived key")
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2228,6 +2228,8 @@ endpoints:
       - "[STATUS] == 200"`,
 		},
 		{
+			// The derived key of the first endpoint is "backend_api", while the explicit key "backend_api" of the second endpoint is sanitized to "backend-api" because Sanitize replaces underscores with dashes.
+			// Derived keys always contain a literal "_" separator and sanitized explicit keys never can, so the two namespaces cannot collide and no duplicate error is expected here.
 			name:        "explicit-key-cannot-collide-with-derived-key",
 			shouldError: false,
 			config: `

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2210,6 +2210,74 @@ suites:
         conditions:
           - "[STATUS] == 200"`,
 		},
+		{
+			name:        "two-endpoints-with-same-explicit-key",
+			shouldError: true,
+			expectedErr: "invalid endpoint shared-key: name and group combination must be unique",
+			config: `
+endpoints:
+  - name: first
+    key: shared-key
+    url: https://example.com/first
+    conditions:
+      - "[STATUS] == 200"
+  - name: second
+    key: shared-key
+    url: https://example.com/second
+    conditions:
+      - "[STATUS] == 200"`,
+		},
+		{
+			name:        "explicit-key-cannot-collide-with-derived-key",
+			shouldError: false,
+			config: `
+endpoints:
+  - name: api
+    group: backend
+    url: https://example.com/api
+    conditions:
+      - "[STATUS] == 200"
+  - name: unrelated
+    key: backend_api
+    url: https://example.com/unrelated
+    conditions:
+      - "[STATUS] == 200"`,
+		},
+		{
+			name:        "external-endpoint-explicit-key-colliding-with-endpoint",
+			shouldError: true,
+			expectedErr: "invalid external endpoint stable-id: name and group combination must be unique",
+			config: `
+endpoints:
+  - name: whatever
+    key: stable-id
+    url: https://example.com/whatever
+    conditions:
+      - "[STATUS] == 200"
+
+external-endpoints:
+  - name: pushed
+    key: stable-id
+    token: some-token`,
+		},
+		{
+			name:        "same-group-and-name-disambiguated-by-explicit-keys",
+			shouldError: false,
+			config: `
+endpoints:
+  - name: worker
+    group: jobs
+    key: worker-a
+    url: https://example.com/a
+    conditions:
+      - "[STATUS] == 200"
+  - name: worker
+    group: jobs
+    key: worker-b
+    url: https://example.com/b
+    conditions:
+      - "[STATUS] == 200"`,
+		},
 	}
 
 	for _, scenario := range scenarios {

--- a/config/endpoint/endpoint.go
+++ b/config/endpoint/endpoint.go
@@ -85,6 +85,10 @@ type Endpoint struct {
 	// Name of the endpoint. Can be anything.
 	Name string `yaml:"name"`
 
+	// ExplicitKey, when set, is used as the endpoint's unique key instead of deriving it from Group and Name.
+	// This lets an endpoint's identity stay stable across name and group changes.
+	ExplicitKey string `yaml:"key,omitempty"`
+
 	// Group the endpoint is a part of. Used for grouping multiple endpoints together on the front end.
 	Group string `yaml:"group,omitempty"`
 
@@ -273,6 +277,9 @@ func (e *Endpoint) DisplayName() string {
 
 // Key returns the unique key for the Endpoint
 func (e *Endpoint) Key() string {
+	if e.ExplicitKey != "" {
+		return key.Sanitize(e.ExplicitKey)
+	}
 	return key.ConvertGroupAndNameToKey(e.Group, e.Name)
 }
 

--- a/config/endpoint/endpoint_test.go
+++ b/config/endpoint/endpoint_test.go
@@ -1004,6 +1004,42 @@ func TestIntegrationEvaluateHealthForICMP(t *testing.T) {
 	}
 }
 
+func TestEndpoint_Key(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint Endpoint
+		expected string
+	}{
+		{
+			name:     "derived-from-group-and-name",
+			endpoint: Endpoint{Group: "g", Name: "n"},
+			expected: "g_n",
+		},
+		{
+			name:     "derived-without-group",
+			endpoint: Endpoint{Name: "n"},
+			expected: "_n",
+		},
+		{
+			name:     "explicit-key-ignores-group-and-name",
+			endpoint: Endpoint{Group: "g", Name: "n", ExplicitKey: "550e8400-e29b-41d4-a716-446655440000"},
+			expected: "550e8400-e29b-41d4-a716-446655440000",
+		},
+		{
+			name:     "explicit-key-is-sanitized",
+			endpoint: Endpoint{Group: "g", Name: "n", ExplicitKey: "My Custom.Key"},
+			expected: "my-custom-key",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if result := tt.endpoint.Key(); result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
 func TestEndpoint_DisplayName(t *testing.T) {
 	if endpoint := (Endpoint{Name: "n"}); endpoint.DisplayName() != "n" {
 		t.Error("endpoint.DisplayName() should've been 'n', but was", endpoint.DisplayName())

--- a/config/endpoint/endpoint_test.go
+++ b/config/endpoint/endpoint_test.go
@@ -1030,6 +1030,11 @@ func TestEndpoint_Key(t *testing.T) {
 			endpoint: Endpoint{Group: "g", Name: "n", ExplicitKey: "My Custom.Key"},
 			expected: "my-custom-key",
 		},
+		{
+			name:     "explicit-key-underscore-is-replaced",
+			endpoint: Endpoint{Group: "g", Name: "n", ExplicitKey: "foo_bar"},
+			expected: "foo-bar",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/config/endpoint/external_endpoint.go
+++ b/config/endpoint/external_endpoint.go
@@ -28,6 +28,10 @@ type ExternalEndpoint struct {
 	// Name of the endpoint. Can be anything.
 	Name string `yaml:"name"`
 
+	// ExplicitKey, when set, is used as the endpoint's unique key instead of deriving it from Group and Name.
+	// This lets an endpoint's identity stay stable across name and group changes.
+	ExplicitKey string `yaml:"key,omitempty"`
+
 	// Group the endpoint is a part of. Used for grouping multiple endpoints together on the front end.
 	Group string `yaml:"group,omitempty"`
 
@@ -83,6 +87,9 @@ func (externalEndpoint *ExternalEndpoint) DisplayName() string {
 
 // Key returns the unique key for the Endpoint
 func (externalEndpoint *ExternalEndpoint) Key() string {
+	if externalEndpoint.ExplicitKey != "" {
+		return key.Sanitize(externalEndpoint.ExplicitKey)
+	}
 	return key.ConvertGroupAndNameToKey(externalEndpoint.Group, externalEndpoint.Name)
 }
 
@@ -91,6 +98,7 @@ func (externalEndpoint *ExternalEndpoint) ToEndpoint() *Endpoint {
 	endpoint := &Endpoint{
 		Enabled:                 externalEndpoint.Enabled,
 		Name:                    externalEndpoint.Name,
+		ExplicitKey:             externalEndpoint.ExplicitKey,
 		Group:                   externalEndpoint.Group,
 		Alerts:                  externalEndpoint.Alerts,
 		NumberOfFailuresInARow:  externalEndpoint.NumberOfFailuresInARow,

--- a/config/endpoint/external_endpoint_test.go
+++ b/config/endpoint/external_endpoint_test.go
@@ -224,6 +224,24 @@ func TestExternalEndpoint_Key(t *testing.T) {
 			},
 			expected: "test-group_test-endpoint-with-spaces",
 		},
+		{
+			name: "explicit-key-ignores-group-and-name",
+			endpoint: &ExternalEndpoint{
+				Name:        "test-endpoint",
+				Group:       "test-group",
+				ExplicitKey: "550e8400-e29b-41d4-a716-446655440000",
+			},
+			expected: "550e8400-e29b-41d4-a716-446655440000",
+		},
+		{
+			name: "explicit-key-is-sanitized",
+			endpoint: &ExternalEndpoint{
+				Name:        "test-endpoint",
+				Group:       "test-group",
+				ExplicitKey: "My Custom.Key",
+			},
+			expected: "my-custom-key",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -282,6 +300,14 @@ func TestExternalEndpoint_ToEndpoint(t *testing.T) {
 			externalEndpoint: &ExternalEndpoint{
 				Name:  "name",
 				Group: "group",
+			},
+		},
+		{
+			name: "explicit-key-propagates",
+			externalEndpoint: &ExternalEndpoint{
+				Name:        "A Human Readable Name",
+				Group:       "some-group",
+				ExplicitKey: "some-stable-uuid",
 			},
 		},
 	}

--- a/config/endpoint/status.go
+++ b/config/endpoint/status.go
@@ -28,12 +28,17 @@ type Status struct {
 	Uptime *Uptime `json:"-"`
 }
 
-// NewStatus creates a new Status
+// NewStatus creates a new Status with a key derived from the group and name
 func NewStatus(group, name string) *Status {
+	return NewStatusWithKey(key.ConvertGroupAndNameToKey(group, name), group, name)
+}
+
+// NewStatusWithKey creates a new Status with an explicit key, which may differ from the derived one when the endpoint has an explicit key configured
+func NewStatusWithKey(statusKey, group, name string) *Status {
 	return &Status{
 		Name:    name,
 		Group:   group,
-		Key:     key.ConvertGroupAndNameToKey(group, name),
+		Key:     statusKey,
 		Results: make([]*Result, 0),
 		Events:  make([]*Event, 0),
 		Uptime:  NewUptime(),

--- a/config/key/key.go
+++ b/config/key/key.go
@@ -4,10 +4,10 @@ import "strings"
 
 // ConvertGroupAndNameToKey converts a group and a name to a key
 func ConvertGroupAndNameToKey(groupName, name string) string {
-	return sanitize(groupName) + "_" + sanitize(name)
+	return Sanitize(groupName) + "_" + Sanitize(name)
 }
 
-func sanitize(s string) string {
+func Sanitize(s string) string {
 	s = strings.TrimSpace(strings.ToLower(s))
 	s = strings.ReplaceAll(s, "/", "-")
 	s = strings.ReplaceAll(s, "_", "-")

--- a/storage/store/memory/memory.go
+++ b/storage/store/memory/memory.go
@@ -195,8 +195,7 @@ func (s *Store) InsertEndpointResult(ep *endpoint.Endpoint, result *endpoint.Res
 	s.Lock()
 	status, exists := s.endpointCache.Get(endpointKey)
 	if !exists {
-		status = endpoint.NewStatus(ep.Group, ep.Name)
-		status.(*endpoint.Status).Key = endpointKey
+		status = endpoint.NewStatusWithKey(endpointKey, ep.Group, ep.Name)
 		status.(*endpoint.Status).Events = append(status.(*endpoint.Status).Events, &endpoint.Event{
 			Type:      endpoint.EventStart,
 			Timestamp: time.Now(),

--- a/storage/store/memory/memory.go
+++ b/storage/store/memory/memory.go
@@ -196,6 +196,7 @@ func (s *Store) InsertEndpointResult(ep *endpoint.Endpoint, result *endpoint.Res
 	status, exists := s.endpointCache.Get(endpointKey)
 	if !exists {
 		status = endpoint.NewStatus(ep.Group, ep.Name)
+		status.(*endpoint.Status).Key = endpointKey
 		status.(*endpoint.Status).Events = append(status.(*endpoint.Status).Events, &endpoint.Event{
 			Type:      endpoint.EventStart,
 			Timestamp: time.Now(),

--- a/storage/store/sql/specific_postgres.go
+++ b/storage/store/sql/specific_postgres.go
@@ -1,5 +1,9 @@
 package sql
 
+import (
+	"github.com/TwiN/logr"
+)
+
 func (s *Store) createPostgresSchema() error {
 	// Create suite tables
 	_, err := s.db.Exec(`
@@ -118,7 +122,17 @@ func (s *Store) createPostgresSchema() error {
 	// Drop the legacy UNIQUE(endpoint_name, endpoint_group) constraint.
 	// It predates support for an explicit endpoint key: with an explicit key, identity is decoupled from name and group, so two endpoints may legitimately share a name and group.
 	// endpoint_key remains UNIQUE, which is the real identity guarantee.
-	_, _ = s.db.Exec(`ALTER TABLE endpoints DROP CONSTRAINT IF EXISTS endpoints_endpoint_name_endpoint_group_key`)
+	var hasLegacyEndpointNameGroupConstraint bool
+	if scanErr := s.db.QueryRow(`SELECT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'endpoints_endpoint_name_endpoint_group_key' AND conrelid = 'endpoints'::regclass)`).Scan(&hasLegacyEndpointNameGroupConstraint); scanErr != nil {
+		logr.Errorf("[sql.createPostgresSchema] Failed to check for the legacy UNIQUE(endpoint_name, endpoint_group) constraint: %s", scanErr.Error())
+	} else if hasLegacyEndpointNameGroupConstraint {
+		logr.Infof("[sql.createPostgresSchema] Dropping the legacy UNIQUE(endpoint_name, endpoint_group) constraint; this is a one-time migration")
+		if _, dropErr := s.db.Exec(`ALTER TABLE endpoints DROP CONSTRAINT endpoints_endpoint_name_endpoint_group_key`); dropErr != nil {
+			logr.Errorf("[sql.createPostgresSchema] Failed to drop the legacy UNIQUE(endpoint_name, endpoint_group) constraint: %s", dropErr.Error())
+		}
+	} else {
+		logr.Debugf("[sql.createPostgresSchema] Legacy UNIQUE(endpoint_name, endpoint_group) constraint is not present; nothing to drop")
+	}
 	// Add suite_result_id to endpoint_results table for suite endpoint linkage
 	_, _ = s.db.Exec(`ALTER TABLE endpoint_results ADD COLUMN IF NOT EXISTS suite_result_id BIGINT REFERENCES suite_results(suite_result_id) ON DELETE CASCADE`)
 	// Create index for suite_result_id

--- a/storage/store/sql/specific_postgres.go
+++ b/storage/store/sql/specific_postgres.go
@@ -33,8 +33,7 @@ func (s *Store) createPostgresSchema() error {
 			endpoint_id    BIGSERIAL PRIMARY KEY,
 			endpoint_key   TEXT UNIQUE,
 			endpoint_name  TEXT NOT NULL,
-			endpoint_group TEXT NOT NULL,
-			UNIQUE(endpoint_name, endpoint_group)
+			endpoint_group TEXT NOT NULL
 		)
 	`)
 	if err != nil {
@@ -116,6 +115,10 @@ func (s *Store) createPostgresSchema() error {
 	`)
 	// Silent table modifications TODO: Remove this in v6.0.0
 	_, _ = s.db.Exec(`ALTER TABLE endpoint_results ADD IF NOT EXISTS domain_expiration BIGINT NOT NULL DEFAULT 0`)
+	// Drop the legacy UNIQUE(endpoint_name, endpoint_group) constraint.
+	// It predates support for an explicit endpoint key: with an explicit key, identity is decoupled from name and group, so two endpoints may legitimately share a name and group.
+	// endpoint_key remains UNIQUE, which is the real identity guarantee.
+	_, _ = s.db.Exec(`ALTER TABLE endpoints DROP CONSTRAINT IF EXISTS endpoints_endpoint_name_endpoint_group_key`)
 	// Add suite_result_id to endpoint_results table for suite endpoint linkage
 	_, _ = s.db.Exec(`ALTER TABLE endpoint_results ADD COLUMN IF NOT EXISTS suite_result_id BIGINT REFERENCES suite_results(suite_result_id) ON DELETE CASCADE`)
 	// Create index for suite_result_id

--- a/storage/store/sql/specific_sqlite.go
+++ b/storage/store/sql/specific_sqlite.go
@@ -1,5 +1,10 @@
 package sql
 
+import (
+	"context"
+	"strings"
+)
+
 func (s *Store) createSQLiteSchema() error {
 	// Create suite tables
 	_, err := s.db.Exec(`
@@ -33,8 +38,7 @@ func (s *Store) createSQLiteSchema() error {
 			endpoint_id    INTEGER PRIMARY KEY,
 			endpoint_key   TEXT UNIQUE,
 			endpoint_name  TEXT NOT NULL,
-			endpoint_group TEXT NOT NULL,
-			UNIQUE(endpoint_name, endpoint_group)
+			endpoint_group TEXT NOT NULL
 		)
 	`)
 	if err != nil {
@@ -144,5 +148,60 @@ func (s *Store) createSQLiteSchema() error {
 	_, _ = s.db.Exec(`CREATE INDEX IF NOT EXISTS endpoint_results_suite_result_id_idx ON endpoint_results(suite_result_id)`)
 	// Note: SQLite doesn't support DROP COLUMN in older versions, so we skip this cleanup
 	// The suite_id column in endpoints table will remain but unused
-	return err
+	if err != nil {
+		return err
+	}
+	// Drop the legacy UNIQUE(endpoint_name, endpoint_group) constraint (see the Postgres equivalent for the rationale).
+	// SQLite cannot drop a table-level constraint, so the table is rebuilt without it when the constraint is present.
+	return s.dropLegacyEndpointNameGroupUniqueConstraint()
+}
+
+// dropLegacyEndpointNameGroupUniqueConstraint removes the UNIQUE(endpoint_name, endpoint_group) constraint from an
+// existing endpoints table by rebuilding it, so that endpoints with an explicit key may share a name and group.
+// It is a no-op on databases where the constraint is already absent (e.g. freshly created ones).
+func (s *Store) dropLegacyEndpointNameGroupUniqueConstraint() error {
+	var ddl string
+	if err := s.db.QueryRow(`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'endpoints'`).Scan(&ddl); err != nil {
+		return err
+	}
+	normalizedDDL := strings.ToLower(strings.ReplaceAll(ddl, " ", ""))
+	if !strings.Contains(normalizedDDL, "unique(endpoint_name,endpoint_group)") {
+		return nil // Constraint already absent
+	}
+	ctx := context.Background()
+	// Use a single connection so the foreign_keys pragma and the transaction below apply to the same session.
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	// foreign_keys must be toggled outside of a transaction (it is a no-op within one).
+	if _, err = conn.ExecContext(ctx, `PRAGMA foreign_keys=OFF`); err != nil {
+		return err
+	}
+	defer func() { _, _ = conn.ExecContext(ctx, `PRAGMA foreign_keys=ON`) }()
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	// endpoint_id values are preserved so foreign keys in child tables (endpoint_results, endpoint_events, etc.) stay valid.
+	statements := []string{
+		`CREATE TABLE endpoints_new (
+			endpoint_id    INTEGER PRIMARY KEY,
+			endpoint_key   TEXT UNIQUE,
+			endpoint_name  TEXT NOT NULL,
+			endpoint_group TEXT NOT NULL
+		)`,
+		`INSERT INTO endpoints_new (endpoint_id, endpoint_key, endpoint_name, endpoint_group)
+			SELECT endpoint_id, endpoint_key, endpoint_name, endpoint_group FROM endpoints`,
+		`DROP TABLE endpoints`,
+		`ALTER TABLE endpoints_new RENAME TO endpoints`,
+	}
+	for _, statement := range statements {
+		if _, err = tx.ExecContext(ctx, statement); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+	}
+	return tx.Commit()
 }

--- a/storage/store/sql/specific_sqlite.go
+++ b/storage/store/sql/specific_sqlite.go
@@ -3,6 +3,8 @@ package sql
 import (
 	"context"
 	"strings"
+
+	"github.com/TwiN/logr"
 )
 
 func (s *Store) createSQLiteSchema() error {
@@ -168,6 +170,8 @@ func (s *Store) dropLegacyEndpointNameGroupUniqueConstraint() error {
 	if !strings.Contains(normalizedDDL, "unique(endpoint_name,endpoint_group)") {
 		return nil // Constraint already absent
 	}
+	// This rebuild happens at most once per database, but it can make startup noticeably slower on large databases, so leave a breadcrumb for operators.
+	logr.Infof("[sql.dropLegacyEndpointNameGroupUniqueConstraint] Rebuilding the endpoints table to drop the legacy UNIQUE(endpoint_name, endpoint_group) constraint; this is a one-time migration")
 	ctx := context.Background()
 	// Use a single connection so the foreign_keys pragma and the transaction below apply to the same session.
 	conn, err := s.db.Conn(ctx)

--- a/storage/store/sql/sql.go
+++ b/storage/store/sql/sql.go
@@ -723,6 +723,7 @@ func (s *Store) getEndpointStatusByKey(tx *sql.Tx, key string, parameters *pagin
 		return nil, err
 	}
 	endpointStatus := endpoint.NewStatus(group, endpointName)
+	endpointStatus.Key = key
 	if parameters.EventsPageSize > 0 {
 		if endpointStatus.Events, err = s.getEndpointEventsByEndpointID(tx, endpointID, parameters.EventsPage, parameters.EventsPageSize); err != nil {
 			logr.Errorf("[sql.getEndpointStatusByKey] Failed to retrieve events for key=%s: %s", key, err.Error())

--- a/storage/store/sql/sql.go
+++ b/storage/store/sql/sql.go
@@ -722,8 +722,7 @@ func (s *Store) getEndpointStatusByKey(tx *sql.Tx, key string, parameters *pagin
 	if err != nil {
 		return nil, err
 	}
-	endpointStatus := endpoint.NewStatus(group, endpointName)
-	endpointStatus.Key = key
+	endpointStatus := endpoint.NewStatusWithKey(key, group, endpointName)
 	if parameters.EventsPageSize > 0 {
 		if endpointStatus.Events, err = s.getEndpointEventsByEndpointID(tx, endpointID, parameters.EventsPage, parameters.EventsPageSize); err != nil {
 			logr.Errorf("[sql.getEndpointStatusByKey] Failed to retrieve events for key=%s: %s", key, err.Error())

--- a/storage/store/sql/sql_test.go
+++ b/storage/store/sql/sql_test.go
@@ -942,3 +942,52 @@ func TestEventOrderingFix(t *testing.T) {
 	t.Logf("First event: %s at %v", events[0].Type, events[0].Timestamp)
 	t.Logf("Last event: %s at %v", events[len(events)-1].Type, events[len(events)-1].Timestamp)
 }
+
+func TestStore_DropsLegacyEndpointNameGroupUniqueConstraint(t *testing.T) {
+	store, _ := NewStore("sqlite", t.TempDir()+"/TestStore_DropsLegacyEndpointNameGroupUniqueConstraint.db", false, storage.DefaultMaximumNumberOfResults, storage.DefaultMaximumNumberOfEvents)
+	defer store.Close()
+	// Simulate a legacy database whose endpoints table still carries the UNIQUE(endpoint_name, endpoint_group) constraint.
+	if _, err := store.db.Exec(`DROP TABLE endpoints`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`CREATE TABLE endpoints (
+		endpoint_id    INTEGER PRIMARY KEY,
+		endpoint_key   TEXT UNIQUE,
+		endpoint_name  TEXT NOT NULL,
+		endpoint_group TEXT NOT NULL,
+		UNIQUE(endpoint_name, endpoint_group)
+	)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`INSERT INTO endpoints (endpoint_key, endpoint_name, endpoint_group) VALUES ('key-1', 'shared', 'grp')`); err != nil {
+		t.Fatal(err)
+	}
+	// Sanity check: the legacy constraint rejects a second endpoint with the same name and group.
+	if _, err := store.db.Exec(`INSERT INTO endpoints (endpoint_key, endpoint_name, endpoint_group) VALUES ('key-2', 'shared', 'grp')`); err == nil {
+		t.Fatal("expected the legacy UNIQUE(endpoint_name, endpoint_group) constraint to reject the duplicate")
+	}
+	// Run the migration.
+	if err := store.dropLegacyEndpointNameGroupUniqueConstraint(); err != nil {
+		t.Fatalf("migration failed: %s", err)
+	}
+	// The seeded row must survive the rebuild with its identity intact.
+	var name string
+	if err := store.db.QueryRow(`SELECT endpoint_name FROM endpoints WHERE endpoint_key = 'key-1'`).Scan(&name); err != nil {
+		t.Fatalf("seeded row was lost during rebuild: %s", err)
+	}
+	if name != "shared" {
+		t.Errorf("expected preserved name 'shared', got %q", name)
+	}
+	// Two endpoints may now share a name and group as long as their keys differ.
+	if _, err := store.db.Exec(`INSERT INTO endpoints (endpoint_key, endpoint_name, endpoint_group) VALUES ('key-2', 'shared', 'grp')`); err != nil {
+		t.Errorf("expected duplicate name+group with a distinct key to be allowed after migration, got: %s", err)
+	}
+	// endpoint_key must still be unique.
+	if _, err := store.db.Exec(`INSERT INTO endpoints (endpoint_key, endpoint_name, endpoint_group) VALUES ('key-1', 'other', 'grp')`); err == nil {
+		t.Error("expected endpoint_key to remain UNIQUE after migration")
+	}
+	// The migration must be idempotent: running it again on the already-migrated table is a no-op.
+	if err := store.dropLegacyEndpointNameGroupUniqueConstraint(); err != nil {
+		t.Errorf("expected migration to be idempotent, got: %s", err)
+	}
+}


### PR DESCRIPTION
## Summary

The endpoint key is derived from group and name and is used as the endpoint's identity in storage and API routes, so renaming an endpoint or moving it between groups orphans its history. 

Added an optional `key` field to `Endpoint` and `ExternalEndpoint` that, when set, is used as the key instead (sanitized, without a group prefix), keeping identity stable across name and group changes.

The explicit key is threaded through `ExternalEndpoint.ToEndpoint()` so pushed results are stored under it, and the memory and SQL stores now report the actual key on `Status` rather than re-deriving it from group and name.

Fixes #1146.

## Checklist

- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable.
