### PR TITLE
fix(jsonpath): prevent panic when key-with-index applied to top-level array

### DIFF
--- a/jsonpath/jsonpath.go
+++ b/jsonpath/jsonpath.go
@@ -102,11 +102,12 @@ func extractValue(currentKey string, value interface{}) interface{} {
 			}
 			return nil
 		}
-		if value == nil || value.(map[string]interface{})[currentKeyWithoutIndex] == nil {
+		valueAsMap, ok := value.(map[string]interface{})
+		if !ok || valueAsMap[currentKeyWithoutIndex] == nil {
 			return nil
 		}
 		// if currentKeyWithoutIndex contains both a key and an index (i.e. data[0])
-		array, _ := value.(map[string]interface{})[currentKeyWithoutIndex].([]interface{})
+		array, _ := valueAsMap[currentKeyWithoutIndex].([]interface{})
 		if len(array) > arrayIndex {
 			if isNestedArray {
 				return extractValue(currentKey[endOfBracket+1:], array[arrayIndex])

--- a/jsonpath/jsonpath_test.go
+++ b/jsonpath/jsonpath_test.go
@@ -63,6 +63,14 @@ func TestEval(t *testing.T) {
 			ExpectedError:        false,
 		},
 		{
+			Name:                 "key-with-index-on-top-level-array",
+			Path:                 "foo[0]",
+			Data:                 `[1, 2, 3]`,
+			ExpectedOutput:       "",
+			ExpectedOutputLength: 0,
+			ExpectedError:        true,
+		},
+		{
 			Name:                 "array-of-values-with-no-path",
 			Path:                 "",
 			Data:                 `[1, 2]`,


### PR DESCRIPTION
### Problem

`jsonpath.extractValue` uses an **unchecked** type assertion when a key has both a prefix and an index (e.g. `foo[0]`):

```go
if value == nil || value.(map[string]interface{})[currentKeyWithoutIndex] == nil {
```

If the value at that level is a JSON **array** rather than an object, the assertion panics:

```
interface conversion: interface {} is []interface {}, not map[string]interface {}
```

Minimal repro:

```go
jsonpath.Eval("foo[0]", []byte("[1,2,3]")) // panics
```

This is reachable from live HTTP response bodies via `[BODY].foo[0]`-style conditions, so a target returning a top-level JSON array crashes the health-check worker rather than just failing the condition. Same class of unchecked-assertion bug as #1703 in this file.

### Fix

Use the comma-ok form — mirroring the sibling array assertion already a few lines below — so a non-map value returns the not-found result instead of panicking. `valueAsMap` is reused on the following line, so the assertion is done once.

### Tests

Added a table case `key-with-index-on-top-level-array` in `jsonpath_test.go` asserting `Eval("foo[0]", []byte("[1,2,3]"))` returns the not-found result (empty output, error) instead of panicking. Verified it panics without the fix and passes with it; full `go test ./jsonpath/...` green (97.2% coverage).

---
for the record: fix found + patched with AI help; all human-reviewed.
