### PR TITLE
Honor minimum-reminder-interval for external endpoints

### DIFF
--- a/api/external_endpoint.go
+++ b/api/external_endpoint.go
@@ -78,8 +78,13 @@ func CreateExternalEndpointResult(cfg *config.Config) fiber.Handler {
 		// Check if an alert should be triggered or resolved
 		if !cfg.Maintenance.IsUnderMaintenance() && !inEndpointMaintenanceWindow {
 			watchdog.HandleAlerting(convertedEndpoint, result, cfg.Alerting)
+			// Sync the counters and the reminder clock back; LastReminderSent
+			// lives on the converted copy and would otherwise reset to zero on
+			// every pushed result, re-sending the alert and ignoring
+			// minimum-reminder-interval (#1765).
 			externalEndpoint.NumberOfSuccessesInARow = convertedEndpoint.NumberOfSuccessesInARow
 			externalEndpoint.NumberOfFailuresInARow = convertedEndpoint.NumberOfFailuresInARow
+			externalEndpoint.LastReminderSent = convertedEndpoint.LastReminderSent
 		} else {
 			logr.Debug("[api.CreateExternalEndpointResult] Not handling alerting because currently in the maintenance window")
 		}

--- a/config/endpoint/external_endpoint.go
+++ b/config/endpoint/external_endpoint.go
@@ -48,6 +48,13 @@ type ExternalEndpoint struct {
 
 	// NumberOfSuccessesInARow is the number of successful evaluations in a row
 	NumberOfSuccessesInARow int `yaml:"-"`
+
+	// LastReminderSent is the time at which the last reminder was sent for this endpoint.
+	// External endpoints run alerting against a converted copy (see ToEndpoint),
+	// so the copy's value must be synced back here after every HandleAlerting
+	// call, or every heartbeat tick / pushed result would see a zero value and
+	// re-send the alert, ignoring minimum-reminder-interval (#1765).
+	LastReminderSent time.Time `yaml:"-"`
 }
 
 // ValidateAndSetDefaults validates the ExternalEndpoint and sets the default values
@@ -95,6 +102,7 @@ func (externalEndpoint *ExternalEndpoint) ToEndpoint() *Endpoint {
 		Alerts:                  externalEndpoint.Alerts,
 		NumberOfFailuresInARow:  externalEndpoint.NumberOfFailuresInARow,
 		NumberOfSuccessesInARow: externalEndpoint.NumberOfSuccessesInARow,
+		LastReminderSent:        externalEndpoint.LastReminderSent,
 	}
 	return endpoint
 }

--- a/watchdog/alerting_test.go
+++ b/watchdog/alerting_test.go
@@ -683,3 +683,69 @@ func verify(t *testing.T, ep *endpoint.Endpoint, expectedNumberOfFailuresInARow,
 		}
 	}
 }
+
+// TestHandleAlertingOnExternalEndpointConversionPreservesReminderInterval pins
+// the external-endpoint flow, which runs alerting against a ToEndpoint() copy
+// per heartbeat tick / pushed result (#1765): the copy must carry
+// LastReminderSent over, and the caller must sync it back, or every tick sees
+// a zero clock and re-sends the alert regardless of minimum-reminder-interval.
+func TestHandleAlertingOnExternalEndpointConversionPreservesReminderInterval(t *testing.T) {
+	_ = os.Setenv("MOCK_ALERT_PROVIDER", "true")
+	defer os.Clearenv()
+
+	cfg := &config.Config{
+		Alerting: &alerting.Config{
+			Custom: &custom.AlertProvider{
+				DefaultConfig: custom.Config{
+					URL:    "https://twin.sh/health",
+					Method: "GET",
+				},
+			},
+		},
+	}
+	enabled := true
+	ee := &endpoint.ExternalEndpoint{
+		Name:  "external",
+		Group: "g",
+		Alerts: []*alert.Alert{
+			{
+				Type:                   alert.TypeCustom,
+				Enabled:                &enabled,
+				FailureThreshold:       1,
+				MinimumReminderInterval: time.Hour,
+			},
+		},
+	}
+
+	// First evaluation triggers the initial alert and stamps the clock.
+	converted := ee.ToEndpoint()
+	HandleAlerting(converted, &endpoint.Result{Success: false}, cfg.Alerting)
+	ee.NumberOfFailuresInARow = converted.NumberOfFailuresInARow
+	ee.LastReminderSent = converted.LastReminderSent
+
+	if !ee.Alerts[0].Triggered {
+		t.Fatal("the alert should have triggered")
+	}
+	if ee.LastReminderSent.IsZero() {
+		t.Fatal("the initial alert should have stamped LastReminderSent on the external endpoint")
+	}
+
+	// A tick 30m later — below the 1h minimum-reminder-interval — must not
+	// refresh the clock (no reminder sent).
+	ee.LastReminderSent = time.Now().Add(-30 * time.Minute)
+	converted = ee.ToEndpoint()
+	HandleAlerting(converted, &endpoint.Result{Success: false}, cfg.Alerting)
+	ee.LastReminderSent = converted.LastReminderSent
+	if time.Since(ee.LastReminderSent) < 25*time.Minute {
+		t.Fatal("a reminder was sent before minimum-reminder-interval elapsed")
+	}
+
+	// A tick 2h later must send the reminder and refresh the clock.
+	ee.LastReminderSent = time.Now().Add(-2 * time.Hour)
+	converted = ee.ToEndpoint()
+	HandleAlerting(converted, &endpoint.Result{Success: false}, cfg.Alerting)
+	ee.LastReminderSent = converted.LastReminderSent
+	if time.Since(ee.LastReminderSent) > time.Minute {
+		t.Fatal("the overdue reminder should have refreshed LastReminderSent")
+	}
+}

