### PR TITLE
ci: harden github actions and add a continuous check

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: 1.26.3
           repository: "${{ github.event.inputs.repository || 'TwiN/gatus' }}"
           ref: "${{ github.event.inputs.ref || 'master' }}"
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Benchmark
         run: go test -bench=. ./storage/store

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,6 +14,9 @@ on:
         description: "Branch, tag or SHA to checkout"
         required: true
         default: "master"
+permissions:
+  contents: read
+
 jobs:
   build:
     name: benchmark

--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -1,0 +1,34 @@
+name: Plumber
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  plumber:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+      # Needed by score-push to publish the score for the README badge.
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: getplumber/plumber@7ad9d267ee5a00163cec9e5c749a088d5f565167 # v0.4.26
+        with:
+          # Code scanning upload needs security-events write, which PRs
+          # from forks do not get. The report stays available as a
+          # workflow artifact there.
+          upload-sarif: ${{ github.event.pull_request.head.repo.fork != true }}
+          # Publishes the score to score.getplumber.io, which feeds the
+          # badge in the README. A failed push never fails the run.
+          score-push: true
+          # Gate at 85 points instead of the all-or-nothing default,
+          # leaves room for a small finding without blocking PRs.
+          min-points: 85

--- a/.github/workflows/publish-custom.yml
+++ b/.github/workflows/publish-custom.yml
@@ -19,28 +19,28 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Get image repository
         run: echo GHCR_IMAGE_REPOSITORY=$(echo ghcr.io/${{ github.actor }}/${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4.5.2
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.GHCR_IMAGE_REPOSITORY }}
           tags: |
             type=raw,value=${{ inputs.tag }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           platforms: ${{ inputs.platforms }}
           pull: true

--- a/.github/workflows/publish-custom.yml
+++ b/.github/workflows/publish-custom.yml
@@ -14,6 +14,11 @@ on:
           - linux/arm/v7
           - linux/arm64
 
+# The docker push to ghcr.io authenticates with GITHUB_TOKEN.
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   publish-custom:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-experimental.yml
+++ b/.github/workflows/publish-experimental.yml
@@ -1,5 +1,8 @@
 name: publish-experimental
 on: [workflow_dispatch]
+permissions:
+  contents: read
+
 jobs:
   publish-experimental:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-experimental.yml
+++ b/.github/workflows/publish-experimental.yml
@@ -5,27 +5,27 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Get image repository
         run: echo IMAGE_REPOSITORY=$(echo ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
       - name: Login to Docker Registry
-        uses: docker/login-action@v4.5.2
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.IMAGE_REPOSITORY }}
           tags: |
             type=raw,value=experimental
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           platforms: linux/amd64
           pull: true

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -7,6 +7,11 @@ on:
 concurrency:
   group: ${{ github.event.workflow_run.head_repository.full_name }}::${{ github.event.workflow_run.head_branch }}::${{ github.workflow }}
   cancel-in-progress: true
+# The docker push to ghcr.io authenticates with GITHUB_TOKEN.
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   publish-latest:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -13,29 +13,29 @@ jobs:
     if: ${{ (github.event.workflow_run.conclusion == 'success') && (github.event.workflow_run.head_repository.full_name == github.repository) }}
     timeout-minutes: 240
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Get image repository
         run: |
           echo DOCKER_IMAGE_REPOSITORY=$(echo ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
           echo GHCR_IMAGE_REPOSITORY=$(echo ghcr.io/${{ github.actor }}/${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
       - name: Login to Docker Registry
-        uses: docker/login-action@v4.5.2
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4.5.2
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ env.DOCKER_IMAGE_REPOSITORY }}
@@ -43,7 +43,7 @@ jobs:
           tags: |
             type=raw,value=latest
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           pull: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 240
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Get image repository
         run: |
           echo DOCKER_IMAGE_REPOSITORY=$(echo ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
@@ -20,19 +20,19 @@ jobs:
       - name: Get the release
         run: echo RELEASE=${GITHUB_REF/refs\/tags\//} >> $GITHUB_ENV
       - name: Login to Docker Registry
-        uses: docker/login-action@v4.5.2
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4.5.2
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ env.DOCKER_IMAGE_REPOSITORY }}
@@ -42,7 +42,7 @@ jobs:
             type=raw,value=stable
             type=raw,value=latest
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           pull: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -2,6 +2,11 @@ name: publish-release
 on:
   release:
     types: [published]
+# The docker push to ghcr.io authenticates with GITHUB_TOKEN.
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   publish-release:
     name: publish-release

--- a/.github/workflows/regenerate-static-assets.yml
+++ b/.github/workflows/regenerate-static-assets.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Check command trigger
         id: command
-        uses: github/command@v2
+        uses: github/command@3442f3fa1efe01bdb024b157083c337902d17372 # v2.0.3
         with:
           command: "/regenerate-static-assets"
           permissions: "write,admin" # The allowed permission levels to invoke this command
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Get PR branch
         id: pr
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -46,7 +46,7 @@ jobs:
             core.setOutput('ref', pr.data.head.ref);
             core.setOutput('repo', pr.data.head.repo.full_name);
       - name: Checkout PR branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ steps.pr.outputs.repo }}
           ref: ${{ steps.pr.outputs.ref }}
