### PR TITLE
feat(rocketchat): support alias/emoji/avatar overrides and client TLS config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1933,23 +1933,28 @@ endpoints:
 
 #### Configuring Rocket.Chat alerts
 
-> ⚠️ **WARNING**: This alerting provider has not been tested yet. If you've tested it and confirmed that it works, please remove this warning and create a pull request, or comment on [#1223](https://github.com/TwiN/gatus/discussions/1223) with whether the provider works as intended. Thank you for your cooperation.
-
-| Parameter                               | Description                                                                                | Default       |
-|:----------------------------------------|:-------------------------------------------------------------------------------------------|:--------------|
-| `alerting.rocketchat`                   | Configuration for alerts of type `rocketchat`                                              | `{}`          |
-| `alerting.rocketchat.webhook-url`       | Rocket.Chat incoming webhook URL                                                           | Required `""` |
-| `alerting.rocketchat.channel`           | Optional channel override                                                                  | `""`          |
-| `alerting.rocketchat.default-alert`     | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert) | N/A           |
-| `alerting.rocketchat.overrides`         | List of overrides that may be prioritized over the default configuration                   | `[]`          |
-| `alerting.rocketchat.overrides[].group` | Endpoint group for which the configuration will be overridden by this configuration        | `""`          |
-| `alerting.rocketchat.overrides[].*`     | See `alerting.rocketchat.*` parameters                                                     | `{}`          |
+| Parameter                                | Description                                                                                 | Default       |
+|:------------------------------------------|:-----------------------------------------------------------------------------------------------|:--------------|
+| `alerting.rocketchat`                    | Configuration for alerts of type `rocketchat`                                               | `{}`          |
+| `alerting.rocketchat.webhook-url`        | Rocket.Chat incoming webhook URL                                                             | Required `""` |
+| `alerting.rocketchat.channel`            | Channel override, e.g. `#alerts` (optional)                                          | `""`          |
+| `alerting.rocketchat.alias`              | Overrides the sender name displayed in Rocket.Chat (optional)                                | `""`          |
+| `alerting.rocketchat.emoji`              | Overrides the sender avatar with an emoji, e.g. `:rotating_light:` (optional)                | `""`          |
+| `alerting.rocketchat.avatar`             | Overrides the sender avatar with an image URL (optional)                                     | `""`          |
+| `alerting.rocketchat.client`             | Client configuration. <br />See [Client configuration](#client-configuration).               | `{}`          |
+| `alerting.rocketchat.default-alert`      | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert)   | N/A           |
+| `alerting.rocketchat.overrides`          | List of overrides that may be prioritized over the default configuration                     | `[]`          |
+| `alerting.rocketchat.overrides[].group`  | Endpoint group for which the configuration will be overridden by this configuration          | `""`          |
+| `alerting.rocketchat.overrides[].*`      | See `alerting.rocketchat.*` parameters                                                       | `{}`          |
 
 ```yaml
 alerting:
   rocketchat:
-    webhook-url: "https://your-rocketchat.com/hooks/YOUR_WEBHOOK_ID/YOUR_TOKEN"
-    channel: "#alerts"  # Optional
+    webhook-url: ${ROCKETCHAT_WEBHOOK_URL}
+    channel: "#alerts"
+    alias: "Gatus"
+    default-alert:
+      send-on-resolved: true
 
 endpoints:
   - name: website
@@ -1959,7 +1964,19 @@ endpoints:
       - "[STATUS] == 200"
     alerts:
       - type: rocketchat
-        send-on-resolved: true
+```
+
+> 💡 For the `channel` override to take effect, the Rocket.Chat incoming webhook integration must have **"Allow to overwrite destination channel in the body parameters"** enabled (Administration > Integrations > your Incoming WebHook). If that setting is off, the `channel` field is silently ignored and messages always go to the channel configured in **Post to Channel**. When enabled, the value must be prefixed with `#` for a channel (e.g. `#alerts`) or `@` for a direct message to a user (e.g. `@jdoe`), and the webhook's bot user needs access to that destination.
+
+If your Rocket.Chat server uses a certificate issued by an internal/private certificate authority, Gatus won't be able to verify it by default. Until certificate authority pinning is supported, the workaround is to skip certificate verification for that webhook's client:
+
+```yaml
+alerting:
+  rocketchat:
+    webhook-url: ${ROCKETCHAT_WEBHOOK_URL}
+    channel: "#alerts"
+    client:
+      insecure: true # Skips TLS certificate verification -- only use this if you trust the network path to your Rocket.Chat server
 ```
 
 

