### PR TITLE
docs: update the postgres bind mount in the compose example

### DIFF
--- a/.examples/docker-compose-postgres-storage/compose.yaml
+++ b/.examples/docker-compose-postgres-storage/compose.yaml
@@ -2,7 +2,9 @@ services:
   postgres:
     image: postgres
     volumes:
-      - ./data/db:/var/lib/postgresql/data
+      # PostgreSQL 18 and above declare the volume at /var/lib/postgresql.
+      # For 17 and earlier, mount ./data/db at /var/lib/postgresql/data instead.
+      - ./data/db:/var/lib/postgresql
     ports:
       - "5432:5432"
     environment:


### PR DESCRIPTION
Fixes #1596.

The compose example uses the unpinned `postgres` image, which is 18 or newer, and mounts the data directory at `/var/lib/postgresql/data`. Postgres 18 made `PGDATA` version specific (`/var/lib/postgresql/18/docker`) and moved the declared `VOLUME` to `/var/lib/postgresql`, so mounts have to target the new location.

Since the same file would be wrong for anyone pinning an older image — the upstream docs warn that on 17 and earlier a mount at `/var/lib/postgresql` does not persist data — I left a two-line comment with the old path next to the new one.
