### PR TITLE
Support pushing condition results to external endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,24 @@ Where:
 
 You must also pass the token as a `Bearer` token in the `Authorization` header.
 
+Optionally, you may also send a JSON body describing the individual conditions that were evaluated on your end.
+They are displayed under **Conditions** when hovering over a result on the dashboard, which is useful when a single error message isn't enough to tell which check failed:
+```
+POST /api/v1/endpoints/{key}/external?success=false
+
+{
+  "conditionResults": [
+    {"condition": "[STATUS] == 200", "success": true},
+    {"condition": "[RESPONSE_TIME] < 300", "success": false}
+  ]
+}
+```
+Where:
+- `conditionResults` (optional): the conditions that were evaluated on your end. Each entry requires a non-empty `condition` of at most 1024 characters and a `success` boolean, with a maximum of 50 entries per request.
+
+The body is entirely optional: a request without one behaves exactly like it did before.
+Note that condition results are for display purposes only: `{success}` remains the source of truth for the health of the endpoint, regardless of whether any of the conditions you pushed failed.
+
 
 ### Suites (ALPHA)
 Suites are collections of endpoints that are executed sequentially with a shared context.

--- a/api/external_endpoint.go
+++ b/api/external_endpoint.go
@@ -1,7 +1,10 @@
 package api
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -14,6 +17,22 @@ import (
 	"github.com/TwiN/logr"
 	"github.com/gofiber/fiber/v2"
 )