--- a/alerting/provider/rocketchat/rocketchat.go
+++ b/alerting/provider/rocketchat/rocketchat.go
@@ -20,8 +20,12 @@ var (
 )
 
 type Config struct {
-	WebhookURL string `yaml:"webhook-url"`       // Rocket.Chat incoming webhook URL
-	Channel    string `yaml:"channel,omitempty"` // Optional channel override
+	WebhookURL   string         `yaml:"webhook-url"`       // Rocket.Chat incoming webhook URL
+	Channel      string         `yaml:"channel,omitempty"` // Optional channel override
+	Alias        string         `yaml:"alias,omitempty"`   // Overrides the sender name displayed in Rocket.Chat
+	Emoji        string         `yaml:"emoji,omitempty"`   // Overrides the sender avatar with an emoji, e.g. ":rotating_light:"
+	Avatar       string         `yaml:"avatar,omitempty"`  // Overrides the sender avatar with an image URL
+	ClientConfig *client.Config `yaml:"client,omitempty"`
 }
 
 func (cfg *Config) Validate() error {
@@ -32,11 +36,23 @@ func (cfg *Config) Validate() error {
 }
 
 func (cfg *Config) Merge(override *Config) {
+	if override.ClientConfig != nil {
+		cfg.ClientConfig = override.ClientConfig
+	}
 	if len(override.WebhookURL) > 0 {
 		cfg.WebhookURL = override.WebhookURL
 	}
 	if len(override.Channel) > 0 {
 		cfg.Channel = override.Channel
+	}
+	if len(override.Alias) > 0 {
+		cfg.Alias = override.Alias
+	}
+	if len(override.Emoji) > 0 {
+		cfg.Emoji = override.Emoji
+	}
+	if len(override.Avatar) > 0 {
+		cfg.Avatar = override.Avatar
 	}
 }
 
@@ -87,7 +103,7 @@ func (provider *AlertProvider) Send(ep *endpoint.Endpoint, alert *alert.Alert, r
 		return err
 	}
 	request.Header.Set("Content-Type", "application/json")
-	response, err := client.GetHTTPClient(nil).Do(request)
+	response, err := client.GetHTTPClient(cfg.ClientConfig).Do(request)
 	if err != nil {
 		return err
 	}
@@ -103,6 +119,9 @@ type Body struct {
 	Text        string       `json:"text"`
 	Channel     string       `json:"channel,omitempty"`
 	Username    string       `json:"username"`
+	Alias       string       `json:"alias,omitempty"`
+	Emoji       string       `json:"emoji,omitempty"`
+	Avatar      string       `json:"avatar,omitempty"`
 	Attachments []Attachment `json:"attachments"`
 }
 
@@ -160,6 +179,15 @@ func (provider *AlertProvider) buildRequestBody(cfg *Config, ep *endpoint.Endpoi
 	}
 	if cfg.Channel != "" {
 		body.Channel = cfg.Channel
+	}
+	if cfg.Alias != "" {
+		body.Alias = cfg.Alias
+	}
+	if cfg.Emoji != "" {
+		body.Emoji = cfg.Emoji
+	}
+	if cfg.Avatar != "" {
+		body.Avatar = cfg.Avatar
 	}
 	if len(formattedConditionResults) > 0 {
 		body.Attachments[0].Fields = append(body.Attachments[0].Fields, Field{

--- a/alerting/provider/rocketchat/rocketchat_test.go
+++ b/alerting/provider/rocketchat/rocketchat_test.go
@@ -29,6 +29,11 @@ func TestAlertProvider_Validate(t *testing.T) {
 			expected: nil,
 		},
 		{
+			name:     "valid-with-alias-emoji-avatar",
+			provider: AlertProvider{DefaultConfig: Config{WebhookURL: "https://rocketchat.com/hooks/123/abc", Alias: "Gatus Bot", Emoji: ":rotating_light:", Avatar: "https://example.com/avatar.png"}},
+			expected: nil,
+		},
+		{
 			name:     "invalid-webhook-url",
 			provider: AlertProvider{DefaultConfig: Config{}},
 			expected: ErrWebhookURLNotSet,
@@ -99,6 +104,32 @@ func TestAlertProvider_Send(t *testing.T) {
 			expectedError: false,
 		},
 		{
+			name: "triggered-with-alias-emoji-avatar",
+			provider: AlertProvider{DefaultConfig: Config{
+				WebhookURL: "https://rocketchat.com/hooks/123/abc",
+				Alias:      "Gatus Bot",
+				Emoji:      ":rotating_light:",
+				Avatar:     "https://example.com/avatar.png",
+			}},
+			alert:    alert.Alert{Description: &firstDescription, SuccessThreshold: 5, FailureThreshold: 3},
+			resolved: false,
+			mockRoundTripper: test.MockRoundTripper(func(r *http.Request) *http.Response {
+				body := make(map[string]interface{})
+				json.NewDecoder(r.Body).Decode(&body)
+				if body["alias"] != "Gatus Bot" {
+					t.Errorf("expected alias to be 'Gatus Bot', got %v", body["alias"])
+				}
+				if body["emoji"] != ":rotating_light:" {
+					t.Errorf("expected emoji to be ':rotating_light:', got %v", body["emoji"])
+				}
+				if body["avatar"] != "https://example.com/avatar.png" {
+					t.Errorf("expected avatar to be 'https://example.com/avatar.png', got %v", body["avatar"])
+				}
+				return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}
+			}),
+			expectedError: false,
+		},
+		{
 			name:     "resolved",
 			provider: AlertProvider{DefaultConfig: Config{WebhookURL: "https://rocketchat.com/hooks/123/abc"}},
 			alert:    alert.Alert{Description: &secondDescription, SuccessThreshold: 5, FailureThreshold: 3},
@@ -149,6 +180,71 @@ func TestAlertProvider_Send(t *testing.T) {
 			}
 			if !scenario.expectedError && err != nil {
 				t.Error("expected no error, got", err.Error())
+			}
+		})
+	}
+}
+
+func TestAlertProvider_GetConfig(t *testing.T) {
+	scenarios := []struct {
+		Name           string
+		Provider       AlertProvider
+		InputGroup     string
+		InputAlert     alert.Alert
+		ExpectedOutput Config
+	}{
+		{
+			Name: "provider-no-override-specify-no-group-should-default",
+			Provider: AlertProvider{
+				DefaultConfig: Config{WebhookURL: "https://rocketchat.com/hooks/123/abc"},
+				Overrides:     nil,
+			},
+			InputGroup:     "",
+			InputAlert:     alert.Alert{},
+			ExpectedOutput: Config{WebhookURL: "https://rocketchat.com/hooks/123/abc"},
+		},
+		{
+			Name: "provider-with-override-specify-group-should-override",
+			Provider: AlertProvider{
+				DefaultConfig: Config{WebhookURL: "https://rocketchat.com/hooks/123/abc"},
+				Overrides: []Override{
+					{
+						Group:  "group",
+						Config: Config{WebhookURL: "https://rocketchat.com/hooks/456/def", Channel: "#group-alerts", Alias: "Group Bot", Emoji: ":fire:", Avatar: "https://example.com/group.png"},
+					},
+				},
+			},
+			InputGroup: "group",
+			InputAlert: alert.Alert{},
+			ExpectedOutput: Config{
+				WebhookURL: "https://rocketchat.com/hooks/456/def",
+				Channel:    "#group-alerts",
+				Alias:      "Group Bot",
+				Emoji:      ":fire:",
+				Avatar:     "https://example.com/group.png",
+			},
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			output, err := scenario.Provider.GetConfig(scenario.InputGroup, &scenario.InputAlert)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if output.WebhookURL != scenario.ExpectedOutput.WebhookURL {
+				t.Errorf("expected webhook-url %s, got %s", scenario.ExpectedOutput.WebhookURL, output.WebhookURL)
+			}
+			if output.Channel != scenario.ExpectedOutput.Channel {
+				t.Errorf("expected channel %s, got %s", scenario.ExpectedOutput.Channel, output.Channel)
+			}
+			if output.Alias != scenario.ExpectedOutput.Alias {
+				t.Errorf("expected alias %s, got %s", scenario.ExpectedOutput.Alias, output.Alias)
+			}
+			if output.Emoji != scenario.ExpectedOutput.Emoji {
+				t.Errorf("expected emoji %s, got %s", scenario.ExpectedOutput.Emoji, output.Emoji)
+			}
+			if output.Avatar != scenario.ExpectedOutput.Avatar {
+				t.Errorf("expected avatar %s, got %s", scenario.ExpectedOutput.Avatar, output.Avatar)
 			}
 		})
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -762,6 +762,11 @@ alerting:
     webhook-url: "http://example.com"
     client:
       insecure: true
+  rocketchat:
+    webhook-url: "http://example.com"
+    channel: "#alerts"
+    client:
+      insecure: true
   messagebird:
     access-key: "1"
     originator: "31619191918"
@@ -798,6 +803,7 @@ endpoints:
         success-threshold: 15
       - type: teams
       - type: pushover
+      - type: rocketchat
     conditions:
       - "[STATUS] == 200"
 `))
@@ -814,6 +820,12 @@ endpoints:
 	if config.Alerting.Slack == nil || config.Alerting.Slack.Validate() != nil {
 		t.Fatal("Slack alerting config should've been valid")
 	}
+	if config.Alerting.RocketChat == nil || config.Alerting.RocketChat.Validate() != nil {
+		t.Fatal("RocketChat alerting config should've been valid")
+	}
+	if config.Alerting.RocketChat.DefaultConfig.Channel != "#alerts" {
+		t.Errorf("RocketChat channel should've been %s, but was %s", "#alerts", config.Alerting.RocketChat.DefaultConfig.Channel)
+	}
 	// Endpoints
 	if len(config.Endpoints) != 1 {
 		t.Error("There should've been 1 endpoint")
@@ -824,8 +836,8 @@ endpoints:
 	if config.Endpoints[0].Interval != 60*time.Second {
 		t.Errorf("Interval should have been %s, because it is the default value", 60*time.Second)
 	}
-	if len(config.Endpoints[0].Alerts) != 9 {
-		t.Fatal("There should've been 9 alerts configured")
+	if len(config.Endpoints[0].Alerts) != 10 {
+		t.Fatal("There should've been 10 alerts configured")
 	}
 
 	if config.Endpoints[0].Alerts[0].Type != alert.TypeSlack {
@@ -932,6 +944,13 @@ endpoints:
 	if !config.Endpoints[0].Alerts[8].IsEnabled() {
 		t.Error("The alert should've been enabled")
 	}
+
+	if config.Endpoints[0].Alerts[9].Type != alert.TypeRocketChat {
+		t.Errorf("The type of the alert should've been %s, but it was %s", alert.TypeRocketChat, config.Endpoints[0].Alerts[9].Type)
+	}
+	if !config.Endpoints[0].Alerts[9].IsEnabled() {
+		t.Error("The alert should've been enabled")
+	}
 }
 
 func TestParseAndValidateConfigBytesWithAlertingAndDefaultAlert(t *testing.T) {
@@ -1007,6 +1026,10 @@ alerting:
     token: "**************"
     default-alert:
       enabled: true
+  rocketchat:
+    webhook-url: "http://example.com"
+    default-alert:
+      enabled: true
 
 external-endpoints:
   - name: ext-ep-test
@@ -1031,6 +1054,7 @@ endpoints:
       - type: pushover
       - type: email
       - type: gotify
+      - type: rocketchat
     conditions:
       - "[STATUS] == 200"
 `))
