### PR TITLE
Option to persist response body in endpoint_results table

### DIFF
--- a/.github/workflows/publish-custom.yml
+++ b/.github/workflows/publish-custom.yml
@@ -14,6 +14,10 @@ on:
           - linux/arm/v7
           - linux/arm64
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   publish-custom:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -601,6 +601,7 @@ If at least one announcement is archived, a **Past Announcements** section will 
 | `storage.caching`                   | Whether to use write-through caching. Improves loading time for large dashboards. <br />Only supported if `storage.type` is `sqlite` or `postgres` | `false`    |
 | `storage.maximum-number-of-results` | The maximum number of results that an endpoint can have                                                                                            | `100`      |
 | `storage.maximum-number-of-events`  | The maximum number of events that an endpoint can have                                                                                             | `50`       |
+| `storage.persist-response-body`     | Whether to persist the (brotli-compressed) response body of each result. Only supported if `storage.type` is `postgres`                            | `false`    |
 
 The results for each endpoint health check as well as the data for uptime and the past events must be persisted
 so that they can be displayed on the dashboard. These parameters allow you to configure the storage in question.

--- a/config/endpoint/result.go
+++ b/config/endpoint/result.go
@@ -49,8 +49,8 @@ type Result struct {
 	//
 	// It is used for health evaluation as well as debugging purposes.
 	// Only populated when an endpoint has a condition or store mapping that reads it (see needsToReadBody).
-	// When using the SQL store with the postgres driver, it is persisted brotli-compressed in the
-	// endpoint_results.response BYTEA column.
+	// When using the SQL store with the postgres driver and storage.persist-response-body enabled, it is
+	// persisted brotli-compressed in the endpoint_results.response BYTEA column.
 	Body []byte `json:"-"`
 
 	///////////////////////////////////////////////////////////////////////

--- a/config/endpoint/result.go
+++ b/config/endpoint/result.go
@@ -47,8 +47,10 @@ type Result struct {
 
 	// Body is the response body
 	//
-	// Note that this field is not persisted in the storage.
 	// It is used for health evaluation as well as debugging purposes.
+	// Only populated when an endpoint has a condition or store mapping that reads it (see needsToReadBody).
+	// When using the SQL store with the postgres driver, it is persisted brotli-compressed in the
+	// endpoint_results.response BYTEA column.
 	Body []byte `json:"-"`
 
 	///////////////////////////////////////////////////////////////////////

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/TwiN/health v1.6.0
 	github.com/TwiN/logr v0.3.1
 	github.com/TwiN/whois v1.3.0
+	github.com/andybalholm/brotli v1.2.1
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
@@ -42,7 +43,6 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	github.com/42wim/httpsig v1.2.4 // indirect
-	github.com/andybalholm/brotli v1.2.1 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect

--- a/storage/config.go
+++ b/storage/config.go
@@ -36,6 +36,10 @@ type Config struct {
 
 	// MaximumNumberOfEvents is the number of events each endpoint should be able to provide
 	MaximumNumberOfEvents int `yaml:"maximum-number-of-events,omitempty"`
+
+	// PersistResponseBody is whether to persist the (brotli-compressed) response body of each result.
+	// Only supported if Config.Type is TypePostgres.
+	PersistResponseBody bool `yaml:"persist-response-body,omitempty"`
 }
 
 // ValidateAndSetDefaults validates the configuration and sets the default values (if applicable)

--- a/storage/store/sql/specific_postgres.go
+++ b/storage/store/sql/specific_postgres.go
@@ -66,7 +66,8 @@ func (s *Store) createPostgresSchema() error {
 			ip                     TEXT      NOT NULL,
 			duration               BIGINT    NOT NULL,
 			timestamp              TIMESTAMP NOT NULL,
-			suite_result_id        BIGINT    REFERENCES suite_results(suite_result_id) ON DELETE CASCADE
+			suite_result_id        BIGINT    REFERENCES suite_results(suite_result_id) ON DELETE CASCADE,
+			response               BYTEA
 		)
 	`)
 	if err != nil {
@@ -118,6 +119,8 @@ func (s *Store) createPostgresSchema() error {
 	_, _ = s.db.Exec(`ALTER TABLE endpoint_results ADD IF NOT EXISTS domain_expiration BIGINT NOT NULL DEFAULT 0`)
 	// Add suite_result_id to endpoint_results table for suite endpoint linkage
 	_, _ = s.db.Exec(`ALTER TABLE endpoint_results ADD COLUMN IF NOT EXISTS suite_result_id BIGINT REFERENCES suite_results(suite_result_id) ON DELETE CASCADE`)
+	// Add response to endpoint_results table to persist the brotli-compressed response body (only populated when a condition reads it)
+	_, _ = s.db.Exec(`ALTER TABLE endpoint_results ADD COLUMN IF NOT EXISTS response BYTEA`)
 	// Create index for suite_result_id
 	_, _ = s.db.Exec(`CREATE INDEX IF NOT EXISTS endpoint_results_suite_result_id_idx ON endpoint_results(suite_result_id)`)
 	// Create index for endpoint_result_conditions

--- a/storage/store/sql/sql.go
+++ b/storage/store/sql/sql.go
@@ -1,9 +1,11 @@
 package sql
 
 import (
+	"bytes"
 	"database/sql"
 	"errors"
 	"fmt"
+	"io"
 	"strconv"
 	"strings"
 	"time"
@@ -16,6 +18,7 @@ import (
 	"github.com/TwiN/gatus/v5/storage/store/common/paging"
 	"github.com/TwiN/gocache/v2"
 	"github.com/TwiN/logr"
+	"github.com/andybalholm/brotli"
 	_ "github.com/lib/pq"
 	_ "modernc.org/sqlite"
 )
@@ -621,30 +624,87 @@ func (s *Store) insertEndpointResult(tx *sql.Tx, endpointID int64, result *endpo
 // insertEndpointResultWithSuiteID inserts a result in the store with optional suite linkage
 func (s *Store) insertEndpointResultWithSuiteID(tx *sql.Tx, endpointID int64, result *endpoint.Result, suiteResultID *int64) error {
 	var endpointResultID int64
-	err := tx.QueryRow(
-		`
-			INSERT INTO endpoint_results (endpoint_id, success, errors, connected, status, dns_rcode, certificate_expiration, domain_expiration, hostname, ip, duration, timestamp, suite_result_id)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-			RETURNING endpoint_result_id
-		`,
-		endpointID,
-		result.Success,
-		strings.Join(result.Errors, arraySeparator),
-		result.Connected,
-		result.HTTPStatus,
-		result.DNSRCode,
-		result.CertificateExpiration,
-		result.DomainExpiration,
-		result.Hostname,
-		result.IP,
-		result.Duration,
-		result.Timestamp.UTC(),
-		suiteResultID,
-	).Scan(&endpointResultID)
+	var err error
+	// The response body is only persisted for the postgres driver, since the response column doesn't
+	// exist on the sqlite schema (it can grow the sqlite file significantly for embedded/lightweight deployments).
+	if s.driver == "postgres" {
+		var compressedResponse []byte
+		if compressedResponse, err = compressResponseBody(result.Body); err != nil {
+			logr.Errorf("[sql.insertEndpointResultWithSuiteID] Failed to compress response body: %s", err.Error())
+			compressedResponse = nil
+		}
+		err = tx.QueryRow(
+			`
+				INSERT INTO endpoint_results (endpoint_id, success, errors, connected, status, dns_rcode, certificate_expiration, domain_expiration, hostname, ip, duration, timestamp, suite_result_id, response)
+				VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+				RETURNING endpoint_result_id
+			`,
+			endpointID,
+			result.Success,
+			strings.Join(result.Errors, arraySeparator),
+			result.Connected,
+			result.HTTPStatus,
+			result.DNSRCode,
+			result.CertificateExpiration,
+			result.DomainExpiration,
+			result.Hostname,
+			result.IP,
+			result.Duration,
+			result.Timestamp.UTC(),
+			suiteResultID,
+			compressedResponse,
+		).Scan(&endpointResultID)
+	} else {
+		err = tx.QueryRow(
+			`
+				INSERT INTO endpoint_results (endpoint_id, success, errors, connected, status, dns_rcode, certificate_expiration, domain_expiration, hostname, ip, duration, timestamp, suite_result_id)
+				VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+				RETURNING endpoint_result_id
+			`,
+			endpointID,
+			result.Success,
+			strings.Join(result.Errors, arraySeparator),
+			result.Connected,
+			result.HTTPStatus,
+			result.DNSRCode,
+			result.CertificateExpiration,
+			result.DomainExpiration,
+			result.Hostname,
+			result.IP,
+			result.Duration,
+			result.Timestamp.UTC(),
+			suiteResultID,
+		).Scan(&endpointResultID)
+	}
 	if err != nil {
 		return err
 	}
 	return s.insertConditionResults(tx, endpointResultID, result.ConditionResults)
+}
+
+// compressResponseBody compresses a response body using brotli so it can be persisted in the response BYTEA column
+func compressResponseBody(body []byte) ([]byte, error) {
+	if len(body) == 0 {
+		return nil, nil
+	}
+	var buf bytes.Buffer
+	writer := brotli.NewWriter(&buf)
+	if _, err := writer.Write(body); err != nil {
+		_ = writer.Close()
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// decompressResponseBody decompresses a response body persisted in the response BYTEA column
+func decompressResponseBody(compressed []byte) ([]byte, error) {
+	if len(compressed) == 0 {
+		return nil, nil
+	}
+	return io.ReadAll(brotli.NewReader(bytes.NewReader(compressed)))
 }
 
 func (s *Store) insertConditionResults(tx *sql.Tx, endpointResultID int64, conditionResults []*endpoint.ConditionResult) error {
@@ -789,9 +849,14 @@ func (s *Store) getEndpointEventsByEndpointID(tx *sql.Tx, endpointID int64, page
 }
 
 func (s *Store) getEndpointResultsByEndpointID(tx *sql.Tx, endpointID int64, page, pageSize int) (results []*endpoint.Result, err error) {
+	// The response column only exists on the postgres schema (see insertEndpointResultWithSuiteID)
+	columns := "endpoint_result_id, success, errors, connected, status, dns_rcode, certificate_expiration, domain_expiration, hostname, ip, duration, timestamp"
+	if s.driver == "postgres" {
+		columns += ", response"
+	}
 	rows, err := tx.Query(
 		`
-			SELECT endpoint_result_id, success, errors, connected, status, dns_rcode, certificate_expiration, domain_expiration, hostname, ip, duration, timestamp
+			SELECT `+columns+`
 			FROM endpoint_results
 			WHERE endpoint_id = $1
 			ORDER BY endpoint_result_id DESC -- Normally, we'd sort by timestamp, but sorting by endpoint_result_id is faster
@@ -809,13 +874,24 @@ func (s *Store) getEndpointResultsByEndpointID(tx *sql.Tx, endpointID int64, pag
 		result := &endpoint.Result{}
 		var id int64
 		var joinedErrors string
-		err = rows.Scan(&id, &result.Success, &joinedErrors, &result.Connected, &result.HTTPStatus, &result.DNSRCode, &result.CertificateExpiration, &result.DomainExpiration, &result.Hostname, &result.IP, &result.Duration, &result.Timestamp)
+		var compressedResponse []byte
+		scanArgs := []any{&id, &result.Success, &joinedErrors, &result.Connected, &result.HTTPStatus, &result.DNSRCode, &result.CertificateExpiration, &result.DomainExpiration, &result.Hostname, &result.IP, &result.Duration, &result.Timestamp}
+		if s.driver == "postgres" {
+			scanArgs = append(scanArgs, &compressedResponse)
+		}
+		err = rows.Scan(scanArgs...)
 		if err != nil {
 			logr.Errorf("[sql.getEndpointResultsByEndpointID] Silently failed to retrieve endpoint result for endpointID=%d: %s", endpointID, err.Error())
 			err = nil
 		}
 		if len(joinedErrors) != 0 {
 			result.Errors = strings.Split(joinedErrors, arraySeparator)
+		}
+		if len(compressedResponse) != 0 {
+			if result.Body, err = decompressResponseBody(compressedResponse); err != nil {
+				logr.Errorf("[sql.getEndpointResultsByEndpointID] Failed to decompress response body for endpointID=%d: %s", endpointID, err.Error())
+				err = nil
+			}
 		}
 		// This is faster than using a subselect
 		results = append([]*endpoint.Result{result}, results...)

--- a/storage/store/sql/sql.go
+++ b/storage/store/sql/sql.go
@@ -66,6 +66,16 @@ type Store struct {
 
 	maximumNumberOfResults int // maximum number of results that an endpoint can have
 	maximumNumberOfEvents  int // maximum number of events that an endpoint can have
+
+	// persistResponseBody is whether to persist the (brotli-compressed) response body in the endpoint_results table.
+	// Only takes effect when driver is postgres, since the response column doesn't exist on the sqlite schema.
+	persistResponseBody bool
+}
+
+// SetPersistResponseBody sets whether to persist the response body in the endpoint_results table.
+// Only takes effect when the store's driver is postgres.
+func (s *Store) SetPersistResponseBody(persist bool) {
+	s.persistResponseBody = persist
 }
 
 // NewStore initializes the database and creates the schema if it doesn't already exist in the path specified
@@ -625,9 +635,9 @@ func (s *Store) insertEndpointResult(tx *sql.Tx, endpointID int64, result *endpo
 func (s *Store) insertEndpointResultWithSuiteID(tx *sql.Tx, endpointID int64, result *endpoint.Result, suiteResultID *int64) error {
 	var endpointResultID int64
 	var err error
-	// The response body is only persisted for the postgres driver, since the response column doesn't
-	// exist on the sqlite schema (it can grow the sqlite file significantly for embedded/lightweight deployments).
-	if s.driver == "postgres" {
+	// The response body is only persisted for the postgres driver (and only when explicitly enabled via
+	// storage.persist-response-body), since the response column doesn't exist on the sqlite schema.
+	if s.driver == "postgres" && s.persistResponseBody {
 		var compressedResponse []byte
 		if compressedResponse, err = compressResponseBody(result.Body); err != nil {
 			logr.Errorf("[sql.insertEndpointResultWithSuiteID] Failed to compress response body: %s", err.Error())

--- a/storage/store/store.go
+++ b/storage/store/store.go
@@ -138,10 +138,13 @@ func Initialize(cfg *storage.Config) error {
 	ctx, cancelFunc = context.WithCancel(context.Background())
 	switch cfg.Type {
 	case storage.TypeSQLite, storage.TypePostgres:
-		store, err = sql.NewStore(string(cfg.Type), cfg.Path, cfg.Caching, cfg.MaximumNumberOfResults, cfg.MaximumNumberOfEvents)
+		var sqlStore *sql.Store
+		sqlStore, err = sql.NewStore(string(cfg.Type), cfg.Path, cfg.Caching, cfg.MaximumNumberOfResults, cfg.MaximumNumberOfEvents)
 		if err != nil {
 			return err
 		}
+		sqlStore.SetPersistResponseBody(cfg.PersistResponseBody)
+		store = sqlStore
 	case storage.TypeMemory:
 		fallthrough
 	default:


### PR DESCRIPTION
Add storage option "**persist-response-body**" (default value is false).
This option allow to store response body **only if storage is Postgres**.
Body is stored in a BYTEA column as data are compressed with Brotli algorithm.
This could be useful for auditability purpose.