### PR TITLE
fix(condition): truncate large resolved values in failure alert messages

### DIFF
--- a/config/endpoint/condition.go
+++ b/config/endpoint/condition.go
@@ -12,12 +12,12 @@ import (
 )
 
 const (
-	// maximumLengthBeforeTruncatingWhenComparedWithPattern is the maximum length an element being compared to a
-	// pattern can have.
+	// maximumResolvedValueDisplayLength is the maximum length a resolved value can have in a condition's display
+	// representation (e.g. in the message of a failed condition included in an alert) before being truncated.
 	//
 	// This is only used for aesthetic purposes; it does not influence whether the condition evaluation results in a
 	// success or a failure
-	maximumLengthBeforeTruncatingWhenComparedWithPattern = 25
+	maximumResolvedValueDisplayLength = 25
 )
 
 // Condition is a condition that needs to be met in order for an Endpoint to be considered healthy.
@@ -255,14 +255,30 @@ func formatDuration(d time.Duration) string {
 	return s
 }
 
+// truncateResolvedValueForDisplay truncates a resolved parameter's value for display purposes if it's too long.
+//
+// It leaves function literals (pat(...), any(...), len(...), has(...)) and INVALID markers untouched, since those
+// aren't resolved response data and truncating them would make the condition harder to understand.
+func truncateResolvedValueForDisplay(parameter, resolvedParameter string) string {
+	if len(resolvedParameter) <= maximumResolvedValueDisplayLength {
+		return resolvedParameter
+	}
+	if strings.HasSuffix(resolvedParameter, InvalidConditionElementSuffix) {
+		return resolvedParameter
+	}
+	if strings.HasSuffix(parameter, FunctionSuffix) && (strings.HasPrefix(parameter, PatternFunctionPrefix) || strings.HasPrefix(parameter, AnyFunctionPrefix) || strings.HasPrefix(parameter, LengthFunctionPrefix) || strings.HasPrefix(parameter, HasFunctionPrefix)) {
+		return resolvedParameter
+	}
+	return fmt.Sprintf("%.25s...(truncated)", resolvedParameter)
+}
+
 // prettify returns a string representation of a condition with its parameters resolved between parentheses
 func prettify(parameters []string, resolvedParameters []string, operator string) string {
-	// Handle pattern function truncation first
-	if strings.HasPrefix(parameters[0], PatternFunctionPrefix) && strings.HasSuffix(parameters[0], FunctionSuffix) && len(resolvedParameters[1]) > maximumLengthBeforeTruncatingWhenComparedWithPattern {
-		resolvedParameters[1] = fmt.Sprintf("%.25s...(truncated)", resolvedParameters[1])
-	}
-	if strings.HasPrefix(parameters[1], PatternFunctionPrefix) && strings.HasSuffix(parameters[1], FunctionSuffix) && len(resolvedParameters[0]) > maximumLengthBeforeTruncatingWhenComparedWithPattern {
-		resolvedParameters[0] = fmt.Sprintf("%.25s...(truncated)", resolvedParameters[0])
+	// Truncate any resolved value that's too long for display purposes, regardless of what it's being compared
+	// against (e.g. a plain [BODY] == "OK" condition against a huge HTML error page shouldn't dump the whole body
+	// into the alert message).
+	for i := range resolvedParameters {
+		resolvedParameters[i] = truncateResolvedValueForDisplay(parameters[i], resolvedParameters[i])
 	}
 	// Determine the state of each parameter
 	leftChanged := parameters[0] != resolvedParameters[0]

--- a/config/endpoint/condition_test.go
+++ b/config/endpoint/condition_test.go
@@ -640,6 +640,13 @@ func TestCondition_evaluate(t *testing.T) {
 			ExpectedOutput:  "pat(*<div id=\"user\">john.doe</div>*) == [BODY] (<!DOCTYPE html><html lang...(truncated))",
 		},
 		{
+			Name:            "body-large-response-failure-without-pattern",
+			Condition:       Condition("[BODY] == expected"),
+			Result:          &Result{Body: []byte(`<!DOCTYPE html><html lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /></head><body><div id="user">jane.doe</div></body></html>`)},
+			ExpectedSuccess: false,
+			ExpectedOutput:  "[BODY] (<!DOCTYPE html><html lang...(truncated)) == expected",
+		},
+		{
 			Name:            "pat-body-in-array",
 			Condition:       Condition("[BODY].data == pat(*Whatever*)"),
 			Result:          &Result{Body: []byte("{\"data\": [\"hello\", \"world\", \"Whatever\"]}")},


### PR DESCRIPTION
## Summary
Truncate large resolved values in condition display output — not just ones compared against `pat()`.

Previously `prettify()` only truncated a resolved value when the *other* side of the condition used `pat(...)`. A plain condition like `[BODY] == "OK"` failing against a large response body (e.g. a CDN returning a full HTML error page on 502/503/504) dumped the entire body into the condition's display string, which then gets embedded in failure alert messages — resulting in huge, unreadable Slack/RocketChat/etc. notifications.

This generalizes the existing truncation (25 chars + `...(truncated)`) to apply to any resolved value over the limit, regardless of what it's being compared against. Function literals (`pat()`, `any()`, `len()`, `has()`) and `(INVALID)` markers are left untouched since they aren't resolved response data.

## Checklist
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
