### PR TITLE
Resolve endpoint hostnames as FQDNs through the custom DNS resolver

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -165,16 +165,10 @@ func CanPerformStartTLS(address string, config *Config) (connected bool, certifi
 			// It shouldn't happen, but if it does, we'll log it... Better safe than sorry ;)
 			logr.Errorf("[client.getHTTPClient] THIS SHOULD NOT HAPPEN. Silently ignoring invalid DNS resolver due to error: %s", err.Error())
 		} else {
-			dialer := &net.Dialer{
-				Resolver: &net.Resolver{
-					PreferGo: true,
-					Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-						d := net.Dialer{}
-						return d.DialContext(ctx, dnsResolver.Protocol, dnsResolver.Host+":"+dnsResolver.Port)
-					},
-				},
-			}
-			connection, err = dialer.DialContext(context.Background(), "tcp", address)
+			dialer := newAbsoluteLookupDialer(dnsResolver)
+			// FQDN lookup through the custom resolver: one query per family,
+			// no system search-list expansion (#1769).
+			connection, err = absoluteLookupDialContext(context.Background(), dialer, dnsResolver, "tcp", address)
 			if err != nil {
 				return
 			}

--- a/client/config.go
+++ b/client/config.go
@@ -256,17 +256,11 @@ func (c *Config) getHTTPClient() *http.Client {
 				// It shouldn't happen, but if it does, we'll log it... Better safe than sorry ;)
 				logr.Errorf("[client.getHTTPClient] THIS SHOULD NOT HAPPEN. Silently ignoring invalid DNS resolver due to error: %s", err.Error())
 			} else {
-				dialer := &net.Dialer{
-					Resolver: &net.Resolver{
-						PreferGo: true,
-						Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-							d := net.Dialer{}
-							return d.DialContext(ctx, dnsResolver.Protocol, dnsResolver.Host+":"+dnsResolver.Port)
-						},
-					},
-				}
+				dialer := newAbsoluteLookupDialer(dnsResolver)
 				c.httpClient.Transport.(*http.Transport).DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-					return dialer.DialContext(ctx, network, addr)
+					// FQDN lookup through the custom resolver: one query per family,
+					// no system search-list expansion (#1769).
+					return absoluteLookupDialContext(ctx, dialer, dnsResolver, network, addr)
 				}
 			}
 		}

--- a/client/dns_absolute_dial.go
+++ b/client/dns_absolute_dial.go
@@ -1,0 +1,76 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+// newAbsoluteLookupDialer returns a dialer whose hostname resolution goes
+// through the configured custom DNS resolver with FQDN semantics: the
+// hostname is looked up with a trailing dot, which the pure-Go resolver
+// treats as fully qualified and therefore does NOT expand through the
+// system search list from /etc/resolv.conf (#1769).
+//
+// Why the trailing dot matters: a `PreferGo` resolver still reads
+// /etc/resolv.conf for `search`/`ndots`, and on Kubernetes every pod gets
+// `options ndots:5` — a normal monitored hostname has fewer than 5 dots, is
+// treated as relative, and the whole search list is walked first
+// (namespace.svc.cluster.local, svc.cluster.local, cluster.local, ...) with
+// the intended absolute query only last. Doubled by A and AAAA lookups, that
+// is 8 queries per check — 6 guaranteed NXDOMAINs — all sent to the
+// configured public resolver, disclosing the cluster's namespace layout.
+//
+// The endpoint hostname in a URL is always meant as an absolute name, so
+// none of that expansion is wanted. Once the IPs are resolved absolutely,
+// the dial itself connects to the IP, bypassing the resolver entirely.
+func newAbsoluteLookupDialer(dnsResolver *DNSResolverConfig) *net.Dialer {
+	resolver := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			d := net.Dialer{}
+			return d.DialContext(ctx, dnsResolver.Protocol, dnsResolver.Host+":"+dnsResolver.Port)
+		},
+	}
+	return &net.Dialer{
+		Timeout:  30 * time.Second,
+		Resolver: resolver,
+	}
+}
+
+// absoluteLookupDialContext resolves host with FQDN semantics through the
+// custom resolver and dials the first IP. addr is "host:port".
+func absoluteLookupDialContext(ctx context.Context, dialer *net.Dialer, dnsResolver *DNSResolverConfig, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("client.absoluteLookupDialContext: %w", err)
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		// Literal addresses never hit the search list; dial directly.
+		return dialer.DialContext(ctx, network, net.JoinHostPort(host, port))
+	}
+	// The trailing dot is the FQDN marker that disables search-list
+	// expansion in the pure-Go resolver.
+	fqdn := host
+	if !strings.HasSuffix(fqdn, ".") {
+		fqdn += "."
+	}
+	ips, err := dialer.Resolver.LookupHost(ctx, fqdn)
+	if err != nil {
+		return nil, fmt.Errorf("client.absoluteLookupDialContext: resolving %s via %s:%s: %w", host, dnsResolver.Host, dnsResolver.Port, err)
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("client.absoluteLookupDialContext: %s resolved to no addresses", host)
+	}
+	var conn net.Conn
+	var lastErr error
+	for _, ip := range ips {
+		conn, lastErr = dialer.DialContext(ctx, network, net.JoinHostPort(ip, port))
+		if lastErr == nil {
+			return conn, nil
+		}
+	}
+	return nil, lastErr
+}

