### PR TITLE
Expose certificateExpiration and domainExpiration in JSON API

### DIFF
--- a/api/endpoint_status_test.go
+++ b/api/endpoint_status_test.go
@@ -39,6 +39,7 @@ var (
 		Timestamp:             timestamp,
 		Duration:              150 * time.Millisecond,
 		CertificateExpiration: 10 * time.Hour,
+		DomainExpiration:      720 * time.Hour,
 		ConditionResults: []*endpoint.ConditionResult{
 			{
 				Condition: "[STATUS] == 200",
@@ -180,19 +181,19 @@ func TestEndpointStatuses(t *testing.T) {
 			Name:         "no-pagination",
 			Path:         "/api/v1/endpoints/statuses",
 			ExpectedCode: http.StatusOK,
-			ExpectedBody: `[{"name":"name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z"},{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z"}]}]`,
+			ExpectedBody: `[{"name":"name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z","certificateExpiration":36000000000000,"domainExpiration":2592000000000000},{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z","certificateExpiration":36000000000000}]}]`,
 		},
 		{
 			Name:         "pagination-first-result",
 			Path:         "/api/v1/endpoints/statuses?page=1&pageSize=1",
 			ExpectedCode: http.StatusOK,
-			ExpectedBody: `[{"name":"name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z"}]}]`,
+			ExpectedBody: `[{"name":"name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z","certificateExpiration":36000000000000}]}]`,
 		},
 		{
 			Name:         "pagination-second-result",
 			Path:         "/api/v1/endpoints/statuses?page=2&pageSize=1",
 			ExpectedCode: http.StatusOK,
-			ExpectedBody: `[{"name":"name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z"}]}]`,
+			ExpectedBody: `[{"name":"name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z","certificateExpiration":36000000000000,"domainExpiration":2592000000000000}]}]`,
 		},
 		{
 			Name:         "pagination-no-results",
@@ -204,7 +205,7 @@ func TestEndpointStatuses(t *testing.T) {
 			Name:         "invalid-pagination-should-fall-back-to-default",
 			Path:         "/api/v1/endpoints/statuses?page=INVALID&pageSize=INVALID",
 			ExpectedCode: http.StatusOK,
-			ExpectedBody: `[{"name":"name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z"},{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z"}]}]`,
+			ExpectedBody: `[{"name":"name","group":"group","key":"group_name","results":[{"status":200,"hostname":"example.org","duration":150000000,"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":true},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":true}],"success":true,"timestamp":"0001-01-01T00:00:00Z","certificateExpiration":36000000000000,"domainExpiration":2592000000000000},{"status":200,"hostname":"example.org","duration":750000000,"errors":["error-1","error-2"],"conditionResults":[{"condition":"[STATUS] == 200","success":true},{"condition":"[RESPONSE_TIME] \u003c 500","success":false},{"condition":"[CERTIFICATE_EXPIRATION] \u003c 72h","success":false}],"success":false,"timestamp":"0001-01-01T00:00:00Z","certificateExpiration":36000000000000}]}]`,
 		},
 	}
 

--- a/config/endpoint/result.go
+++ b/config/endpoint/result.go
@@ -40,10 +40,10 @@ type Result struct {
 	Timestamp time.Time `json:"timestamp"`
 
 	// CertificateExpiration is the duration before the certificate expires
-	CertificateExpiration time.Duration `json:"-"`
+	CertificateExpiration time.Duration `json:"certificateExpiration,omitempty"`
 
 	// DomainExpiration is the duration before the domain expires
-	DomainExpiration time.Duration `json:"-"`
+	DomainExpiration time.Duration `json:"domainExpiration,omitempty"`
 
 	// Body is the response body
 	//


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->

Expose CertificateExpiration and DomainExpiration fields in endpoint.Result JSON serialization with omitempty tags so that downstream consumers and API clients can access them.

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable.