--- a/watchdog/external_endpoint.go
+++ b/watchdog/external_endpoint.go
@@ -73,9 +73,15 @@ func executeExternalEndpointHeartbeat(ee *endpoint.ExternalEndpoint, cfg *config
 	}
 	if !cfg.Maintenance.IsUnderMaintenance() && !inEndpointMaintenanceWindow {
 		HandleAlerting(convertedEndpoint, result, cfg.Alerting)
-		// Sync the failure/success counters back to the external endpoint
+		// Sync the failure/success counters and the reminder clock back to
+		// the external endpoint; alert Triggered flags already stick because
+		// ToEndpoint shares the Alerts slice, but LastReminderSent lives on
+		// the converted copy and would otherwise reset to zero on every
+		// heartbeat tick, re-sending the alert and ignoring
+		// minimum-reminder-interval (#1765).
 		ee.NumberOfSuccessesInARow = convertedEndpoint.NumberOfSuccessesInARow
 		ee.NumberOfFailuresInARow = convertedEndpoint.NumberOfFailuresInARow
+		ee.LastReminderSent = convertedEndpoint.LastReminderSent
 	} else {
 		logr.Debug("[watchdog.monitorExternalEndpointHeartbeat] Not handling alerting because currently in the maintenance window")
 	}


### PR DESCRIPTION
Fixes #1765.

## Root cause

External endpoints run alerting against a `ToEndpoint()` **copy** on every heartbeat tick (and every pushed result). Two pieces of alert state have different fates across that conversion:

- `Alert.Triggered` survives, because `ToEndpoint` shares the `Alerts` slice and its pointer elements;
- `Endpoint.LastReminderSent` does not: it is a plain field on the converted copy. `handleAlertsToTrigger` stamps it there (`ep.LastReminderSent = time.Now()`), the copy is discarded, and only the failure/success counters are synced back to the `ExternalEndpoint`.

So every tick built a fresh copy with the zero `time.Time`, `time.Since(zero)` was always past `minimum-reminder-interval`, `sendReminder` was always true, and the alert re-sent on each heartbeat evaluation — with `heartbeat.interval: 5m` and `minimum-reminder-interval: 1h`, alerts at 03:25, 03:30, 03:40… exactly as reported.

## Fix

- `ExternalEndpoint` gains `LastReminderSent` (in-memory only, `yaml:"-"`);
- `ToEndpoint` carries it into the converted endpoint;
- both call sites — `executeExternalEndpointHeartbeat` (watchdog) and `CreateExternalEndpointResult` (push API) — sync it back alongside the counters they already sync.

## Test

`TestHandleAlertingOnExternalEndpointConversionPreservesReminderInterval` (watchdog) simulates the per-tick conversion flow: the initial trigger stamps the clock; a tick 30m later (below the 1h interval) must not refresh it; a tick 2h later must. Differential: the test does not build against `main` (the field/copy-back do not exist there). `go test ./watchdog/ ./config/endpoint/ ./api/` all green.