+
+const (
+	// maximumNumberOfConditionResultsPerPush is the maximum number of condition results that may be pushed alongside the result of an external endpoint
+	maximumNumberOfConditionResultsPerPush = 50
+
+	// maximumConditionLengthPerPush is the maximum length of a single condition pushed alongside the result of an external endpoint
+	maximumConditionLengthPerPush = 1024
+)
+
+// externalEndpointResultRequestBody is the optional JSON body that may be sent when pushing the result of an
+// external endpoint. The query parameters remain the source of truth for everything that isn't part of this body.
+type externalEndpointResultRequestBody struct {
+	// ConditionResults are the results of the conditions evaluated by whatever pushed the result.
+	// They are displayed as-is on the dashboard; they do not influence the success of the result.
+	ConditionResults []*endpoint.ConditionResult `json:"conditionResults"`
+}
 
 func CreateExternalEndpointResult(cfg *config.Config) fiber.Handler {
 	extraLabels := cfg.GetUniqueExtraMetricLabels()
@@ -58,6 +77,25 @@ func CreateExternalEndpointResult(cfg *config.Config) fiber.Handler {
 		}
 		if errorFromQuery := c.Query("error"); !result.Success && len(errorFromQuery) > 0 {
 			result.AddError(errorFromQuery)
+		}
+		if body := bytes.TrimSpace(c.Body()); len(body) > 0 {
+			var requestBody externalEndpointResultRequestBody
+			if err := json.Unmarshal(body, &requestBody); err != nil {
+				logr.Errorf("[api.CreateExternalEndpointResult] Invalid request body for external endpoint with key=%s: %s", key, err.Error())
+				return c.Status(400).SendString("invalid request body: " + err.Error())
+			}
+			if len(requestBody.ConditionResults) > maximumNumberOfConditionResultsPerPush {
+				return c.Status(400).SendString(fmt.Sprintf("too many condition results: maximum is %d", maximumNumberOfConditionResultsPerPush))
+			}
+			for _, conditionResult := range requestBody.ConditionResults {
+				if conditionResult == nil || len(strings.TrimSpace(conditionResult.Condition)) == 0 {
+					return c.Status(400).SendString("conditionResults[].condition must not be empty")
+				}
+				if len(conditionResult.Condition) > maximumConditionLengthPerPush {
+					return c.Status(400).SendString(fmt.Sprintf("conditionResults[].condition must not exceed %d characters", maximumConditionLengthPerPush))
+				}
+			}
+			result.ConditionResults = requestBody.ConditionResults
 		}
 		convertedEndpoint := externalEndpoint.ToEndpoint()
 		if err := store.Get().InsertEndpointResult(convertedEndpoint, result); err != nil {

--- a/api/external_endpoint_test.go
+++ b/api/external_endpoint_test.go
@@ -1,8 +1,10 @@
 package api
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/TwiN/gatus/v5/alerting"
@@ -43,6 +45,7 @@ func TestCreateExternalEndpointResult(t *testing.T) {
 	scenarios := []struct {
 		Name                           string
 		Path                           string
+		Body                           string
 		AuthorizationHeaderBearerToken string
 		ExpectedCode                   int
 	}{
@@ -112,10 +115,56 @@ func TestCreateExternalEndpointResult(t *testing.T) {
 			AuthorizationHeaderBearerToken: "Bearer token",
 			ExpectedCode:                   200,
 		},
+		{
+			Name:                           "malformed-body",
+			Path:                           "/api/v1/endpoints/g_n/external?success=true",
+			Body:                           "{",
+			AuthorizationHeaderBearerToken: "Bearer token",
+			ExpectedCode:                   400,
+		},
+		{
+			Name:                           "body-is-not-an-object",
+			Path:                           "/api/v1/endpoints/g_n/external?success=true",
+			Body:                           "[]",
+			AuthorizationHeaderBearerToken: "Bearer token",
+			ExpectedCode:                   400,
+		},
+		{
+			Name:                           "null-condition-result",
+			Path:                           "/api/v1/endpoints/g_n/external?success=true",
+			Body:                           `{"conditionResults":[null]}`,
+			AuthorizationHeaderBearerToken: "Bearer token",
+			ExpectedCode:                   400,
+		},
+		{
+			Name:                           "blank-condition",
+			Path:                           "/api/v1/endpoints/g_n/external?success=true",
+			Body:                           `{"conditionResults":[{"condition":"  ","success":true}]}`,
+			AuthorizationHeaderBearerToken: "Bearer token",
+			ExpectedCode:                   400,
+		},
+		{
+			Name:                           "condition-too-long",
+			Path:                           "/api/v1/endpoints/g_n/external?success=true",
+			Body:                           `{"conditionResults":[{"condition":"` + strings.Repeat("a", maximumConditionLengthPerPush+1) + `","success":true}]}`,
+			AuthorizationHeaderBearerToken: "Bearer token",
+			ExpectedCode:                   400,
+		},
+		{
+			Name:                           "too-many-condition-results",
+			Path:                           "/api/v1/endpoints/g_n/external?success=true",
+			Body:                           `{"conditionResults":[` + strings.Repeat(`{"condition":"[STATUS] == 200","success":true},`, maximumNumberOfConditionResultsPerPush) + `{"condition":"[STATUS] == 200","success":true}]}`,
+			AuthorizationHeaderBearerToken: "Bearer token",
+			ExpectedCode:                   400,
+		},
 	}
 	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
-			request := httptest.NewRequest("POST", scenario.Path, http.NoBody)
+			var body io.Reader = http.NoBody
+			if len(scenario.Body) > 0 {
+				body = strings.NewReader(scenario.Body)
+			}
+			request := httptest.NewRequest("POST", scenario.Path, body)
 			if len(scenario.AuthorizationHeaderBearerToken) > 0 {
 				request.Header.Set("Authorization", scenario.AuthorizationHeaderBearerToken)
 			}
@@ -173,4 +222,71 @@ func TestCreateExternalEndpointResult(t *testing.T) {
 			t.Errorf("expected 0 successes in a row but got %d", externalEndpointFromConfig.NumberOfSuccessesInARow)
 		}
 	})
+}
+
+func TestCreateExternalEndpointResultWithConditionResults(t *testing.T) {
+	defer store.Get().Clear()
+	defer cache.Clear()
+	cfg := &config.Config{
+		Alerting: &alerting.Config{
+			Discord: &discord.AlertProvider{},
+		},
+		ExternalEndpoints: []*endpoint.ExternalEndpoint{
+			{
+				Name:  "n",
+				Group: "g",
+				Token: "token",
+			},
+		},
+		Maintenance: &maintenance.Config{},
+	}
+	api := New(cfg)
+	router := api.Router()
+	push := func(t *testing.T, path, body string) {
+		t.Helper()
+		var requestBody io.Reader = http.NoBody
+		if len(body) > 0 {
+			requestBody = strings.NewReader(body)
+		}
+		request := httptest.NewRequest("POST", path, requestBody)
+		request.Header.Set("Authorization", "Bearer token")
+		response, err := router.Test(request)
+		if err != nil {
+			t.Fatalf("failed to push result: %s", err.Error())
+		}
+		defer response.Body.Close()
+		if response.StatusCode != 200 {
+			t.Fatalf("%s %s should have returned 200, but returned %d instead", request.Method, request.URL, response.StatusCode)
+		}
+	}
+	// Even though one of the conditions is successful, the result must remain unsuccessful,
+	// because success is determined by the query parameter and not by the condition results.
+	push(t, "/api/v1/endpoints/g_n/external?success=false", `{"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] < 300","success":false}],"somethingElse":1}`)
+	push(t, "/api/v1/endpoints/g_n/external?success=true", "")
+	push(t, "/api/v1/endpoints/g_n/external?success=true", "{}")
+	endpointStatus, err := store.Get().GetEndpointStatusByKey("g_n", paging.NewEndpointStatusParams().WithResults(1, 10))
+	if err != nil {
+		t.Fatalf("failed to get endpoint status: %s", err.Error())
+	}
+	if len(endpointStatus.Results) != 3 {
+		t.Fatalf("expected 3 results but got %d", len(endpointStatus.Results))
+	}
+	if endpointStatus.Results[0].Success {
+		t.Error("expected first result to be unsuccessful, because success comes from the query parameter")
+	}
+	if len(endpointStatus.Results[0].ConditionResults) != 2 {
+		t.Fatalf("expected first result to have 2 condition results but got %d", len(endpointStatus.Results[0].ConditionResults))
+	}
+	if endpointStatus.Results[0].ConditionResults[0].Condition != "[STATUS] == 200" || !endpointStatus.Results[0].ConditionResults[0].Success {
+		t.Errorf("expected first condition result to be '[STATUS] == 200' and successful, but got '%s' and %v", endpointStatus.Results[0].ConditionResults[0].Condition, endpointStatus.Results[0].ConditionResults[0].Success)
+	}
+	if endpointStatus.Results[0].ConditionResults[1].Condition != "[RESPONSE_TIME] < 300" || endpointStatus.Results[0].ConditionResults[1].Success {
+		t.Errorf("expected second condition result to be '[RESPONSE_TIME] < 300' and unsuccessful, but got '%s' and %v", endpointStatus.Results[0].ConditionResults[1].Condition, endpointStatus.Results[0].ConditionResults[1].Success)
+	}
+	if len(endpointStatus.Results[1].ConditionResults) != 0 {
+		t.Errorf("expected second result to have no condition results, because no body was sent")
+	}
+	if len(endpointStatus.Results[2].ConditionResults) != 0 {
+		t.Errorf("expected third result to have no condition results, because the body was empty")
+	}
 }


### PR DESCRIPTION
## Summary

An external endpoint can only report a single free-text `error` alongside its result, so when an agent evaluates several checks on its end, there is no way to show which of them failed. The dashboard already renders a `Conditions` list per result, but it is unreachable from the push API, which reads no request body.

Added an optional JSON body to `POST /api/v1/endpoints/{key}/external` carrying `conditionResults`, which are stored on the result and rendered like the conditions of a regular endpoint. Entries are validated (non-empty condition, max 1024 characters, max 50 per request) and a malformed body is rejected with a 400.

The query parameters are unchanged and an absent body behaves exactly like before, so existing clients are unaffected. Condition results are display-only: `success` remains the source of truth for the health of the endpoint, and no errors are synthesized from failed conditions.

## Checklist

- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable.