### PR TITLE
fix(client): resolve endpoint hostnames as absolute with a custom DNS resolver

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -174,7 +174,7 @@ func CanPerformStartTLS(address string, config *Config) (connected bool, certifi
 					},
 				},
 			}
-			connection, err = dialer.DialContext(context.Background(), "tcp", address)
+			connection, err = dialer.DialContext(context.Background(), "tcp", absoluteDialAddress(address))
 			if err != nil {
 				return
 			}

--- a/client/config.go
+++ b/client/config.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/TwiN/gatus/v5/config/tunneling/sshtunnel"
@@ -38,6 +39,25 @@ var (
 		StoreCookies:   false,
 	}
 )
+
+// absoluteDialAddress fully qualifies the host of a host:port dial address, so that the
+// resolver answers it directly instead of walking the system search list first.
+//
+// A custom DNS resolver forces Go's pure-Go resolver, which still reads the search domains
+// and ndots from /etc/resolv.conf and applies them to the configured resolver. A hostname
+// configured on an endpoint is always meant as absolute, so that expansion is never wanted:
+// under Kubernetes, where kubelet writes ndots:5 into every pod, it turns each check into
+// several guaranteed-NXDOMAIN lookups sent to the configured resolver.
+//
+// Only the name handed to the resolver changes. SNI and the Host header are taken from the
+// request URL, so the trailing dot is not visible to the target.
+func absoluteDialAddress(address string) string {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil || len(host) == 0 || strings.HasSuffix(host, ".") || net.ParseIP(host) != nil {
+		return address
+	}
+	return net.JoinHostPort(host+".", port)
+}
 
 // GetDefaultConfig returns a copy of the default configuration
 func GetDefaultConfig() *Config {
@@ -266,7 +286,7 @@ func (c *Config) getHTTPClient() *http.Client {
 					},
 				}
 				c.httpClient.Transport.(*http.Transport).DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-					return dialer.DialContext(ctx, network, addr)
+					return dialer.DialContext(ctx, network, absoluteDialAddress(addr))
 				}
 			}
 		}

--- a/client/config_test.go
+++ b/client/config_test.go
@@ -184,3 +184,49 @@ func TestConfig_TlsIsValid(t *testing.T) {
 		})
 	}
 }
+
+func TestAbsoluteDialAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		address string
+		want    string
+	}{
+		{
+			name:    "hostname-is-made-absolute",
+			address: "example.com:443",
+			want:    "example.com.:443",
+		},
+		{
+			name:    "already-absolute-hostname-is-left-alone",
+			address: "example.com.:443",
+			want:    "example.com.:443",
+		},
+		{
+			name:    "ipv4-literal-is-left-alone",
+			address: "1.1.1.1:443",
+			want:    "1.1.1.1:443",
+		},
+		{
+			name:    "ipv6-literal-is-left-alone",
+			address: "[2606:4700:4700::1111]:443",
+			want:    "[2606:4700:4700::1111]:443",
+		},
+		{
+			name:    "address-without-port-is-left-alone",
+			address: "example.com",
+			want:    "example.com",
+		},
+		{
+			name:    "empty-host-is-left-alone",
+			address: ":443",
+			want:    ":443",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := absoluteDialAddress(tt.address); got != tt.want {
+				t.Errorf("absoluteDialAddress(%q) = %q, want %q", tt.address, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1769.

### Problem

Setting `client.dns-resolver` builds a `net.Resolver` with `PreferGo: true`. The pure-Go resolver still reads the `search` domains and `ndots` from `/etc/resolv.conf` and applies them — Gatus just sends the resulting queries to the configured resolver instead of the system one.

A hostname configured on an endpoint is always meant as absolute, so that expansion is never wanted. On Kubernetes it is also expensive: kubelet writes `options ndots:5` into every `ClusterFirst` pod, so a normal monitored hostname is treated as relative and the search list is walked first.

```
audiobookshelf.example.com.observability.svc.cluster.local   NXDOMAIN
audiobookshelf.example.com.svc.cluster.local                 NXDOMAIN
audiobookshelf.example.com.cluster.local                     NXDOMAIN
audiobookshelf.example.com                                   ← the intended one
```

Doubled by A and AAAA, that is 8 queries per check where 2 are wanted, and each bogus one discloses the cluster's internal `<namespace>.svc.cluster.local` naming to the configured public resolver. Measured hit counts and a packet capture are in the issue.

### Change

Qualify the host of the dial address before handing it to the resolver:

```go
func absoluteDialAddress(address string) string {
	host, port, err := net.SplitHostPort(address)
	if err != nil || len(host) == 0 || strings.HasSuffix(host, ".") || net.ParseIP(host) != nil {
		return address
	}
	return net.JoinHostPort(host+".", port)
}
```

Applied at both places that build the custom resolver — `getHTTPClient` in `client/config.go` and `CanPerformStartTLS` in `client/client.go`.

### Notes on scope and safety

- **Only the custom-resolver path changes.** The default path keeps using the system resolver with its search list intact, since honouring `search` there is correct and users may rely on it for short internal names.
- **Not visible to the target.** Only the name handed to the resolver is affected. SNI and the `Host` header come from the request URL, and in `CanPerformStartTLS` the `ServerName` is taken from the original argument, not the dial address.
- **Idempotent and conservative.** IP literals (v4 and v6), already-absolute names, and addresses without a port are returned unchanged.

### Testing

`TestAbsoluteDialAddress` covers all six cases above. `make test` passes across the repo. No dependency changes, so no `go mod tidy && go mod vendor` needed, and no frontend changes.
