### PR TITLE
fix: order recent checks by timestamp

### DIFF
--- a/storage/store/sql/sql.go
+++ b/storage/store/sql/sql.go
@@ -794,7 +794,7 @@ func (s *Store) getEndpointResultsByEndpointID(tx *sql.Tx, endpointID int64, pag
 			SELECT endpoint_result_id, success, errors, connected, status, dns_rcode, certificate_expiration, domain_expiration, hostname, ip, duration, timestamp
 			FROM endpoint_results
 			WHERE endpoint_id = $1
-			ORDER BY endpoint_result_id DESC -- Normally, we'd sort by timestamp, but sorting by endpoint_result_id is faster
+			ORDER BY timestamp DESC, endpoint_result_id DESC
 			LIMIT $2 OFFSET $3
 		`,
 		endpointID,

--- a/storage/store/sql/sql_test.go
+++ b/storage/store/sql/sql_test.go
@@ -292,6 +292,45 @@ func TestStore_InsertCleansUpEventsAndResultsProperly(t *testing.T) {
 	}
 }
 
+func TestStore_ResultsAreOrderedByTimestamp(t *testing.T) {
+	store, _ := NewStore("sqlite", t.TempDir()+"/TestStore_ResultsAreOrderedByTimestamp.db", false, storage.DefaultMaximumNumberOfResults, storage.DefaultMaximumNumberOfEvents)
+	defer store.Close()
+
+	olderResult := testUnsuccessfulResult
+	olderResult.Timestamp = time.Now().Add(-time.Minute)
+	newerResult := testSuccessfulResult
+	newerResult.Timestamp = time.Now()
+
+	if err := store.InsertEndpointResult(&testEndpoint, &newerResult); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.InsertEndpointResult(&testEndpoint, &olderResult); err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := store.GetEndpointStatusByKey(testEndpoint.Key(), paging.NewEndpointStatusParams().WithResults(1, 1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(status.Results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(status.Results))
+	}
+	if !status.Results[0].Timestamp.Equal(newerResult.Timestamp) {
+		t.Errorf("expected most recent result timestamp %s, got %s", newerResult.Timestamp, status.Results[0].Timestamp)
+	}
+
+	status, err = store.GetEndpointStatusByKey(testEndpoint.Key(), paging.NewEndpointStatusParams().WithResults(1, 2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(status.Results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(status.Results))
+	}
+	if !status.Results[0].Timestamp.Equal(olderResult.Timestamp) || !status.Results[1].Timestamp.Equal(newerResult.Timestamp) {
+		t.Errorf("expected results in chronological order, got %s then %s", status.Results[0].Timestamp, status.Results[1].Timestamp)
+	}
+}
+
 func TestStore_InsertWithCaching(t *testing.T) {
 	store, _ := NewStore("sqlite", t.TempDir()+"/TestStore_InsertWithCaching.db", true, storage.DefaultMaximumNumberOfResults, storage.DefaultMaximumNumberOfEvents)
 	defer store.Close()


### PR DESCRIPTION
Fixes #1732

## Summary
- select recent endpoint results by timestamp instead of generated ID
- use the result ID as a deterministic tie-breaker
- preserve chronological ordering within the returned page
- cover pagination and display ordering when IDs and timestamps disagree

## Testing
- `go test ./storage/store/sql -run '^TestStore_ResultsAreOrderedByTimestamp$' -count=1`
- `make test`
- `go test ./... -race`
- `go build ./...`
- `go vet ./...`
- `gofmt -d storage/store/sql/sql.go storage/store/sql/sql_test.go`
- `git diff --check`

## Agent disclosure
This contribution was made by OpenAI Codex (GPT-5).