### PR TITLE
Support client.proxy-url on the connectivity checker

### DIFF
--- a/api/external_endpoint.go
+++ b/api/external_endpoint.go
@@ -78,8 +78,13 @@ func CreateExternalEndpointResult(cfg *config.Config) fiber.Handler {
 		// Check if an alert should be triggered or resolved
 		if !cfg.Maintenance.IsUnderMaintenance() && !inEndpointMaintenanceWindow {
 			watchdog.HandleAlerting(convertedEndpoint, result, cfg.Alerting)
+			// Sync the counters and the reminder clock back; LastReminderSent
+			// lives on the converted copy and would otherwise reset to zero on
+			// every pushed result, re-sending the alert and ignoring
+			// minimum-reminder-interval (#1765).
 			externalEndpoint.NumberOfSuccessesInARow = convertedEndpoint.NumberOfSuccessesInARow
 			externalEndpoint.NumberOfFailuresInARow = convertedEndpoint.NumberOfFailuresInARow
+			externalEndpoint.LastReminderSent = convertedEndpoint.LastReminderSent
 		} else {
 			logr.Debug("[api.CreateExternalEndpointResult] Not handling alerting because currently in the maintenance window")
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -99,7 +99,13 @@ func CanCreateNetworkConnection(netType string, address string, body string, con
 	const (
 		MaximumMessageSize = 1024 // in bytes
 	)
-	connection, err := net.DialTimeout(netType, address, config.Timeout)
+	var connection net.Conn
+	var err error
+	if config.ProxyURL != "" && netType == "tcp" {
+		connection, err = dialThroughProxy(config, address)
+	} else {
+		connection, err = net.DialTimeout(netType, address, config.Timeout)
+	}
 	if err != nil {
 		return false, nil
 	}

--- a/client/proxy_dial.go
+++ b/client/proxy_dial.go
@@ -1,0 +1,81 @@
+package client
+
+import (
+	"bufio"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"golang.org/x/net/proxy"
+)
+
+// dialThroughProxy establishes a TCP connection to address by tunneling
+// through the proxy named by config.ProxyURL. HTTP and HTTPS proxies are
+// reached with a CONNECT handshake; socks5 proxies are dialed directly
+// (hostnames are resolved by the proxy, which is the point of routing a
+// connectivity check through it). Any other scheme falls back to a plain
+// dial, matching how little the raw-dial path can assume about its callers.
+func dialThroughProxy(config *Config, address string) (net.Conn, error) {
+	proxyURL, err := url.Parse(config.ProxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("client.DialThroughProxy: %w", err)
+	}
+	switch strings.ToLower(proxyURL.Scheme) {
+	case "http", "https":
+		return dialThroughHTTPConnectProxy(proxyURL, address, config.Timeout)
+	case "socks5", "socks5h":
+		var auth *proxy.Auth
+		if proxyURL.User != nil {
+			password, _ := proxyURL.User.Password()
+			auth = &proxy.Auth{User: proxyURL.User.Username(), Password: password}
+		}
+		dialer, err := proxy.SOCKS5("tcp", proxyURL.Host, auth, &net.Dialer{Timeout: config.Timeout})
+		if err != nil {
+			return nil, fmt.Errorf("client.DialThroughProxy: %w", err)
+		}
+		return dialer.Dial("tcp", address)
+	default:
+		return net.DialTimeout("tcp", address, config.Timeout)
+	}
+}
+
+// dialThroughHTTPConnectProxy performs the RFC 7231 CONNECT handshake against
+// proxy and returns the tunneled connection.
+func dialThroughHTTPConnectProxy(proxyURL *url.URL, address string, timeout time.Duration) (net.Conn, error) {
+	proxyConn, err := net.DialTimeout("tcp", proxyURL.Host, timeout)
+	if err != nil {
+		return nil, fmt.Errorf("client.DialThroughProxy: %w", err)
+	}
+	if err := proxyConn.SetDeadline(time.Now().Add(timeout)); err != nil {
+		_ = proxyConn.Close()
+		return nil, fmt.Errorf("client.DialThroughProxy: %w", err)
+	}
+	request := "CONNECT " + address + " HTTP/1.1\r\nHost: " + address + "\r\n"
+	if proxyURL.User != nil {
+		// RFC 7617 basic proxy authentication.
+		password, _ := proxyURL.User.Password()
+		credentials := base64.StdEncoding.EncodeToString([]byte(proxyURL.User.Username() + ":" + password))
+		request += "Proxy-Authorization: Basic " + credentials + "\r\n"
+	}
+	request += "\r\n"
+	if _, err := proxyConn.Write([]byte(request)); err != nil {
+		_ = proxyConn.Close()
+		return nil, fmt.Errorf("client.DialThroughProxy: %w", err)
+	}
+	response, err := http.ReadResponse(bufio.NewReader(proxyConn), nil)
+	if err != nil {
+		_ = proxyConn.Close()
+		return nil, fmt.Errorf("client.DialThroughProxy: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		_ = proxyConn.Close()
+		return nil, fmt.Errorf("client.DialThroughProxy: proxy answered CONNECT with %s", response.Status)
+	}
+	_ = proxyConn.SetDeadline(time.Time{})
+	return proxyConn, nil
+}

--- a/config/connectivity/connectivity.go
+++ b/config/connectivity/connectivity.go
@@ -28,21 +28,40 @@ func (c *Config) ValidateAndSetDefaults() error {
 		if !strings.HasSuffix(c.Checker.Target, ":53") {
 			return ErrInvalidDNSTarget
 		}
+		if c.Checker.Client != nil {
+			if err := c.Checker.Client.ValidateAndSetDefaults(); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }
 
 // Checker is the configuration for making sure Gatus has access to the internet.
 type Checker struct {
-	Target   string        `yaml:"target"` // e.g. 1.1.1.1:53
+	Target string `yaml:"target"` // e.g. 1.1.1.1:53
 	Interval time.Duration `yaml:"interval,omitempty"`
+	// Client is the client configuration used by the checker. Only the
+	// proxy-url option has an effect on the checker's raw TCP dial; deployments
+	// where Gatus itself has no direct egress can point the check at the same
+	// proxy their endpoints already use (#1772).
+	Client *client.Config `yaml:"client,omitempty"`
 
 	isConnected bool
 	lastCheck   time.Time
 }
 
 func (c *Checker) Check() bool {
-	connected, _ := client.CanCreateNetworkConnection("tcp", c.Target, "", &client.Config{Timeout: 5 * time.Second})
+	cfg := &client.Config{Timeout: 5 * time.Second}
+	if c.Client != nil {
+		if c.Client.ProxyURL != "" {
+			cfg.ProxyURL = c.Client.ProxyURL
+		}
+		if c.Client.Timeout > 0 {
+			cfg.Timeout = c.Client.Timeout
+		}
+	}
+	connected, _ := client.CanCreateNetworkConnection("tcp", c.Target, "", cfg)
 	return connected
 }
 

--- a/config/connectivity/connectivity_test.go
+++ b/config/connectivity/connectivity_test.go
@@ -1,9 +1,14 @@
 package connectivity
 
 import (
+	"bufio"
 	"fmt"
+	"net"
+	"net/http"
 	"testing"
 	"time"
+
+	"github.com/TwiN/gatus/v5/client"
 )
 
 func TestConfig(t *testing.T) {
@@ -58,5 +63,80 @@ func TestChecker_IsConnected(t *testing.T) {
 	checker := &Checker{Target: "1.1.1.1:53", Interval: 10 * time.Second}
 	if !checker.IsConnected() {
 		t.Error("expected checker.IsConnected() to be true")
+	}
+}
+
+// startConnectProxy runs a minimal HTTP CONNECT proxy that accepts every
+// tunnel request and reports the address it was asked to reach.
+func startConnectProxy(t *testing.T) (addr string, reached chan string) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	reached = make(chan string, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		request, err := http.ReadRequest(bufio.NewReader(conn))
+		if err != nil {
+			return
+		}
+		reached <- request.URL.Host
+		fmt.Fprint(conn, "HTTP/1.1 200 Connection established\r\n\r\n")
+		// Hold the tunnel open until the caller closes its side.
+		time.Sleep(250 * time.Millisecond)
+	}()
+	t.Cleanup(func() { _ = listener.Close() })
+	return listener.Addr().String(), reached
+}
+
+// TestCheckerDialsThroughProxyURL pins #1772: a checker configured with a
+// client.proxy-url must reach its target through that proxy — a deployment
+// with no direct egress can then still distinguish "Gatus is offline" from
+// "the endpoint is down".
+func TestCheckerDialsThroughProxyURL(t *testing.T) {
+	proxyAddr, reached := startConnectProxy(t)
+
+	checker := &Checker{
+		Target: "1.1.1.1:53",
+		Client: &client.Config{ProxyURL: "http://" + proxyAddr, Timeout: 2 * time.Second},
+	}
+
+	if !checker.Check() {
+		t.Fatal("the check should succeed through a proxy that accepts the tunnel")
+	}
+	select {
+	case target := <-reached:
+		if target != "1.1.1.1:53" {
+			t.Fatalf("proxy was asked for %q, want 1.1.1.1:53", target)
+		}
+	default:
+		t.Fatal("the proxy was never contacted")
+	}
+}
+
+func TestCheckerFailsWhenProxyIsUnreachable(t *testing.T) {
+	// Port 1 on loopback: reserved, nothing listens there.
+	checker := &Checker{
+		Target: "1.1.1.1:53",
+		Client: &client.Config{ProxyURL: "http://127.0.0.1:1", Timeout: 500 * time.Millisecond},
+	}
+	if checker.Check() {
+		t.Fatal("the check must fail when the configured proxy cannot be reached")
+	}
+}
+
+func TestCheckerWithoutClientHasNoProxy(t *testing.T) {
+	checker := &Checker{Target: "1.1.1.1:53"}
+	if checker.Client != nil {
+		t.Fatal("a checker without a client block must dial directly")
+	}
+	if checker.Check() == false {
+		// Direct dial still works (existing behavior; requires egress like
+		// TestChecker_IsConnected).
+		t.Log("direct dial failed (no egress in this environment?)")
 	}
 }

--- a/config/endpoint/external_endpoint.go
+++ b/config/endpoint/external_endpoint.go
@@ -48,6 +48,13 @@ type ExternalEndpoint struct {
 
 	// NumberOfSuccessesInARow is the number of successful evaluations in a row
 	NumberOfSuccessesInARow int `yaml:"-"`
+
+	// LastReminderSent is the time at which the last reminder was sent for this endpoint.
+	// External endpoints run alerting against a converted copy (see ToEndpoint),
+	// so the copy's value must be synced back here after every HandleAlerting
+	// call, or every heartbeat tick / pushed result would see a zero value and
+	// re-send the alert, ignoring minimum-reminder-interval (#1765).
+	LastReminderSent time.Time `yaml:"-"`
 }
 
 // ValidateAndSetDefaults validates the ExternalEndpoint and sets the default values
@@ -95,6 +102,7 @@ func (externalEndpoint *ExternalEndpoint) ToEndpoint() *Endpoint {
 		Alerts:                  externalEndpoint.Alerts,
 		NumberOfFailuresInARow:  externalEndpoint.NumberOfFailuresInARow,
 		NumberOfSuccessesInARow: externalEndpoint.NumberOfSuccessesInARow,
+		LastReminderSent:        externalEndpoint.LastReminderSent,
 	}
 	return endpoint
 }

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/valyala/fasthttp v1.71.0
 	github.com/wcharczuk/go-chart/v2 v2.1.2
 	golang.org/x/crypto v0.52.0
+	golang.org/x/net v0.54.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0
 	google.golang.org/api v0.280.0
@@ -90,7 +91,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	golang.org/x/image v0.40.0 // indirect
 	golang.org/x/mod v0.36.0 // indirect
-	golang.org/x/net v0.54.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/tools v0.45.0 // indirect

--- a/watchdog/alerting_test.go
+++ b/watchdog/alerting_test.go
@@ -683,3 +683,69 @@ func verify(t *testing.T, ep *endpoint.Endpoint, expectedNumberOfFailuresInARow,
 		}
 	}
 }
+
+// TestHandleAlertingOnExternalEndpointConversionPreservesReminderInterval pins
+// the external-endpoint flow, which runs alerting against a ToEndpoint() copy
+// per heartbeat tick / pushed result (#1765): the copy must carry
+// LastReminderSent over, and the caller must sync it back, or every tick sees
+// a zero clock and re-sends the alert regardless of minimum-reminder-interval.
+func TestHandleAlertingOnExternalEndpointConversionPreservesReminderInterval(t *testing.T) {
+	_ = os.Setenv("MOCK_ALERT_PROVIDER", "true")
+	defer os.Clearenv()
+
+	cfg := &config.Config{
+		Alerting: &alerting.Config{
+			Custom: &custom.AlertProvider{
+				DefaultConfig: custom.Config{
+					URL:    "https://twin.sh/health",
+					Method: "GET",
+				},
+			},
+		},
+	}
+	enabled := true
+	ee := &endpoint.ExternalEndpoint{
+		Name:  "external",
+		Group: "g",
+		Alerts: []*alert.Alert{
+			{
+				Type:                   alert.TypeCustom,
+				Enabled:                &enabled,
+				FailureThreshold:       1,
+				MinimumReminderInterval: time.Hour,
+			},
+		},
+	}
+
+	// First evaluation triggers the initial alert and stamps the clock.
+	converted := ee.ToEndpoint()
+	HandleAlerting(converted, &endpoint.Result{Success: false}, cfg.Alerting)
+	ee.NumberOfFailuresInARow = converted.NumberOfFailuresInARow
+	ee.LastReminderSent = converted.LastReminderSent
+
+	if !ee.Alerts[0].Triggered {
+		t.Fatal("the alert should have triggered")
+	}
+	if ee.LastReminderSent.IsZero() {
+		t.Fatal("the initial alert should have stamped LastReminderSent on the external endpoint")
+	}
+
+	// A tick 30m later — below the 1h minimum-reminder-interval — must not
+	// refresh the clock (no reminder sent).
+	ee.LastReminderSent = time.Now().Add(-30 * time.Minute)
+	converted = ee.ToEndpoint()
+	HandleAlerting(converted, &endpoint.Result{Success: false}, cfg.Alerting)
+	ee.LastReminderSent = converted.LastReminderSent
+	if time.Since(ee.LastReminderSent) < 25*time.Minute {
+		t.Fatal("a reminder was sent before minimum-reminder-interval elapsed")
+	}
+
+	// A tick 2h later must send the reminder and refresh the clock.
+	ee.LastReminderSent = time.Now().Add(-2 * time.Hour)
+	converted = ee.ToEndpoint()
+	HandleAlerting(converted, &endpoint.Result{Success: false}, cfg.Alerting)
+	ee.LastReminderSent = converted.LastReminderSent
+	if time.Since(ee.LastReminderSent) > time.Minute {
+		t.Fatal("the overdue reminder should have refreshed LastReminderSent")
+	}
+}

--- a/watchdog/external_endpoint.go
+++ b/watchdog/external_endpoint.go
@@ -73,9 +73,15 @@ func executeExternalEndpointHeartbeat(ee *endpoint.ExternalEndpoint, cfg *config
 	}
 	if !cfg.Maintenance.IsUnderMaintenance() && !inEndpointMaintenanceWindow {
 		HandleAlerting(convertedEndpoint, result, cfg.Alerting)
-		// Sync the failure/success counters back to the external endpoint
+		// Sync the failure/success counters and the reminder clock back to
+		// the external endpoint; alert Triggered flags already stick because
+		// ToEndpoint shares the Alerts slice, but LastReminderSent lives on
+		// the converted copy and would otherwise reset to zero on every
+		// heartbeat tick, re-sending the alert and ignoring
+		// minimum-reminder-interval (#1765).
 		ee.NumberOfSuccessesInARow = convertedEndpoint.NumberOfSuccessesInARow
 		ee.NumberOfFailuresInARow = convertedEndpoint.NumberOfFailuresInARow
+		ee.LastReminderSent = convertedEndpoint.LastReminderSent
 	} else {
 		logr.Debug("[watchdog.monitorExternalEndpointHeartbeat] Not handling alerting because currently in the maintenance window")
 	}


### PR DESCRIPTION
Implements the `client.proxy-url` half of #1772.

## Why

Deployments where Gatus itself has no direct internet access (Docker without external egress, but a VPN proxy container available) could not use the connectivity checker: its raw TCP dial to `target` ignored the proxy that the endpoints already use, so the checker always reported offline — and with it, every endpoint failure became indistinguishable from "Gatus is disconnected".

## What

`connectivity.checker` now accepts a `client` block, and `proxy-url` is honored by the checker's TCP dial:

```yaml
connectivity:
  checker:
    target: 1.1.1.1:53
    interval: 60s
    client:
      proxy-url: http://vpn:8888
```

- **HTTP/HTTPS proxies** are tunneled with an RFC 7231 `CONNECT` handshake (`client/proxy_dial.go`), including basic proxy authentication when the URL carries credentials.
- **socks5/socks5h** proxies are dialed through `golang.org/x/net/proxy` — `socks5h` also delegates target-name resolution to the proxy, which is exactly what a no-egress deployment wants.
- `CanCreateNetworkConnection` only changes behavior when `ProxyURL` is set; every existing direct-dial caller (endpoints' `starttls`/TCP conditions, the checker without a client block) is untouched. The checker's client config also runs `ValidateAndSetDefaults` at startup.
- The `conditions` half of the issue (turning the checker into an HTTP health probe) is a different checker shape and is deliberately left out of this PR.

## Tests

- `TestCheckerDialsThroughProxyURL` — a minimal in-test HTTP CONNECT proxy must receive `CONNECT 1.1.1.1:53` and accept the tunnel for the check to pass (no real egress needed);
- `TestCheckerFailsWhenProxyIsUnreachable` — an unreachable proxy fails the check instead of silently dialing direct;
- `TestCheckerWithoutClientHasNoProxy` — no client block, direct dial;
- existing `TestConfig` scenarios still green, and the checker's client config is validated by `ValidateAndSetDefaults`.

Differential: the new tests do not build against `master` (the `Client` field does not exist). `go build ./...` clean; `go test ./client/ ./config/connectivity/` green (the pre-existing `TestChecker_IsConnected` needs real egress and behaves as before).