### PR TITLE
feat(alerting): Add Bark alerting provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,7 +839,7 @@ endpoints:
 | Parameter                  | Description                                                                                                                             | Default |
 |:---------------------------|:----------------------------------------------------------------------------------------------------------------------------------------|:--------|
 | `alerting.awsses`          | Configuration for alerts of type `awsses`. <br />See [Configuring AWS SES alerts](#configuring-aws-ses-alerts).                         | `{}`    |
-| `alerting.bark`            | Configuration for alerts of type `bark`. <br />See [Configuring Bark alerts](#configuring-bark-alerts).                                | `{}`    |
+| `alerting.bark`            | Configuration for alerts of type `bark`. <br />See [Configuring Bark alerts](#configuring-bark-alerts).                                 | `{}`    |
 | `alerting.clickup`         | Configuration for alerts of type `clickup`. <br />See [Configuring ClickUp alerts](#configuring-clickup-alerts).                        | `{}`    |
 | `alerting.custom`          | Configuration for custom actions on failure or alerts. <br />See [Configuring Custom alerts](#configuring-custom-alerts).               | `{}`    |
 | `alerting.datadog`         | Configuration for alerts of type `datadog`. <br />See [Configuring Datadog alerts](#configuring-datadog-alerts).                        | `{}`    |

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Have any feedback or questions? [Create a discussion](https://github.com/TwiN/ga
   - [Tunneling](#tunneling)
   - [Alerting](#alerting)
     - [Configuring AWS SES alerts](#configuring-aws-ses-alerts)
+    - [Configuring Bark alerts](#configuring-bark-alerts)
     - [Configuring ClickUp alerts](#configuring-clickup-alerts)
     - [Configuring Datadog alerts](#configuring-datadog-alerts)
     - [Configuring Discord alerts](#configuring-discord-alerts)
@@ -838,6 +839,7 @@ endpoints:
 | Parameter                  | Description                                                                                                                             | Default |
 |:---------------------------|:----------------------------------------------------------------------------------------------------------------------------------------|:--------|
 | `alerting.awsses`          | Configuration for alerts of type `awsses`. <br />See [Configuring AWS SES alerts](#configuring-aws-ses-alerts).                         | `{}`    |
+| `alerting.bark`            | Configuration for alerts of type `bark`. <br />See [Configuring Bark alerts](#configuring-bark-alerts).                                | `{}`    |
 | `alerting.clickup`         | Configuration for alerts of type `clickup`. <br />See [Configuring ClickUp alerts](#configuring-clickup-alerts).                        | `{}`    |
 | `alerting.custom`          | Configuration for custom actions on failure or alerts. <br />See [Configuring Custom alerts](#configuring-custom-alerts).               | `{}`    |
 | `alerting.datadog`         | Configuration for alerts of type `datadog`. <br />See [Configuring Datadog alerts](#configuring-datadog-alerts).                        | `{}`    |
@@ -921,6 +923,64 @@ endpoints:
 If the `access-key-id` and `secret-access-key` are not defined Gatus will fall back to IAM authentication.
 
 Make sure you have the ability to use `ses:SendEmail`.
+
+
+#### Configuring Bark alerts
+
+| Parameter                            | Description                                                                                                                       | Default                 |
+|:-------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------|:------------------------|
+| `alerting.bark`                      | Configuration for alerts of type `bark`                                                                                           | `{}`                    |
+| `alerting.bark.server-url`           | Base URL of the official or self-hosted Bark server. A URL ending in `/push` is also accepted                                    | `https://api.day.app`   |
+| `alerting.bark.device-key`           | Bark device key                                                                                                                   | Required `""`           |
+| `alerting.bark.title`                | Notification title. When empty, Gatus uses `Gatus: <endpoint>`                                                                    | `""`                    |
+| `alerting.bark.group`                | Bark notification group                                                                                                           | `""`                    |
+| `alerting.bark.sound`                | Bark notification sound                                                                                                           | `""`                    |
+| `alerting.bark.icon`                 | URL of the notification icon                                                                                                      | `""`                    |
+| `alerting.bark.url`                  | URL or URL scheme opened when the notification is selected                                                                        | `""`                    |
+| `alerting.bark.level`                | Bark notification level: `critical`, `active`, `timeSensitive`, or `passive`                                                     | `""`                    |
+| `alerting.bark.default-alert`        | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert)                                       | N/A                     |
+| `alerting.bark.overrides`            | List of overrides selected by endpoint group                                                                                       | `[]`                    |
+| `alerting.bark.overrides[].group`    | Endpoint group for which the configuration is overridden                                                                          | `""`                    |
+| `alerting.bark.overrides[].*`        | See `alerting.bark.*` parameters, except `group`, which selects the endpoint group and inherits the default Bark notification group | `{}`                    |
+
+```yaml
+alerting:
+  bark:
+    server-url: "https://api.day.app"
+    device-key: "${BARK_DEVICE_KEY}"
+    group: "gatus"
+    default-alert:
+      failure-threshold: 3
+      success-threshold: 2
+      send-on-resolved: true
+    overrides:
+      - group: "production"
+        sound: "alarm"
+        level: "timeSensitive"
+
+endpoints:
+  - name: website
+    group: production
+    interval: 30s
+    url: "https://twin.sh/health"
+    conditions:
+      - "[STATUS] == 200"
+    alerts:
+      - type: bark
+        description: "health check failed"
+        provider-override:
+          title: "Production website"
+          group: "gatus-production"
+          level: "critical"
+```
+
+The device key is a push credential: anyone who has it can send notifications to the device. Keep it out of public
+configuration files and inject it through an environment variable such as `BARK_DEVICE_KEY`. Use HTTPS for remote
+Bark servers; an HTTP connection sends the device key without transport encryption.
+
+See the [Bark project](https://github.com/finb/bark) and the
+[Bark server API V2 documentation](https://github.com/Finb/bark-server/blob/master/docs/API_V2.md) for server and
+notification details.
 
 
 #### Configuring ClickUp alerts

--- a/alerting/alert/type.go
+++ b/alerting/alert/type.go
@@ -8,6 +8,9 @@ const (
 	// TypeAWSSES is the Type for the awsses alerting provider
 	TypeAWSSES Type = "aws-ses"
 
+	// TypeBark is the Type for the bark alerting provider
+	TypeBark Type = "bark"
+
 	// TypeClickUp is the Type for the clickup alerting provider
 	TypeClickUp Type = "clickup"
 

--- a/alerting/config.go
+++ b/alerting/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/TwiN/gatus/v5/alerting/alert"
 	"github.com/TwiN/gatus/v5/alerting/provider"
 	"github.com/TwiN/gatus/v5/alerting/provider/awsses"
+	"github.com/TwiN/gatus/v5/alerting/provider/bark"
 	"github.com/TwiN/gatus/v5/alerting/provider/clickup"
 	"github.com/TwiN/gatus/v5/alerting/provider/custom"
 	"github.com/TwiN/gatus/v5/alerting/provider/datadog"
@@ -54,6 +55,9 @@ import (
 type Config struct {
 	// AWSSimpleEmailService is the configuration for the aws-ses alerting provider
 	AWSSimpleEmailService *awsses.AlertProvider `yaml:"aws-ses,omitempty"`
+
+	// Bark is the configuration for the bark alerting provider
+	Bark *bark.AlertProvider `yaml:"bark,omitempty"`
 
 	// ClickUp is the configuration for the clickup alerting provider
 	ClickUp *clickup.AlertProvider `yaml:"clickup,omitempty"`

--- a/alerting/provider/bark/bark.go
+++ b/alerting/provider/bark/bark.go
@@ -1,0 +1,330 @@
+package bark
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"unicode"
+
+	"github.com/TwiN/gatus/v5/alerting/alert"
+	"github.com/TwiN/gatus/v5/client"
+	"github.com/TwiN/gatus/v5/config/endpoint"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	DefaultServerURL         = "https://api.day.app"
+	maxErrorResponseBodySize = 64 * 1024
+)
+
+var (
+	ErrDeviceKeyNotSet           = errors.New("device key not set")
+	ErrInvalidServerURL          = errors.New("invalid server URL")
+	ErrInvalidLevel              = errors.New("invalid notification level")
+	ErrGroupOverrideWithoutGroup = errors.New("group override without group")
+	ErrDuplicateGroupOverride    = errors.New("duplicate group override")
+	ErrCrossOriginRedirect       = errors.New("cross-origin redirect not allowed")
+)
+
+type Config struct {
+	ServerURL string `yaml:"server-url,omitempty"`
+	DeviceKey string `yaml:"device-key,omitempty"`
+	Title     string `yaml:"title,omitempty"`
+	Group     string `yaml:"group,omitempty"`
+	Sound     string `yaml:"sound,omitempty"`
+	Icon      string `yaml:"icon,omitempty"`
+	URL       string `yaml:"url,omitempty"`
+	Level     string `yaml:"level,omitempty"`
+}
+
+func (cfg *Config) Validate() error {
+	if cfg.ServerURL == "" {
+		cfg.ServerURL = DefaultServerURL
+	}
+	if err := cfg.validateOptionalFields(); err != nil {
+		return err
+	}
+	if cfg.DeviceKey == "" {
+		return ErrDeviceKeyNotSet
+	}
+	return nil
+}
+
+func (cfg *Config) validateOptionalFields() error {
+	if cfg.ServerURL != "" {
+		parsedURL, err := url.Parse(cfg.ServerURL)
+		if err != nil || strings.ContainsAny(cfg.ServerURL, "?#") || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") || parsedURL.Host == "" || parsedURL.RawQuery != "" || parsedURL.Fragment != "" {
+			return ErrInvalidServerURL
+		}
+		cfg.ServerURL = strings.TrimRight(cfg.ServerURL, "/")
+	}
+	if cfg.Level != "" && cfg.Level != "critical" && cfg.Level != "active" && cfg.Level != "timeSensitive" && cfg.Level != "passive" {
+		return ErrInvalidLevel
+	}
+	return nil
+}
+
+func (cfg *Config) Merge(override *Config) {
+	if override == nil {
+		return
+	}
+	if override.ServerURL != "" {
+		cfg.ServerURL = override.ServerURL
+	}
+	if override.DeviceKey != "" {
+		cfg.DeviceKey = override.DeviceKey
+	}
+	if override.Title != "" {
+		cfg.Title = override.Title
+	}
+	if override.Group != "" {
+		cfg.Group = override.Group
+	}
+	if override.Sound != "" {
+		cfg.Sound = override.Sound
+	}
+	if override.Icon != "" {
+		cfg.Icon = override.Icon
+	}
+	if override.URL != "" {
+		cfg.URL = override.URL
+	}
+	if override.Level != "" {
+		cfg.Level = override.Level
+	}
+}
+
+type AlertProvider struct {
+	DefaultConfig Config       `yaml:",inline"`
+	DefaultAlert  *alert.Alert `yaml:"default-alert,omitempty"`
+	Overrides     []Override   `yaml:"overrides,omitempty"`
+}
+
+type Override struct {
+	Group  string `yaml:"-"`
+	Config `yaml:"-"`
+}
+
+func (override *Override) UnmarshalYAML(value *yaml.Node) error {
+	var selector struct {
+		Group string `yaml:"group"`
+	}
+	if err := value.Decode(&selector); err != nil {
+		return err
+	}
+	configNode := mappingNodeWithoutKey(value, "group")
+	var config Config
+	if err := configNode.Decode(&config); err != nil {
+		return err
+	}
+	override.Group = selector.Group
+	override.Config = config
+	return nil
+}
+
+func (override Override) MarshalYAML() (any, error) {
+	var configNode yaml.Node
+	if err := configNode.Encode(override.Config); err != nil {
+		return nil, err
+	}
+	configNode = mappingNodeWithoutKey(&configNode, "group")
+	configNode.Content = append([]*yaml.Node{
+		{Kind: yaml.ScalarNode, Value: "group"},
+		{Kind: yaml.ScalarNode, Value: override.Group},
+	}, configNode.Content...)
+	return &configNode, nil
+}
+
+func mappingNodeWithoutKey(value *yaml.Node, key string) yaml.Node {
+	result := *value
+	result.Content = make([]*yaml.Node, 0, len(value.Content))
+	for i := 0; i+1 < len(value.Content); i += 2 {
+		if value.Content[i].Value != key {
+			result.Content = append(result.Content, value.Content[i], value.Content[i+1])
+		}
+	}
+	return result
+}
+
+type Body struct {
+	DeviceKey string `json:"device_key"`
+	Title     string `json:"title"`
+	Body      string `json:"body"`
+	Group     string `json:"group,omitempty"`
+	Sound     string `json:"sound,omitempty"`
+	Icon      string `json:"icon,omitempty"`
+	URL       string `json:"url,omitempty"`
+	Level     string `json:"level,omitempty"`
+}
+
+func (provider *AlertProvider) Validate() error {
+	if err := provider.DefaultConfig.Validate(); err != nil {
+		return err
+	}
+	groups := make(map[string]struct{}, len(provider.Overrides))
+	for i := range provider.Overrides {
+		override := &provider.Overrides[i]
+		if override.Group == "" {
+			return ErrGroupOverrideWithoutGroup
+		}
+		if _, exists := groups[override.Group]; exists {
+			return ErrDuplicateGroupOverride
+		}
+		if err := override.Config.validateOptionalFields(); err != nil {
+			return err
+		}
+		groups[override.Group] = struct{}{}
+	}
+	return nil
+}
+
+func (provider *AlertProvider) Send(ep *endpoint.Endpoint, alertConfig *alert.Alert, result *endpoint.Result, resolved bool) error {
+	cfg, err := provider.GetConfig(ep.Group, alertConfig)
+	if err != nil {
+		return err
+	}
+	request, err := http.NewRequest(http.MethodPost, buildPushURL(cfg.ServerURL), bytes.NewReader(provider.buildRequestBody(cfg, ep, alertConfig, result, resolved)))
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	httpClient := *client.GetHTTPClient(nil)
+	sharedRedirectPolicy := httpClient.CheckRedirect
+	httpClient.CheckRedirect = func(redirectedRequest *http.Request, previousRequests []*http.Request) error {
+		if len(previousRequests) != 0 && !sameOrigin(previousRequests[0].URL, redirectedRequest.URL) {
+			return ErrCrossOriginRedirect
+		}
+		if sharedRedirectPolicy != nil {
+			return sharedRedirectPolicy(redirectedRequest, previousRequests)
+		}
+		if len(previousRequests) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+	response, err := httpClient.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	if response.StatusCode >= http.StatusBadRequest {
+		body, _ := io.ReadAll(io.LimitReader(response.Body, maxErrorResponseBodySize+1))
+		truncated := len(body) > maxErrorResponseBodySize
+		if truncated {
+			body = body[:maxErrorResponseBodySize]
+		}
+		responseBody := sanitizeResponseBody(string(body), cfg.DeviceKey)
+		if truncated {
+			responseBody += " [truncated]"
+		}
+		return fmt.Errorf("call to Bark alert provider returned %s: %s", response.Status, responseBody)
+	}
+	return nil
+}
+
+func sanitizeResponseBody(responseBody, deviceKey string) string {
+	responseBody = strings.ReplaceAll(responseBody, deviceKey, "[REDACTED]")
+	return strings.Map(func(character rune) rune {
+		if unicode.IsControl(character) || unicode.In(character, unicode.Zl, unicode.Zp) {
+			return ' '
+		}
+		return character
+	}, responseBody)
+}
+
+func sameOrigin(first, second *url.URL) bool {
+	return strings.EqualFold(first.Scheme, second.Scheme) &&
+		strings.EqualFold(first.Hostname(), second.Hostname()) &&
+		effectivePort(first) == effectivePort(second)
+}
+
+func effectivePort(target *url.URL) string {
+	if port := target.Port(); port != "" {
+		return port
+	}
+	if target.Scheme == "http" {
+		return "80"
+	}
+	if target.Scheme == "https" {
+		return "443"
+	}
+	return ""
+}
+
+func buildPushURL(serverURL string) string {
+	if strings.HasSuffix(serverURL, "/push") {
+		return serverURL
+	}
+	return serverURL + "/push"
+}
+
+func (provider *AlertProvider) GetDefaultAlert() *alert.Alert {
+	return provider.DefaultAlert
+}
+
+func (provider *AlertProvider) buildRequestBody(cfg *Config, ep *endpoint.Endpoint, alertConfig *alert.Alert, result *endpoint.Result, resolved bool) []byte {
+	title := cfg.Title
+	if title == "" {
+		title = "Gatus: " + ep.DisplayName()
+	}
+	var message string
+	if resolved {
+		message = fmt.Sprintf("An alert has been resolved after passing successfully %d time(s) in a row", alertConfig.SuccessThreshold)
+	} else {
+		message = fmt.Sprintf("An alert has been triggered due to having failed %d time(s) in a row", alertConfig.FailureThreshold)
+	}
+	if description := alertConfig.GetDescription(); description != "" {
+		message += " with the following description: " + description
+	}
+	if result != nil {
+		for _, conditionResult := range result.ConditionResults {
+			prefix := "🔴"
+			if conditionResult.Success {
+				prefix = "🟢"
+			}
+			message += fmt.Sprintf("\n%s %s", prefix, conditionResult.Condition)
+		}
+	}
+	body, _ := json.Marshal(Body{
+		DeviceKey: cfg.DeviceKey,
+		Title:     title,
+		Body:      message,
+		Group:     cfg.Group,
+		Sound:     cfg.Sound,
+		Icon:      cfg.Icon,
+		URL:       cfg.URL,
+		Level:     cfg.Level,
+	})
+	return body
+}
+
+func (provider *AlertProvider) GetConfig(group string, alertConfig *alert.Alert) (*Config, error) {
+	cfg := provider.DefaultConfig
+	for i := range provider.Overrides {
+		if provider.Overrides[i].Group == group {
+			cfg.Merge(&provider.Overrides[i].Config)
+			break
+		}
+	}
+	if alertConfig != nil && len(alertConfig.ProviderOverride) != 0 {
+		override := Config{}
+		if err := yaml.Unmarshal(alertConfig.ProviderOverrideAsBytes(), &override); err != nil {
+			return nil, err
+		}
+		cfg.Merge(&override)
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func (provider *AlertProvider) ValidateOverrides(group string, alertConfig *alert.Alert) error {
+	_, err := provider.GetConfig(group, alertConfig)
+	return err
+}

--- a/alerting/provider/bark/bark_test.go
+++ b/alerting/provider/bark/bark_test.go
@@ -1,0 +1,567 @@
+package bark
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/TwiN/gatus/v5/alerting/alert"
+	"github.com/TwiN/gatus/v5/client"
+	"github.com/TwiN/gatus/v5/config/endpoint"
+	"gopkg.in/yaml.v3"
+)
+
+func TestConfigValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		config        Config
+		expectedURL   string
+		expectedError error
+	}{
+		{
+			name:        "minimal configuration uses default server URL",
+			config:      Config{DeviceKey: "device-key"},
+			expectedURL: DefaultServerURL,
+		},
+		{
+			name:          "device key is required",
+			config:        Config{},
+			expectedError: ErrDeviceKeyNotSet,
+		},
+		{
+			name:          "server URL requires HTTP or HTTPS",
+			config:        Config{ServerURL: "ftp://example.com", DeviceKey: "device-key"},
+			expectedError: ErrInvalidServerURL,
+		},
+		{
+			name:          "server URL requires a host",
+			config:        Config{ServerURL: "https:///push", DeviceKey: "device-key"},
+			expectedError: ErrInvalidServerURL,
+		},
+		{
+			name:          "server URL rejects query",
+			config:        Config{ServerURL: "https://example.com?key=value", DeviceKey: "device-key"},
+			expectedError: ErrInvalidServerURL,
+		},
+		{
+			name:          "server URL rejects empty query",
+			config:        Config{ServerURL: "https://example.com?", DeviceKey: "device-key"},
+			expectedError: ErrInvalidServerURL,
+		},
+		{
+			name:          "server URL rejects fragment",
+			config:        Config{ServerURL: "https://example.com/#fragment", DeviceKey: "device-key"},
+			expectedError: ErrInvalidServerURL,
+		},
+		{
+			name:          "server URL rejects empty fragment",
+			config:        Config{ServerURL: "https://example.com#", DeviceKey: "device-key"},
+			expectedError: ErrInvalidServerURL,
+		},
+		{
+			name:        "server URL is normalized",
+			config:      Config{ServerURL: "https://example.com/bark///", DeviceKey: "device-key"},
+			expectedURL: "https://example.com/bark",
+		},
+		{
+			name:        "critical level is valid",
+			config:      Config{DeviceKey: "device-key", Level: "critical"},
+			expectedURL: DefaultServerURL,
+		},
+		{
+			name:        "active level is valid",
+			config:      Config{DeviceKey: "device-key", Level: "active"},
+			expectedURL: DefaultServerURL,
+		},
+		{
+			name:        "timeSensitive level is valid",
+			config:      Config{DeviceKey: "device-key", Level: "timeSensitive"},
+			expectedURL: DefaultServerURL,
+		},
+		{
+			name:        "passive level is valid",
+			config:      Config{DeviceKey: "device-key", Level: "passive"},
+			expectedURL: DefaultServerURL,
+		},
+		{
+			name:          "unknown level is invalid",
+			config:        Config{DeviceKey: "device-key", Level: "urgent"},
+			expectedError: ErrInvalidLevel,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			err := test.config.Validate()
+			if !errors.Is(err, test.expectedError) {
+				t.Fatalf("expected error %v, got %v", test.expectedError, err)
+			}
+			if test.expectedURL != "" && test.config.ServerURL != test.expectedURL {
+				t.Errorf("expected server URL %q, got %q", test.expectedURL, test.config.ServerURL)
+			}
+		})
+	}
+}
+
+func TestAlertProviderValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		provider      AlertProvider
+		expectedError error
+	}{
+		{
+			name:     "valid default and partial override",
+			provider: AlertProvider{DefaultConfig: Config{DeviceKey: "device-key"}, Overrides: []Override{{Group: "production", Config: Config{Level: "critical"}}}},
+		},
+		{
+			name:          "override group is required",
+			provider:      AlertProvider{DefaultConfig: Config{DeviceKey: "device-key"}, Overrides: []Override{{Config: Config{Level: "critical"}}}},
+			expectedError: ErrGroupOverrideWithoutGroup,
+		},
+		{
+			name:          "override group must be unique",
+			provider:      AlertProvider{DefaultConfig: Config{DeviceKey: "device-key"}, Overrides: []Override{{Group: "production"}, {Group: "production"}}},
+			expectedError: ErrDuplicateGroupOverride,
+		},
+		{
+			name:          "override server URL is validated",
+			provider:      AlertProvider{DefaultConfig: Config{DeviceKey: "device-key"}, Overrides: []Override{{Group: "production", Config: Config{ServerURL: "mailto:invalid"}}}},
+			expectedError: ErrInvalidServerURL,
+		},
+		{
+			name:          "override level is validated",
+			provider:      AlertProvider{DefaultConfig: Config{DeviceKey: "device-key"}, Overrides: []Override{{Group: "production", Config: Config{Level: "urgent"}}}},
+			expectedError: ErrInvalidLevel,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if err := test.provider.Validate(); !errors.Is(err, test.expectedError) {
+				t.Fatalf("expected error %v, got %v", test.expectedError, err)
+			}
+		})
+	}
+}
+
+func TestOverrideYAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := AlertProvider{
+		DefaultConfig: Config{DeviceKey: "device-key", Group: "default-notification-group"},
+		Overrides: []Override{{
+			Group: "production",
+			Config: Config{
+				Title: "Production",
+				Group: "must-not-shadow-selector",
+				Level: "critical",
+			},
+		}},
+	}
+	encoded, err := yaml.Marshal(original)
+	if err != nil {
+		t.Fatal("expected Bark override to marshal, got", err)
+	}
+	var decoded AlertProvider
+	if err := yaml.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatal("expected marshaled Bark override to unmarshal, got", err)
+	}
+	if len(decoded.Overrides) != 1 {
+		t.Fatalf("expected one Bark override, got %d", len(decoded.Overrides))
+	}
+	if decoded.DefaultConfig.Group != "default-notification-group" {
+		t.Errorf("expected default Bark notification group to survive YAML round trip, got %q", decoded.DefaultConfig.Group)
+	}
+	actual := decoded.Overrides[0]
+	if actual.Group != "production" || actual.Title != "Production" || actual.Level != "critical" {
+		t.Errorf("unexpected Bark override after YAML round trip: %#v", actual)
+	}
+	if actual.Config.Group != "" {
+		t.Errorf("expected override group to remain an endpoint selector, got Bark notification group %q", actual.Config.Group)
+	}
+}
+
+func TestAlertProviderGetConfig(t *testing.T) {
+	t.Parallel()
+
+	provider := AlertProvider{
+		DefaultConfig: Config{
+			ServerURL: "https://default.example.com",
+			DeviceKey: "default-device-key",
+			Title:     "Default title",
+			Group:     "default-group",
+			Sound:     "default-sound",
+			Icon:      "https://default.example.com/icon.png",
+			URL:       "https://default.example.com/details",
+			Level:     "active",
+		},
+		Overrides: []Override{
+			{
+				Group: "production",
+				Config: Config{
+					ServerURL: "https://group.example.com/",
+					DeviceKey: "group-device-key",
+					Title:     "Group title",
+					Sound:     "group-sound",
+					Icon:      "https://group.example.com/icon.png",
+					URL:       "https://group.example.com/details",
+					Level:     "timeSensitive",
+				},
+			},
+		},
+	}
+	alertConfig := &alert.Alert{
+		ProviderOverride: map[string]any{
+			"device-key": "alert-device-key",
+			"title":      "Alert title",
+			"group":      "alert-group",
+			"sound":      "alert-sound",
+			"level":      "critical",
+		},
+	}
+
+	actual, err := provider.GetConfig("production", alertConfig)
+	if err != nil {
+		t.Fatal("expected configuration to be valid, got", err)
+	}
+	expected := &Config{
+		ServerURL: "https://group.example.com",
+		DeviceKey: "alert-device-key",
+		Title:     "Alert title",
+		Group:     "alert-group",
+		Sound:     "alert-sound",
+		Icon:      "https://group.example.com/icon.png",
+		URL:       "https://group.example.com/details",
+		Level:     "critical",
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("expected configuration %#v, got %#v", expected, actual)
+	}
+	withoutAlertOverride, err := provider.GetConfig("production", &alert.Alert{})
+	if err != nil {
+		t.Fatal("expected group configuration to be valid, got", err)
+	}
+	if withoutAlertOverride.Group != "default-group" {
+		t.Errorf("expected group override to inherit Bark notification group, got %q", withoutAlertOverride.Group)
+	}
+}
+
+func TestAlertProviderGetConfigValidatesMergedConfiguration(t *testing.T) {
+	t.Parallel()
+
+	provider := AlertProvider{DefaultConfig: Config{DeviceKey: "device-key"}}
+	alertConfig := &alert.Alert{ProviderOverride: map[string]any{"level": "urgent"}}
+
+	_, err := provider.GetConfig("", alertConfig)
+	if !errors.Is(err, ErrInvalidLevel) {
+		t.Fatalf("expected error %v, got %v", ErrInvalidLevel, err)
+	}
+}
+
+func TestAlertProviderGetConfigRejectsInvalidProviderOverrideType(t *testing.T) {
+	t.Parallel()
+
+	provider := AlertProvider{DefaultConfig: Config{DeviceKey: "device-key"}}
+	alertConfig := &alert.Alert{ProviderOverride: map[string]any{"server-url": []string{"https://example.com"}}}
+
+	if _, err := provider.GetConfig("", alertConfig); err == nil {
+		t.Fatal("expected invalid provider override type to return an error")
+	}
+}
+
+func TestAlertProviderGetDefaultAlert(t *testing.T) {
+	t.Parallel()
+
+	defaultAlert := &alert.Alert{FailureThreshold: 4}
+	if actual := (&AlertProvider{DefaultAlert: defaultAlert}).GetDefaultAlert(); actual != defaultAlert {
+		t.Error("expected configured default alert")
+	}
+	if actual := (&AlertProvider{}).GetDefaultAlert(); actual != nil {
+		t.Error("expected nil default alert")
+	}
+}
+
+func TestAlertProviderBuildRequestBody(t *testing.T) {
+	t.Parallel()
+
+	description := "degraded \"edge\""
+	tests := []struct {
+		name             string
+		config           Config
+		endpoint         endpoint.Endpoint
+		alert            alert.Alert
+		result           endpoint.Result
+		resolved         bool
+		expectedTitle    string
+		expectedBody     string
+		expectedOptional map[string]string
+	}{
+		{
+			name:     "triggered alert uses threshold description and actual condition results",
+			config:   Config{DeviceKey: "device-key"},
+			endpoint: endpoint.Endpoint{Name: "api", Group: "production"},
+			alert:    alert.Alert{FailureThreshold: 3, SuccessThreshold: 2, Description: &description},
+			result: endpoint.Result{ConditionResults: []*endpoint.ConditionResult{
+				{Condition: "[STATUS] == 200", Success: false},
+				{Condition: "[BODY].status == \"UP\"", Success: true},
+			}},
+			expectedTitle: "Gatus: production/api",
+			expectedBody:  "An alert has been triggered due to having failed 3 time(s) in a row with the following description: degraded \"edge\"\n🔴 [STATUS] == 200\n🟢 [BODY].status == \"UP\"",
+		},
+		{
+			name:          "reminder uses the unresolved alert message",
+			config:        Config{DeviceKey: "device-key"},
+			endpoint:      endpoint.Endpoint{Name: "api"},
+			alert:         alert.Alert{FailureThreshold: 5, SuccessThreshold: 2},
+			expectedTitle: "Gatus: api",
+			expectedBody:  "An alert has been triggered due to having failed 5 time(s) in a row",
+		},
+		{
+			name:          "resolved alert uses success threshold and custom title",
+			config:        Config{DeviceKey: "device-key", Title: "Service recovered"},
+			endpoint:      endpoint.Endpoint{Name: "api"},
+			alert:         alert.Alert{FailureThreshold: 3, SuccessThreshold: 2},
+			resolved:      true,
+			expectedTitle: "Service recovered",
+			expectedBody:  "An alert has been resolved after passing successfully 2 time(s) in a row",
+		},
+		{
+			name:          "optional Bark fields are included",
+			config:        Config{DeviceKey: "device-key", Group: "gatus", Sound: "alarm", Icon: "https://example.com/icon.png", URL: "https://example.com/incidents/1", Level: "timeSensitive"},
+			endpoint:      endpoint.Endpoint{Name: "api"},
+			alert:         alert.Alert{FailureThreshold: 4},
+			expectedTitle: "Gatus: api",
+			expectedBody:  "An alert has been triggered due to having failed 4 time(s) in a row",
+			expectedOptional: map[string]string{
+				"group": "gatus",
+				"sound": "alarm",
+				"icon":  "https://example.com/icon.png",
+				"url":   "https://example.com/incidents/1",
+				"level": "timeSensitive",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			body := (&AlertProvider{}).buildRequestBody(&test.config, &test.endpoint, &test.alert, &test.result, test.resolved)
+			var decoded map[string]string
+			if err := json.Unmarshal(body, &decoded); err != nil {
+				t.Fatal("expected valid JSON, got", err)
+			}
+			if decoded["device_key"] != "device-key" {
+				t.Errorf("expected device key in JSON payload")
+			}
+			if decoded["title"] != test.expectedTitle {
+				t.Errorf("expected title %q, got %q", test.expectedTitle, decoded["title"])
+			}
+			if decoded["body"] != test.expectedBody {
+				t.Errorf("expected body %q, got %q", test.expectedBody, decoded["body"])
+			}
+			for _, field := range []string{"group", "sound", "icon", "url", "level"} {
+				expectedValue, expected := test.expectedOptional[field]
+				actualValue, present := decoded[field]
+				if expected && (!present || actualValue != expectedValue) {
+					t.Errorf("expected %s %q, got %q", field, expectedValue, actualValue)
+				}
+				if !expected && present {
+					t.Errorf("expected empty %s to be omitted", field)
+				}
+			}
+		})
+	}
+}
+
+func TestAlertProviderSend(t *testing.T) {
+	description := "database unavailable"
+	var received Body
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPost {
+			t.Errorf("expected method POST, got %s", request.Method)
+		}
+		if request.URL.Path != "/push" {
+			t.Errorf("expected path /push, got %s", request.URL.Path)
+		}
+		if request.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("expected application/json content type, got %s", request.Header.Get("Content-Type"))
+		}
+		if strings.Contains(request.URL.String(), "secret-device-key") {
+			t.Error("device key must not be included in the request URL")
+		}
+		if err := json.NewDecoder(request.Body).Decode(&received); err != nil {
+			t.Error("expected a valid JSON request body, got", err)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	provider := AlertProvider{DefaultConfig: Config{ServerURL: server.URL, DeviceKey: "secret-device-key", Group: "gatus"}}
+	err := provider.Send(
+		&endpoint.Endpoint{Name: "database"},
+		&alert.Alert{FailureThreshold: 3, Description: &description},
+		&endpoint.Result{ConditionResults: []*endpoint.ConditionResult{{Condition: "[STATUS] == 200", Success: false}}},
+		false,
+	)
+	if err != nil {
+		t.Fatal("expected request to succeed, got", err)
+	}
+	if received.DeviceKey != "secret-device-key" || received.Title != "Gatus: database" || received.Group != "gatus" {
+		t.Errorf("unexpected Bark payload: %#v", received)
+	}
+}
+
+func TestAlertProviderSendBuildsPushURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		serverSuffix string
+		expectedPath string
+	}{
+		{name: "trailing slash", serverSuffix: "/", expectedPath: "/push"},
+		{name: "existing push path", serverSuffix: "/push", expectedPath: "/push"},
+		{name: "self-hosted path prefix", serverSuffix: "/bark", expectedPath: "/bark/push"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var actualPath string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				actualPath = request.URL.Path
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+			provider := AlertProvider{DefaultConfig: Config{ServerURL: server.URL + test.serverSuffix, DeviceKey: "device-key"}}
+			if err := provider.Send(&endpoint.Endpoint{Name: "api"}, &alert.Alert{FailureThreshold: 1}, &endpoint.Result{}, false); err != nil {
+				t.Fatal("expected request to succeed, got", err)
+			}
+			if actualPath != test.expectedPath {
+				t.Errorf("expected path %q, got %q", test.expectedPath, actualPath)
+			}
+		})
+	}
+}
+
+func TestAlertProviderSendReturnsSafeResponseErrors(t *testing.T) {
+	tests := []struct {
+		status       int
+		body         string
+		expectedBody string
+	}{
+		{status: http.StatusBadRequest, body: "invalid request", expectedBody: "invalid request"},
+		{status: http.StatusInternalServerError, body: "server unavailable", expectedBody: "server unavailable"},
+		{status: http.StatusBadRequest, body: "invalid device secret-device-key", expectedBody: "invalid device [REDACTED]"},
+		{status: http.StatusBadRequest, body: "invalid\nsecret-device-key", expectedBody: "invalid [REDACTED]"},
+		{status: http.StatusBadRequest, body: "invalid\u2028secret-device-key\u2029response", expectedBody: "invalid [REDACTED] response"},
+	}
+
+	for _, test := range tests {
+		t.Run(http.StatusText(test.status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(test.status)
+				_, _ = io.WriteString(w, test.body)
+			}))
+			defer server.Close()
+			provider := AlertProvider{DefaultConfig: Config{ServerURL: server.URL, DeviceKey: "secret-device-key", Title: "secret request title"}}
+			err := provider.Send(&endpoint.Endpoint{Name: "api"}, &alert.Alert{FailureThreshold: 1}, &endpoint.Result{}, false)
+			if err == nil {
+				t.Fatal("expected an error response")
+			}
+			errorText := err.Error()
+			if !strings.Contains(errorText, "Bark") || !strings.Contains(errorText, strconv.Itoa(test.status)) || !strings.Contains(errorText, http.StatusText(test.status)) || !strings.Contains(errorText, test.expectedBody) {
+				t.Errorf("expected provider, status, and response body in error, got %q", errorText)
+			}
+			if strings.Contains(errorText, "secret-device-key") || strings.Contains(errorText, "secret request title") {
+				t.Errorf("request credentials or body leaked in error: %q", errorText)
+			}
+		})
+	}
+}
+
+func TestAlertProviderSendLimitsErrorResponseBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = io.WriteString(w, strings.Repeat("x", 64*1024+100))
+	}))
+	defer server.Close()
+
+	provider := AlertProvider{DefaultConfig: Config{ServerURL: server.URL, DeviceKey: "device-key"}}
+	err := provider.Send(&endpoint.Endpoint{Name: "api"}, &alert.Alert{FailureThreshold: 1}, &endpoint.Result{}, false)
+	if err == nil {
+		t.Fatal("expected an error response")
+	}
+	if len(err.Error()) > 65*1024 {
+		t.Errorf("expected bounded error response, got %d bytes", len(err.Error()))
+	}
+	if !strings.Contains(err.Error(), "[truncated]") {
+		t.Errorf("expected truncation marker, got %q", err.Error())
+	}
+}
+
+func TestAlertProviderSendRejectsCrossOriginRedirect(t *testing.T) {
+	targetReceivedRequest := false
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		targetReceivedRequest = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer target.Close()
+	redirect := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		http.Redirect(w, request, target.URL, http.StatusTemporaryRedirect)
+	}))
+	defer redirect.Close()
+
+	provider := AlertProvider{DefaultConfig: Config{ServerURL: redirect.URL, DeviceKey: "secret-device-key"}}
+	err := provider.Send(&endpoint.Endpoint{Name: "api"}, &alert.Alert{FailureThreshold: 1}, &endpoint.Result{}, false)
+	if err == nil {
+		t.Fatal("expected cross-origin redirect to fail")
+	}
+	if targetReceivedRequest {
+		t.Error("expected request body not to be forwarded to another origin")
+	}
+	if strings.Contains(err.Error(), "secret-device-key") {
+		t.Errorf("device key leaked in redirect error: %q", err.Error())
+	}
+}
+
+type trackingReadCloser struct {
+	io.Reader
+	closed bool
+}
+
+func (body *trackingReadCloser) Close() error {
+	body.closed = true
+	return nil
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (roundTrip roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return roundTrip(request)
+}
+
+func TestAlertProviderSendClosesResponseBody(t *testing.T) {
+	body := &trackingReadCloser{Reader: strings.NewReader("ok")}
+	client.InjectHTTPClient(&http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Status: "200 OK", Body: body, Header: make(http.Header)}, nil
+	})})
+	t.Cleanup(func() { client.InjectHTTPClient(nil) })
+
+	provider := AlertProvider{DefaultConfig: Config{ServerURL: "https://example.com", DeviceKey: "device-key"}}
+	if err := provider.Send(&endpoint.Endpoint{Name: "api"}, &alert.Alert{FailureThreshold: 1}, &endpoint.Result{}, false); err != nil {
+		t.Fatal("expected request to succeed, got", err)
+	}
+	if !body.closed {
+		t.Error("expected response body to be closed")
+	}
+}

