### PR TITLE
fix: preserve explicit zero concurrency

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -123,8 +123,27 @@ type Config struct {
 	// Announcements is the list of system-wide announcements
 	Announcements []*announcement.Announcement `yaml:"announcements,omitempty"`
 
-	configPath      string    // path to the file or directory from which config was loaded
-	lastFileModTime time.Time // last modification time
+	configPath            string    // path to the file or directory from which config was loaded
+	lastFileModTime       time.Time // last modification time
+	concurrencyConfigured bool      // whether concurrency was explicitly present in the YAML configuration
+}
+
+// UnmarshalYAML records whether concurrency was explicitly configured so that
+// an omitted value can use the default while an explicit zero remains the
+// documented unlimited-concurrency setting.
+func (config *Config) UnmarshalYAML(value *yaml.Node) error {
+	type configWithoutMethods Config
+	if err := value.Decode((*configWithoutMethods)(config)); err != nil {
+		return err
+	}
+	config.concurrencyConfigured = false
+	for i := 0; i+1 < len(value.Content); i += 2 {
+		if value.Content[i].Value == "concurrency" && value.Content[i+1].Tag != "!!null" {
+			config.concurrencyConfigured = true
+			break
+		}
+	}
+	return nil
 }
 
 // GetUniqueExtraMetricLabels returns a slice of unique metric labels from all enabled endpoints
@@ -691,7 +710,7 @@ func ValidateAndSetConcurrencyDefaults(config *Config) {
 		logr.Warn("WARNING: The 'disable-monitoring-lock' configuration has been deprecated and will be removed in v6.0.0")
 		logr.Warn("WARNING: Please set 'concurrency: 0' instead")
 		logr.Debug("[config.ValidateAndSetConcurrencyDefaults] DisableMonitoringLock is true, setting unlimited (0) concurrency")
-	} else if config.Concurrency <= 0 && !config.DisableMonitoringLock {
+	} else if config.Concurrency < 0 || (config.Concurrency == 0 && !config.concurrencyConfigured) {
 		config.Concurrency = DefaultConcurrency
 		logr.Debugf("[config.ValidateAndSetConcurrencyDefaults] Setting default concurrency to %d", config.Concurrency)
 	} else {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -539,6 +539,40 @@ endpoints:
 	}
 }
 
+func TestParseAndValidateConfigBytesConcurrency(t *testing.T) {
+	tests := []struct {
+		name          string
+		configuration string
+		expected      int
+	}{
+		{name: "omitted uses default", expected: DefaultConcurrency},
+		{name: "null uses default", configuration: "concurrency:", expected: DefaultConcurrency},
+		{name: "explicit zero is unlimited", configuration: "concurrency: 0", expected: 0},
+		{name: "positive value is preserved", configuration: "concurrency: 20", expected: 20},
+		{name: "negative value uses default", configuration: "concurrency: -1", expected: DefaultConcurrency},
+		{name: "deprecated lock disable is unlimited", configuration: "disable-monitoring-lock: true", expected: 0},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config, err := parseAndValidateConfigBytes([]byte(fmt.Sprintf(`
+%s
+endpoints:
+  - name: website
+    url: https://twin.sh/health
+    conditions:
+      - "[STATUS] == 200"
+`, test.configuration)))
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if config.Concurrency != test.expected {
+				t.Errorf("expected concurrency %d, got %d", test.expected, config.Concurrency)
+			}
+		})
+	}
+}
+
 func TestParseAndValidateConfigBytesWithAddress(t *testing.T) {
 	config, err := parseAndValidateConfigBytes([]byte(`
 web:


### PR DESCRIPTION
## Summary

- preserve explicit `concurrency: 0` as unlimited monitoring
- continue defaulting omitted, null, and negative concurrency values to 3
- preserve positive values and the deprecated `disable-monitoring-lock: true` compatibility path

## Root cause

YAML decoding collapsed an omitted integer and an explicit zero into the same Go zero value. Default validation then treated both as unspecified and replaced them with `DefaultConcurrency`.

The configuration decoder now records whether a non-null `concurrency` key was present. Defaulting uses that provenance to keep the documented zero value distinct without changing the public configuration field.

## Impact

Operators using `concurrency: 0` retain unlimited monitoring, so slow checks are not unexpectedly serialized to three workers and prevented from reaching configured alert thresholds during short outages.

## Verification

- red-first regression: explicit zero returned 3 before the repair
- focused concurrency regression: PASS
- full `config` package: PASS
- focused race regression: PASS
- `go test ./... -cover -count=1`: PASS
- `go test ./... -race -count=1`: PASS
- `go vet ./...`: PASS
- `go build ./...`: PASS
- `git diff --check`: PASS

Closes #1755.

Created by Codex (GPT-5).