@@ -79,7 +79,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Create response comment
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const status = '${{ needs.regenerate-static-assets.outputs.status }}';

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -8,6 +8,9 @@ on:
       - master
     paths:
       - 'web/**'
+permissions:
+  contents: read
+
 jobs:
   test-ui:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: make frontend-install
       - run: make frontend-build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: 1.26.3
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build binary to make sure it works
         run: go build
       - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ on:
       - '*.md'
       - '.github/**'
       - '.examples/**'
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/TwiN/gatus?)](https://goreportcard.com/report/github.com/TwiN/gatus)
 [![Go version](https://img.shields.io/github/go-mod/go-version/TwiN/gatus.svg)](https://github.com/TwiN/gatus)
 [![Docker pulls](https://img.shields.io/docker/pulls/twinproduction/gatus.svg)](https://cloud.docker.com/repository/docker/twinproduction/gatus)
+[![Plumber Score](https://score.getplumber.io/github.com/TwiN/gatus.svg)](https://score.getplumber.io/github.com/TwiN/gatus)
 [![Follow TwiN](https://img.shields.io/github/followers/TwiN?label=Follow&style=social)](https://github.com/TwiN)
 
 Gatus is a developer-oriented health dashboard that gives you the ability to monitor your services using HTTP, ICMP, TCP, and even DNS


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
Hi, drive-by CI hardening in three commits, one logical change each.

**Commit 1 pins every action to its commit sha**, versions kept as comments. A tag like `@v4` is a movable pointer: whoever controls the action, or anyone who compromises it, can re-point it and your next run executes their code with the job's token, including in the four publish workflows that push images to ghcr and Docker Hub. Even a precise tag like `v4.5.2` can be re-pointed, only a commit sha cannot. Same pattern as the tj-actions/changed-files incident (CVE-2025-30066). All shas were resolved from the upstream repos and cross checked against their release tags. Dependabot keeps opening its bump PRs exactly as before, it understands sha pins with a version comment, same as its recent docker/login-action bump.

**Commit 2 adds `permissions:` blocks to the seven workflows that had none.** The scopes are derived from what each workflow does with the token, not guessed: the test, ui and benchmark workflows only check out and build (`contents: read`), publish-experimental pushes to Docker Hub with dedicated secrets (`contents: read` too), and the three workflows that log into ghcr.io with GITHUB_TOKEN get `packages: write` on top. Your labeler and regenerate-static-assets workflows already declare scoped permissions and are untouched.

**Commit 3 adds [Plumber](https://github.com/getplumber/plumber) to CI**, the tool I used to find the issues in the first place, so none of this quietly drifts back:

- Scans the workflows on each push to master and on each PR, fails when something regresses: an unpinned action, a job without permissions, an archived dependency, a known CVE.
- Runs on its built-in defaults, no config file to review. Findings land in the security tab as SARIF.
- Adds a score badge to the README. It works like OpenSSF Scorecard's published results: runs publish the score to score.getplumber.io, the badge shows the state of master, a failed publish never fails your CI, and it reads UNKNOWN in gray until the first run.

One heads up: if the org uses an Actions allowlist in settings, patterns written against tags (like `owner/action@v4`) stop matching once refs are shas and workflows refuse to start. Entries need to be `owner/action@*` in that case.

To be fully transparent: I work on Plumber. If you do not want the tool in your CI, no hard feelings, say so and I remove that commit from the PR, the two hardening commits are the part that matters and they stand entirely on their own.
## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Updated documentation in `README.md`, if applicable.