--- a/alerting/provider/provider.go
+++ b/alerting/provider/provider.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"github.com/TwiN/gatus/v5/alerting/alert"
 	"github.com/TwiN/gatus/v5/alerting/provider/awsses"
+	"github.com/TwiN/gatus/v5/alerting/provider/bark"
 	"github.com/TwiN/gatus/v5/alerting/provider/clickup"
 	"github.com/TwiN/gatus/v5/alerting/provider/custom"
 	"github.com/TwiN/gatus/v5/alerting/provider/datadog"
@@ -93,6 +94,7 @@ func MergeProviderDefaultAlertIntoEndpointAlert(providerDefaultAlert, endpointAl
 var (
 	// Validate provider interface implementation on compile
 	_ AlertProvider = (*awsses.AlertProvider)(nil)
+	_ AlertProvider = (*bark.AlertProvider)(nil)
 	_ AlertProvider = (*clickup.AlertProvider)(nil)
 	_ AlertProvider = (*custom.AlertProvider)(nil)
 	_ AlertProvider = (*datadog.AlertProvider)(nil)
@@ -135,6 +137,7 @@ var (
 
 	// Validate config interface implementation on compile
 	_ Config[awsses.Config]         = (*awsses.Config)(nil)
+	_ Config[bark.Config]           = (*bark.Config)(nil)
 	_ Config[clickup.Config]        = (*clickup.Config)(nil)
 	_ Config[custom.Config]         = (*custom.Config)(nil)
 	_ Config[datadog.Config]        = (*datadog.Config)(nil)

--- a/config/config.go
+++ b/config/config.go
@@ -595,6 +595,7 @@ func ValidateAlertingConfig(alertingConfig *alerting.Config, endpoints []*endpoi
 	}
 	alertTypes := []alert.Type{
 		alert.TypeAWSSES,
+		alert.TypeBark,
 		alert.TypeClickUp,
 		alert.TypeCustom,
 		alert.TypeDatadog,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/TwiN/gatus/v5/alerting/alert"
 	"github.com/TwiN/gatus/v5/alerting/provider"
 	"github.com/TwiN/gatus/v5/alerting/provider/awsses"
+	"github.com/TwiN/gatus/v5/alerting/provider/bark"
 	"github.com/TwiN/gatus/v5/alerting/provider/clickup"
 	"github.com/TwiN/gatus/v5/alerting/provider/custom"
 	"github.com/TwiN/gatus/v5/alerting/provider/datadog"
@@ -1856,6 +1857,7 @@ func TestParseAndValidateConfigBytesWithNoEndpoints(t *testing.T) {
 func TestGetAlertingProviderByAlertType(t *testing.T) {
 	alertingConfig := &alerting.Config{
 		AWSSimpleEmailService: &awsses.AlertProvider{},
+		Bark:                  &bark.AlertProvider{},
 		ClickUp:               &clickup.AlertProvider{},
 		Custom:                &custom.AlertProvider{},
 		Datadog:               &datadog.AlertProvider{},
@@ -1901,6 +1903,7 @@ func TestGetAlertingProviderByAlertType(t *testing.T) {
 		expected  provider.AlertProvider
 	}{
 		{alertType: alert.TypeAWSSES, expected: alertingConfig.AWSSimpleEmailService},
+		{alertType: alert.TypeBark, expected: alertingConfig.Bark},
 		{alertType: alert.TypeClickUp, expected: alertingConfig.ClickUp},
 		{alertType: alert.TypeCustom, expected: alertingConfig.Custom},
 		{alertType: alert.TypeDatadog, expected: alertingConfig.Datadog},
@@ -1947,6 +1950,70 @@ func TestGetAlertingProviderByAlertType(t *testing.T) {
 				t.Errorf("expected %s configuration", scenario.alertType)
 			}
 		})
+	}
+}
+
+func TestParseAndValidateConfigBytesWithBarkAlerting(t *testing.T) {
+	t.Parallel()
+
+	config, err := parseAndValidateConfigBytes([]byte(`
+alerting:
+  bark:
+    server-url: https://bark.example.com/
+    device-key: test-device-key
+    title: Gatus status
+    group: gatus
+    default-alert:
+      failure-threshold: 7
+      success-threshold: 4
+      send-on-resolved: true
+    overrides:
+      - group: production
+        level: passive
+
+endpoints:
+  - name: api
+    group: production
+    url: https://example.com/health
+    conditions:
+      - "[STATUS] == 200"
+    alerts:
+      - type: bark
+        provider-override:
+          group: incident
+          sound: alarm
+`))
+	if err != nil {
+		t.Fatal("expected Bark configuration to parse, got", err)
+	}
+	if config.Alerting == nil || config.Alerting.Bark == nil {
+		t.Fatal("expected Bark alerting provider")
+	}
+	if config.Alerting.Bark.DefaultConfig.ServerURL != "https://bark.example.com" {
+		t.Errorf("expected normalized Bark server URL, got %q", config.Alerting.Bark.DefaultConfig.ServerURL)
+	}
+	if config.Alerting.Bark.DefaultConfig.DeviceKey != "test-device-key" {
+		t.Error("expected Bark device key to be parsed")
+	}
+	if config.Alerting.Bark.DefaultConfig.Group != "gatus" {
+		t.Errorf("expected Bark notification group %q, got %q", "gatus", config.Alerting.Bark.DefaultConfig.Group)
+	}
+	if config.Alerting.GetAlertingProviderByAlertType(alert.TypeBark) != config.Alerting.Bark {
+		t.Error("expected Bark provider to be discoverable by alert type")
+	}
+	endpointAlert := config.Endpoints[0].Alerts[0]
+	if endpointAlert.Type != alert.TypeBark {
+		t.Errorf("expected alert type %q, got %q", alert.TypeBark, endpointAlert.Type)
+	}
+	if endpointAlert.FailureThreshold != 7 || endpointAlert.SuccessThreshold != 4 || !endpointAlert.IsSendingOnResolved() {
+		t.Errorf("expected Bark default alert to be merged, got %#v", endpointAlert)
+	}
+	merged, err := config.Alerting.Bark.GetConfig(config.Endpoints[0].Group, endpointAlert)
+	if err != nil {
+		t.Fatal("expected merged Bark configuration to be valid, got", err)
+	}
+	if merged.Level != "passive" || merged.Sound != "alarm" || merged.Group != "incident" {
+		t.Errorf("expected group and alert overrides, got %#v", merged)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #1325

- Add Bark as a built-in alerting provider using the Bark V2 JSON `/push` API.
- Support the official Bark service and self-hosted servers.
- Support default alerts, endpoint group overrides, alert-level provider overrides, and resolved notifications.
- Preserve endpoint group selector semantics when Bark overrides are marshaled and unmarshaled as YAML.
- Validate server URLs and notification levels, prevent cross-origin credential forwarding, and redact device keys from bounded error responses.
- Sanitize control characters and Unicode line and paragraph separators in provider errors to keep log entries on one line.
- Add provider and configuration tests, along with setup and credential security documentation in `README.md`.
- Add no new dependencies.

## Testing

- `go test -count=1 ./alerting/provider/bark ./alerting/provider ./config`
- `go test -race -count=1 ./alerting/provider/bark`
- `go vet ./alerting/provider/bark ./alerting/provider ./config`
- `make test` passes for Bark and all alerting providers. The existing live DNS CNAME test under `client/TestQueryDNS/test_Config_with_type_CNAME` may fail because the public DNS response returns an IP address instead of the hard-coded CNAME.

Automated HTTP tests use local test servers. No live Bark device credentials were used.

## Checklist

- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable.