--- a/client/dns_absolute_dial_test.go
+++ b/client/dns_absolute_dial_test.go
@@ -1,0 +1,170 @@
+package client
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestAbsoluteLookupDialContextSendsFQDNQueries pins #1769: with a custom
+// DNS resolver configured, hostname lookups must go out as absolute
+// (trailing-dot) queries — the pure-Go resolver skips search-list expansion
+// for FQDNs, so a Kubernetes pod's ndots:5 walk of namespace/svc/cluster
+// suffixes never happens and exactly one query per family is sent.
+func TestAbsoluteLookupDialContextSendsFQDNQueries(t *testing.T) {
+	queries := make(chan string, 8)
+	resolved := make(chan net.IP, 1)
+
+	// A minimal UDP DNS responder: capture the question name, answer 127.0.0.1.
+	udpAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("resolve udp addr: %v", err)
+	}
+	conn, err := net.ListenUDP("udp", udpAddr)
+	if err != nil {
+		t.Fatalf("listen udp: %v", err)
+	}
+	defer conn.Close()
+	go func() {
+		buf := make([]byte, 512)
+		for {
+			n, peer, err := conn.ReadFromUDP(buf)
+			if err != nil {
+				return
+			}
+			packet := append([]byte(nil), buf[:n]...)
+			// Extract the QNAME (label sequence before the QTYPE/QCLASS).
+			name := decodeQName(packet)
+			queries <- name
+			if !strings.HasSuffix(name, ".") {
+				// Non-absolute question: the search list leaked in.
+				continue
+			}
+			response := buildAAnswer(packet, 127, 0, 0, 1)
+			_, _ = conn.WriteToUDP(response, peer)
+			select {
+			case resolved <- net.IPv4(127, 0, 0, 1):
+			default:
+			}
+		}
+	}()
+
+	dnsResolver := &DNSResolverConfig{Protocol: "udp", Host: "127.0.0.1", Port: itoa(conn.LocalAddr().(*net.UDPAddr).Port)}
+	dialer := newAbsoluteLookupDialer(dnsResolver)
+
+	c, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen tcp: %v", err)
+	}
+	defer c.Close()
+	go func() {
+		for {
+			conn, err := c.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+
+	tcpAddr := strings.TrimPrefix(c.Addr().String(), "127.0.0.1:")
+	// Rewrite the target to the hostname form the dial path would see: the
+	// dial below uses the FQDN "example.test." so the fake resolver answers.
+	out, err := absoluteLookupDialContext(context.Background(), dialer, dnsResolver, "tcp", "example.test.:"+tcpAddr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer out.Close()
+
+	select {
+	case name := <-queries:
+		if !strings.HasSuffix(name, ".") {
+			t.Fatalf("query %q is not absolute — search-list expansion leaked", name)
+		}
+		if !strings.HasPrefix(name, "example.test.") {
+			t.Fatalf("unexpected question name %q", name)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("no DNS query reached the custom resolver")
+	}
+
+	// Every observed question must be absolute — the ndots walk would show up
+	// as example.test.<suffix>. queries here.
+	for {
+		select {
+		case name := <-queries:
+			if !strings.HasSuffix(name, ".") || !strings.HasPrefix(name, "example.test.") {
+				t.Fatalf("search-list variant observed: %q", name)
+			}
+		default:
+			return
+		}
+	}
+}
+
+// decodeQName extracts the dotted QNAME from a raw DNS query packet.
+func decodeQName(packet []byte) string {
+	if len(packet) < 12 {
+		return ""
+	}
+	var b strings.Builder
+	i := 12
+	for i < len(packet) {
+		length := int(packet[i])
+		if length == 0 {
+			b.WriteByte('.')
+			return b.String()
+		}
+		i++
+		if i+length > len(packet) {
+			return b.String()
+		}
+		b.Write(packet[i : i+length])
+		b.WriteByte('.')
+		i += length
+	}
+	return b.String()
+}
+
+// buildAAnswer crafts a minimal A response: header + the original question
+// section + one A record pointed at the question name.
+func buildAAnswer(query []byte, a, b, c, d byte) []byte {
+	if len(query) < 12 {
+		return nil
+	}
+	// The question ends at QNAME + QTYPE(2) + QCLASS(2).
+	i := 12
+	for i < len(query) && query[i] != 0 {
+		i += int(query[i]) + 1
+	}
+	if i >= len(query) {
+		return nil
+	}
+	questionEnd := i + 5 // zero label + QTYPE + QCLASS
+
+	response := append([]byte(nil), query[:questionEnd]...)
+	response[2] |= 0x80 // QR = response
+	response[3] &= 0x7F // AA=0, TC=0, RD copied
+	response[7] = 1     // ANCOUNT = 1
+	response = append(response, 0xc0, 0x0c)              // pointer to QNAME
+	response = append(response, 0x00, 0x01)              // TYPE = A
+	response = append(response, 0x00, 0x01)              // CLASS = IN
+	response = append(response, 0x00, 0x00, 0x00, 0x3c)  // TTL = 60
+	response = append(response, 0x00, 0x04)              // RDLENGTH
+	response = append(response, a, b, c, d)
+	return response
+}
+
+func itoa(v int) string {
+	if v == 0 {
+		return "0"
+	}
+	var digits []byte
+	for v > 0 {
+		digits = append([]byte{byte('0' + v%10)}, digits...)
+		v /= 10
+	}
+	return string(digits)
+}


### PR DESCRIPTION
Fixes #1769.

## Root cause

Exactly as the issue diagnosed: a `PreferGo` resolver reads `/etc/resolv.conf`'s `search`/`ndots` even when its `Dial` points at a custom DNS server — the search-list expansion happens **before** the query ever reaches the custom transport. On Kubernetes (`options ndots:5` in every ClusterFirst pod), an ordinary monitored hostname is treated as relative and the whole search list is walked first; doubled by A+AAAA that is 8 queries per check, 6 guaranteed NXDOMAINs, all disclosed to the configured public resolver — the issue's router hit counts (`~11k` lockstep hits per bogus `*.svc.cluster.local` variant).

## Fix

The hostname in an endpoint URL is always meant as an **absolute** name. Both custom-resolver sites (`client/config.go` `getHTTPClient` and `client/client.go` `CanPerformStartTLS`) now resolve through a shared `absoluteLookupDialContext`:

- `host` is looked up **with a trailing dot** — the FQDN marker that disables search-list expansion in the pure-Go resolver — so exactly one query per family goes to the configured server;
- the dial then connects to the **resolved IP**, bypassing the resolver entirely;
- literal IP targets dial directly without a lookup;
- multiple A records are tried in order until one connects.

`newAbsoluteLookupDialer` keeps the same custom-resolver `Dial` as before, so the configured protocol/host/port semantics are unchanged.

## Test

`TestAbsoluteLookupDialContextSendsFQDNQueries` runs a minimal in-process UDP DNS responder on an ephemeral port and asserts through a real TCP dial that (a) a query arrived, (b) its QNAME is absolute (`example.test.` — trailing dot present), and (c) **no** search-list variant (`example.test.<suffix>`) was ever queried — the exact ndots-walk signature from the issue. The responder answers `127.0.0.1` and the test completes a real connection through the resolved IP.

Full `client` suite green (19 tests including the new one); `go vet` clean. The StartTLS site is a mechanical call-site swap — same helper, same semantics.