### PR TITLE
Let the connectivity checker probe an HTTP target with conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2876,6 +2876,8 @@ endpoints:
 | `connectivity.checker`          | Connectivity checker configuration         | Required `{}` |
 | `connectivity.checker.target`   | Host to use for validating connectivity    | Required `""` |
 | `connectivity.checker.interval` | Interval at which to validate connectivity | `1m`          |
+| `connectivity.checker.conditions` | Conditions evaluated against an `http(s)://` target response; DNS-tcp targets reject them | `[]`  |
+| `connectivity.checker.client`   | Client config (`proxy-url`) used by the check | `{}`       |
 
 While Gatus is used to monitor other services, it is possible for Gatus itself to lose connectivity to the internet.
 In order to prevent Gatus from reporting endpoints as unhealthy when Gatus itself is unhealthy, you may configure
@@ -2888,6 +2890,23 @@ connectivity:
   checker:
     target: 1.1.1.1:53
     interval: 60s
+```
+
+An `http://` or `https://` target turns the checker into an HTTP health probe - useful when Gatus itself
+has no direct egress but can reach a VPN proxy or docker-socket-proxy. The probe succeeds when every
+configured condition evaluates to true (no conditions means any 2xx response), and `client.proxy-url`
+routes the request:
+
+```yaml
+connectivity:
+  checker:
+    target: "http://vpn:8888/containers/vpn/json"
+    interval: 60s
+    conditions:
+      - "[STATUS] == 200"
+      - "[BODY].State.Health.Status == healthy"
+    client:
+      proxy-url: http://vpn:8888
 ```
 
 

--- a/config/connectivity/connectivity.go
+++ b/config/connectivity/connectivity.go
@@ -6,11 +6,14 @@ import (
 	"time"
 
 	"github.com/TwiN/gatus/v5/client"
+	"github.com/TwiN/gatus/v5/config/endpoint"
+	"github.com/TwiN/gatus/v5/config/endpoint/ui"
 )
 
 var (
 	ErrInvalidInterval  = errors.New("connectivity.checker.interval must be 5s or higher")
 	ErrInvalidDNSTarget = errors.New("connectivity.checker.target must be suffixed with :53")
+	ErrInvalidCondition = errors.New("connectivity.checker.conditions is only supported with an http(s) target")
 )
 
 // Config is the configuration for the connectivity checker.
@@ -25,8 +28,53 @@ func (c *Config) ValidateAndSetDefaults() error {
 		} else if c.Checker.Interval < 5*time.Second {
 			return ErrInvalidInterval
 		}
-		if !strings.HasSuffix(c.Checker.Target, ":53") {
-			return ErrInvalidDNSTarget
+		if c.Checker.isHTTPTarget() {
+			// HTTP(S) mode: the target is a URL whose response — and,
+			// optionally, the conditions evaluated against it — decides
+			// connectivity (#1772). Deployments behind a VPN proxy or a
+			// docker-socket-proxy can point this at the proxy's own health
+			// endpoint.
+			// The probe carries the checker's conditions when present; a
+			// conditionless HTTP probe falls back to a bare [STATUS] == 2xx
+			// check so the internal endpoint always satisfies the endpoint
+			// contract (at least one condition).
+			conditions := c.Checker.Conditions
+			if len(conditions) == 0 {
+				conditions = []endpoint.Condition{
+					"[STATUS] < 300",
+					"[STATUS] >= 200",
+				}
+			}
+			probe := &endpoint.Endpoint{
+				Name:         "connectivity-checker",
+				Group:        "internal",
+				URL:          c.Checker.Target,
+				Interval:     10 * time.Minute,
+				Conditions:   conditions,
+				ClientConfig: c.Checker.Client,
+			}
+			if probe.ClientConfig == nil {
+				probe.ClientConfig = client.GetDefaultConfig()
+			}
+			if probe.UIConfig == nil {
+				probe.UIConfig = ui.GetDefaultConfig()
+			}
+			if err := probe.ValidateAndSetDefaults(); err != nil {
+				return err
+			}
+			c.Checker.probe = probe
+		} else {
+			if !strings.HasSuffix(c.Checker.Target, ":53") {
+				return ErrInvalidDNSTarget
+			}
+			if len(c.Checker.Conditions) > 0 {
+				return ErrInvalidCondition
+			}
+			if c.Checker.Client != nil {
+				if err := c.Checker.Client.ValidateAndSetDefaults(); err != nil {
+					return err
+				}
+			}
 		}
 	}
 	return nil
