### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ core applications: https://status.twin.sh/
 
 _Looking for a managed solution? Check out [Gatus.io](https://gatus.io)._
 
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/gatus)
+
 <details>
   <summary><b>Quick start</b></summary>
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary

Hey! I work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Gatus to our marketplace, so this PR adds a small "Deploy with Zenith" badge right under the "looking for a managed solution?" line in the README (it links to https://zenith.hosting/host/gatus).

We share a cut of revenue with the projects we host, so hosting Gatus this way sends some
money back to the project. happy to explain if you're curious at hello@zenith.hosting

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [ ] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Updated documentation in `README.md`, if applicable.