### PR TITLE
fix(client): enable HTTP/2

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -231,6 +231,9 @@ func (c *Config) getHTTPClient() *http.Client {
 				MaxIdleConnsPerHost: 20,
 				Proxy:               http.ProxyFromEnvironment,
 				TLSClientConfig:     tlsConfig,
+				// net/http disables HTTP/2 whenever TLSClientConfig is set,
+				// so HTTP/2-only endpoints answer 505 without this.
+				ForceAttemptHTTP2: true,
 			},
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
 				if c.IgnoreRedirect {


### PR DESCRIPTION
## Summary
net/http disables HTTP/2 when TLSClientConfig is set, so Gatus only ever speaks HTTP/1.1. HTTP/2-only endpoints answer 505 and the endpoint can never pass — a Quad9's DoH check is a example that fails with 505 errors.

no ForceAttemptHTTP2:  505 / connection reset
ForceAttemptHTTP2:     HTTP/2.0 -> 200 OK
go test ./client/ passes.

You can test this check by configuring the following:
```
- name: Quad9 DoH upstream
      interval: 1m
      group: dns
      url: "https://dns10.quad9.net/dns-query?dns=AAABAAABAAAAAAAAA3d3dwdleGFtcGxlA2NvbQAAAQAB"
      client:
        timeout: 5s
      conditions:
        - "[STATUS] == 200"
        - "len([BODY]) > 0"
        - "[RESPONSE_TIME] < 1000"
```

## Checklist
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