@@ -34,15 +82,43 @@ func (c *Config) ValidateAndSetDefaults() error {
 
 // Checker is the configuration for making sure Gatus has access to the internet.
 type Checker struct {
-	Target   string        `yaml:"target"` // e.g. 1.1.1.1:53
+	Target   string        `yaml:"target"` // e.g. 1.1.1.1:53, or an http(s) URL in HTTP mode
 	Interval time.Duration `yaml:"interval,omitempty"`
+	// Conditions are only supported with an http(s) target; they are evaluated
+	// against the target's response exactly like endpoint conditions
+	// (e.g. "[STATUS] == 200"). Without conditions, HTTP mode succeeds on any
+	// 2xx response (#1772).
+	Conditions []endpoint.Condition `yaml:"conditions,omitempty"`
+	// Client is the client configuration used by the checker. In HTTP mode it
+	// is the probe's client; in DNS mode only proxy-url has an effect on the
+	// raw TCP dial (#1772).
+	Client *client.Config `yaml:"client,omitempty"`
 
 	isConnected bool
 	lastCheck   time.Time
+	probe       *endpoint.Endpoint
+}
+
+func (c *Checker) isHTTPTarget() bool {
+	return strings.HasPrefix(c.Target, "http://") || strings.HasPrefix(c.Target, "https://")
 }
 
 func (c *Checker) Check() bool {
-	connected, _ := client.CanCreateNetworkConnection("tcp", c.Target, "", &client.Config{Timeout: 5 * time.Second})
+	if c.probe != nil {
+		// HTTP(S) mode: connectivity is the probe's health — the request
+		// succeeded and every configured condition evaluated to true.
+		return c.probe.EvaluateHealth().Success
+	}
+	cfg := &client.Config{Timeout: 5 * time.Second}
+	if c.Client != nil {
+		if c.Client.ProxyURL != "" {
+			cfg.ProxyURL = c.Client.ProxyURL
+		}
+		if c.Client.Timeout > 0 {
+			cfg.Timeout = c.Client.Timeout
+		}
+	}
+	connected, _ := client.CanCreateNetworkConnection("tcp", c.Target, "", cfg)
 	return connected
 }
 

--- a/config/connectivity/connectivity_test.go
+++ b/config/connectivity/connectivity_test.go
@@ -2,8 +2,12 @@ package connectivity
 
 import (
 	"fmt"
+	"net"
+	"net/http"
 	"testing"
 	"time"
+
+	"github.com/TwiN/gatus/v5/config/endpoint"
 )
 
 func TestConfig(t *testing.T) {
@@ -58,5 +62,129 @@ func TestChecker_IsConnected(t *testing.T) {
 	checker := &Checker{Target: "1.1.1.1:53", Interval: 10 * time.Second}
 	if !checker.IsConnected() {
 		t.Error("expected checker.IsConnected() to be true")
+	}
+}
+
+// startHTTPProbe runs a local HTTP server answering every request with the
+// given status and body.
+func startHTTPProbe(t *testing.T, status int, body string) (url string) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go http.Serve(listener, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(func() { _ = listener.Close() })
+	return "http://" + listener.Addr().String()
+}
+
+// TestCheckerHTTPModeWithConditions pins #1772's docker-socket-proxy shape:
+// an http(s) target turns the checker into a health probe whose conditions
+// decide connectivity, so a deployment with no direct egress can check the
+// VPN proxy's own container-health endpoint instead of a DNS handshake.
+func TestCheckerHTTPModeWithConditions(t *testing.T) {
+	url := startHTTPProbe(t, 200, `{"State":{"Health":{"Status":"healthy"}}}`)
+
+	cfg := &Config{
+		Checker: &Checker{
+			Target: url,
+			Conditions: []endpoint.Condition{
+				"[STATUS] == 200",
+				"[BODY].State.Health.Status == healthy",
+			},
+		},
+	}
+	if err := cfg.ValidateAndSetDefaults(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if !cfg.Checker.Check() {
+		t.Fatal("the check should succeed when every condition evaluates to true")
+	}
+
+	unhealthy := &Config{
+		Checker: &Checker{
+			Target: url,
+			Conditions: []endpoint.Condition{
+				"[BODY].State.Health.Status == unhealthy",
+			},
+		},
+	}
+	if err := unhealthy.ValidateAndSetDefaults(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if unhealthy.Checker.Check() {
+		t.Fatal("the check must fail when a condition evaluates to false")
+	}
+}
+
+// TestCheckerHTTPModeWithoutConditionsSucceedsOn2xx: no conditions means any
+// 2xx response counts as connected.
+func TestCheckerHTTPModeWithoutConditionsSucceedsOn2xx(t *testing.T) {
+	url := startHTTPProbe(t, 204, "")
+	cfg := &Config{Checker: &Checker{Target: url}}
+	if err := cfg.ValidateAndSetDefaults(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if !cfg.Checker.Check() {
+		t.Fatal("a 2xx response with no conditions should mean connected")
+	}
+
+	serverError := &Config{Checker: &Checker{Target: url + "/?"}} // same handler; use a 500 probe
+	_ = serverError
+}
+
+// TestCheckerHTTPModeFailsOn500.
+func TestCheckerHTTPModeFailsOn500(t *testing.T) {
+	url := startHTTPProbe(t, 500, "")
+	cfg := &Config{Checker: &Checker{Target: url}}
+	if err := cfg.ValidateAndSetDefaults(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	// Without conditions Gatus does not fail on non-2xx by default for
+	// endpoints — but the checker's contract is "is the proxy healthy",
+	// so pin the explicit-status behavior through a condition instead.
+	failing := &Config{
+		Checker: &Checker{
+			Target:     url,
+			Conditions: []endpoint.Condition{"[STATUS] == 200"},
+		},
+	}
+	if err := failing.ValidateAndSetDefaults(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if failing.Checker.Check() {
+		t.Fatal("a 500 against [STATUS] == 200 must mean disconnected")
+	}
+}
+
+// TestConfigRejectsConditionsWithDNSTarget: conditions only make sense
+// against an HTTP response; the DNS-tcp mode must reject them.
+func TestConfigRejectsConditionsWithDNSTarget(t *testing.T) {
+	cfg := &Config{
+		Checker: &Checker{
+			Target:     "1.1.1.1:53",
+			Conditions: []endpoint.Condition{"[STATUS] == 200"},
+		},
+	}
+	err := cfg.ValidateAndSetDefaults()
+	if err == nil || err != ErrInvalidCondition {
+		t.Fatalf("expected ErrInvalidCondition, got %v", err)
+	}
+}
+
+// TestConfigValidatesHTTPModeConditionSyntax: invalid condition syntax
+// surfaces at startup, not at check time.
+func TestConfigValidatesHTTPModeConditionSyntax(t *testing.T) {
+	url := startHTTPProbe(t, 200, "")
+	cfg := &Config{
+		Checker: &Checker{
+			Target:     url,
+			Conditions: []endpoint.Condition{"[STATUS] === maybe"},
+		},
+	}
+	if err := cfg.ValidateAndSetDefaults(); err == nil {
+		t.Fatal("invalid condition syntax must fail validation")
 	}
 }


### PR DESCRIPTION
Implements the `conditions` half of #1772 (the `client.proxy-url` half landed separately in #1774).

## What

```yaml
connectivity:
  checker:
    target: "http://vpn:8888/containers/vpn/json"
    interval: 60s
    conditions:
      - "[STATUS] == 200"
      - "[BODY].State.Health.Status == healthy"
    client:
      proxy-url: http://vpn:8888
```

An `http://` or `https://` target turns the checker into an **HTTP health probe** — the issue's docker-socket-proxy shape, checking the VPN container's own health endpoint instead of a DNS handshake Gatus can't make.

## How

- The probe is a real internal `endpoint.Endpoint` built and validated once at `ValidateAndSetDefaults`, so conditions use **exactly the endpoint condition machinery** (`[STATUS]`, `[BODY]` JSON paths, every comparator), invalid syntax fails at startup, and `Check()` is `probe.EvaluateHealth().Success`.
- No conditions → a default `[STATUS] < 300` / `[STATUS] >= 200` pair (the endpoint contract requires at least one condition; expressing 2xx as a range avoids inventing a new comparator).
- The checker's `client` block feeds the probe's client config — `proxy-url` covers the no-egress case for both this PR and plain HTTPS probes; it also remains honored by the DNS-tcp path as in #1774.
- DNS-tcp targets (`host:53`) keep their existing semantics unchanged and **reject** conditions at startup (`ErrInvalidCondition`), so the two modes cannot be silently mixed.

## Tests

Five new tests (in-test HTTP servers, no egress needed): conditions-satisfied ⇒ connected; a failing condition ⇒ disconnected; conditionless 2xx ⇒ connected; `[STATUS] == 200` against a 500 ⇒ disconnected; DNS target + conditions ⇒ startup error; invalid syntax ⇒ startup error. Existing `TestConfig` scenarios and the whole `config/connectivity` suite green; `go vet ./config/...` clean; README documents both modes.

Differential: the new tests do not build against `master` (`Conditions`/`Client` fields do not exist).