@@ -1221,8 +1245,8 @@ endpoints:
 	if config.Endpoints[0].Interval != 60*time.Second {
 		t.Errorf("Interval should have been %s, because it is the default value", 60*time.Second)
 	}
-	if len(config.Endpoints[0].Alerts) != 11 {
-		t.Fatalf("There should've been 11 alerts configured, got %d", len(config.Endpoints[0].Alerts))
+	if len(config.Endpoints[0].Alerts) != 12 {
+		t.Fatalf("There should've been 12 alerts configured, got %d", len(config.Endpoints[0].Alerts))
 	}
 
 	if config.Endpoints[0].Alerts[0].Type != alert.TypeSlack {
@@ -1363,6 +1387,19 @@ endpoints:
 	}
 	if config.Endpoints[0].Alerts[10].SuccessThreshold != 2 {
 		t.Errorf("The default success threshold of the alert should've been %d, but it was %d", 2, config.Endpoints[0].Alerts[10].SuccessThreshold)
+	}
+
+	if config.Endpoints[0].Alerts[11].Type != alert.TypeRocketChat {
+		t.Errorf("The type of the alert should've been %s, but it was %s", alert.TypeRocketChat, config.Endpoints[0].Alerts[11].Type)
+	}
+	if !config.Endpoints[0].Alerts[11].IsEnabled() {
+		t.Error("The alert should've been enabled")
+	}
+	if config.Endpoints[0].Alerts[11].FailureThreshold != 3 {
+		t.Errorf("The default failure threshold of the alert should've been %d, but it was %d", 3, config.Endpoints[0].Alerts[11].FailureThreshold)
+	}
+	if config.Endpoints[0].Alerts[11].SuccessThreshold != 2 {
+		t.Errorf("The default success threshold of the alert should've been %d, but it was %d", 2, config.Endpoints[0].Alerts[11].SuccessThreshold)
 	}
 }
 


### PR DESCRIPTION
## Summary

Extends the existing Rocket.Chat alerting provider (config/type registration was already scaffolded) with:
- `channel`, `alias`, `emoji`, `avatar` overrides, matching Rocket.Chat's incoming webhook payload fields
- `client` config (reusing the shared `client.Config`), so a webhook behind an internal/self-signed CA can be reached via `client.insecure: true`
- Unit tests covering the new fields and group-override merging
- Config parsing tests registering `rocketchat` alongside the other providers already covered in `config_test.go`
- README section for `alerting.rocketchat`, including the untested-provider warning removal (confirmed working per [discussion #1223](https://github.com/TwiN/gatus/discussions/1223#discussioncomment-17560054)) and a note that Rocket.Chat ignores the `channel` override unless **"Allow to overwrite destination channel in the body parameters"** is enabled on the incoming webhook integration

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./alerting/provider/rocketchat/... -v`
- [x] `go test ./config/... -v -run Alerting`